### PR TITLE
Use the current block builder when changing tips

### DIFF
--- a/core/src/tip_manager.rs
+++ b/core/src/tip_manager.rs
@@ -388,7 +388,7 @@ impl TipManager {
                 config: self.tip_payment_program_info.config_pda_bump.0,
                 old_tip_receiver: config.tip_receiver,
                 new_tip_receiver: *new_tip_receiver,
-                block_builder: *block_builder,
+                block_builder: config.block_builder,
                 tip_payment_account_0: self.tip_payment_program_info.tip_pda_0.0,
                 tip_payment_account_1: self.tip_payment_program_info.tip_pda_1.0,
                 tip_payment_account_2: self.tip_payment_program_info.tip_pda_2.0,


### PR DESCRIPTION
#### Problem
- Constraint in tip program was violated
- Trying to change tip receiver with _new_ block builder, but it needs to be the _current_ one.
- The next bb is set in the next ix

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
