### PR TITLE
chore: panic if relayer config values not present

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -177,7 +177,7 @@ pub struct ValidatorConfig {
     pub ledger_column_options: LedgerColumnOptions,
     pub runtime_config: RuntimeConfig,
     pub enable_quic_servers: bool,
-    pub relayer_config: RelayerAndBlockEngineConfig,
+    pub maybe_relayer_config: Option<RelayerAndBlockEngineConfig>,
     pub shred_receiver_address: Option<SocketAddr>,
     pub tip_manager_config: TipManagerConfig,
 }
@@ -243,7 +243,7 @@ impl Default for ValidatorConfig {
             ledger_column_options: LedgerColumnOptions::default(),
             runtime_config: RuntimeConfig::default(),
             enable_quic_servers: false,
-            relayer_config: RelayerAndBlockEngineConfig::default(),
+            maybe_relayer_config: None,
             shred_receiver_address: None,
             tip_manager_config: TipManagerConfig::default(),
         }
@@ -1038,7 +1038,7 @@ impl Validator {
             config.runtime_config.log_messages_bytes_limit,
             config.enable_quic_servers,
             &staked_nodes,
-            config.relayer_config.clone(),
+            config.maybe_relayer_config.clone(),
             config.tip_manager_config.clone(),
             config.shred_receiver_address,
         );

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -65,7 +65,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         ledger_column_options: config.ledger_column_options.clone(),
         runtime_config: config.runtime_config.clone(),
         enable_quic_servers: config.enable_quic_servers,
-        relayer_config: config.relayer_config.clone(),
+        maybe_relayer_config: config.maybe_relayer_config.clone(),
         shred_receiver_address: config.shred_receiver_address,
         tip_manager_config: config.tip_manager_config.clone(),
     }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2643,15 +2643,29 @@ pub fn main() {
     let voting_disabled = matches.is_present("no_voting") || restricted_repair_only_mode;
     let tip_manager_config = tip_manager_config_from_matches(&matches, voting_disabled);
 
-    let relayer_config = RelayerAndBlockEngineConfig {
-        block_engine_address: value_of(&matches, "block_engine_address").unwrap_or_default(),
-        block_engine_auth_service_address: value_of(&matches, "block_engine_auth_service_address")
-            .unwrap_or_default(),
-        relayer_auth_service_address: value_of(&matches, "relayer_auth_service_address")
-            .unwrap_or_default(),
-        relayer_address: value_of(&matches, "relayer_address").unwrap_or_default(),
-        trust_relayer_packets: matches.is_present("trust_relayer_packets"),
-        trust_block_engine_packets: matches.is_present("trust_block_engine_packets"),
+    let is_block_engine_enabled = matches.is_present("block_engine_address")
+        || matches.is_present("block_engine_auth_service_address")
+        || matches.is_present("relayer_auth_service_address")
+        || matches.is_present("relayer_address")
+        || matches.is_present("trust_relayer_packets")
+        || matches.is_present("trust_block_engine_packets");
+    let maybe_relayer_config = if is_block_engine_enabled {
+        Some(RelayerAndBlockEngineConfig {
+            block_engine_address: value_of(&matches, "block_engine_address").unwrap(),
+            block_engine_auth_service_address: value_of(
+                &matches,
+                "block_engine_auth_service_address",
+            )
+            .expect("expected block_engine_auth_service_address address to be provided"),
+            relayer_auth_service_address: value_of(&matches, "relayer_auth_service_address")
+                .expect("expected relayer_auth_service_address address to be provided"),
+            relayer_address: value_of(&matches, "relayer_address")
+                .expect("expected relayer_address to be provided"),
+            trust_relayer_packets: matches.is_present("trust_relayer_packets"),
+            trust_block_engine_packets: matches.is_present("trust_block_engine_packets"),
+        })
+    } else {
+        None
     };
 
     let mut validator_config = ValidatorConfig {
@@ -2787,7 +2801,7 @@ pub fn main() {
             ..RuntimeConfig::default()
         },
         enable_quic_servers,
-        relayer_config,
+        maybe_relayer_config,
         tip_manager_config,
         shred_receiver_address: matches
             .value_of("shred_receiver_address")


### PR DESCRIPTION
#### Problem
We need to panic early when relayer and block-engine values aren't present to avoid wasted cycles debugging non-existent issues.

#### Summary of Changes
Add a new cli-arg `no-proxy`. When this is present then relayer_stage will not be started, when not present along with no-voting then we panic if any relayer_stage values are missing.
