### PR TITLE
[JIT-460] When claiming mev tips, skip accounts that won't have min rent exempt amount after claiming

### DIFF
--- a/tip-distributor/README.md
+++ b/tip-distributor/README.md
@@ -1,6 +1,6 @@
 # Tip Distributor
 This library and collection of binaries are responsible for generating and uploading merkle roots to the on-chain 
-tip-distribution program found [here](https://github.com/jito-labs/jito-programs/blob/a450ef006e60e10894c02269ec8a301b81a083a0/tip-payment/programs/tip-distribution/src/lib.rs).
+tip-distribution program found [here](https://github.com/jito-foundation/jito-programs/blob/submodule/tip-payment/programs/tip-distribution/src/lib.rs).
 
 ## Background
 Each individual validator is assigned a new PDA per epoch where their share of tips, in lamports, will be stored. 

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -33,7 +33,9 @@ pub fn claim_mev_tips(
     tip_distribution_program_id: &Pubkey,
     keypair_path: &PathBuf,
 ) -> Result<(), ClaimMevError> {
-    /// roughly how long before blockhash expires const MAX_RETRY_DURATION: Duration = Duration::from_secs(60);
+    // roughly how long before blockhash expires
+    const MAX_RETRY_DURATION: Duration = Duration::from_secs(60);
+
     let merkle_trees: GeneratedMerkleTreeCollection =
         read_json_from_file(merkle_root_path).expect("read GeneratedMerkleTreeCollection");
     let keypair = read_keypair_file(keypair_path).expect("read keypair file");

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -116,7 +116,8 @@ pub fn claim_mev_tips(
                 // some older accounts can be rent-paying
                 // any new transfers will need to make the account rent-exempt (runtime enforced)
                 if current_balance + node.amount < stake_acct_min_rent {
-                    warn!("Current balance + tip claim amount of {} is less than required rent-exempt of {} for pubkey: {}. Skipping.", current_balance + node.amount, stake_acct_min_rent, node.claimant);
+                    warn!("Current balance + tip claim amount of {} is less than required rent-exempt of {} for pubkey: {}. Skipping.",
+                        current_balance + node.amount, stake_acct_min_rent, node.claimant);
                     below_min_rent_count += 1;
                     continue;
                 }

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -133,7 +133,7 @@ pub fn claim_mev_tips(
             }
         }
 
-        info!("Sending {} tip claim transactions. {} tried sending 0 lamports, {} would be below minimum rent",
+        info!("Sending {} tip claim transactions. {} tried sending zero lamports, {} would be below minimum rent",
             &transactions.len(), zero_lamports_count, below_min_rent_count);
         send_transactions_with_retry(&rpc_client, &transactions, MAX_RETRY_DURATION).await;
     });

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -1,8 +1,7 @@
-use log::warn;
 use {
     crate::{read_json_from_file, send_transactions_with_retry, GeneratedMerkleTreeCollection},
     anchor_lang::{AccountDeserialize, InstructionData, ToAccountMetas},
-    log::{debug, info},
+    log::{debug, info, warn},
     solana_client::{nonblocking::rpc_client::RpcClient, rpc_request::RpcError},
     solana_program::system_program,
     solana_rpc_client_api::client_error::ErrorKind,
@@ -15,11 +14,9 @@ use {
     },
     std::{path::PathBuf, time::Duration},
     thiserror::Error,
-    tip_distribution::state::*,
+    tip_distribution::state::{ClaimStatus, *},
     tokio::runtime::Builder,
 };
-
-use tip_distribution::state::ClaimStatus;
 
 #[derive(Error, Debug)]
 pub enum ClaimMevError {

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -102,12 +102,12 @@ pub fn claim_mev_tips(
                         debug!("claim status account already exists, skipping pubkey {:?}.", claim_status_pubkey);
                         continue;
                     }
-                    // expected to not find ClaimStatus account
+                    // expected to not find ClaimStatus account, don't skip
                     Err(client_error::Error { kind: client_error::ErrorKind::RpcError(RpcError::ForUser(err)), .. }) if err.starts_with("AccountNotFound") => {}
                     Err(err) => panic!("Unexpected RPC Error: {}", err),
                 }
 
-                let current_balance= rpc_client.get_balance(&node.claimant).await.expect("Failed to get balance");
+                let current_balance = rpc_client.get_balance(&node.claimant).await.expect("Failed to get balance");
                 // some older accounts can be rent-paying
                 // any new transfers will need to make the account rent-exempt (runtime enforced)
                 if current_balance + node.amount < stake_acct_min_rent {

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -60,6 +60,10 @@ pub fn claim_mev_tips(
     runtime.block_on(async move {
         let blockhash = rpc_client.get_latest_blockhash().await.expect("read blockhash");
         let balance = rpc_client.get_balance(&keypair.pubkey()).await.expect("failed to get balance");
+        let node_count = merkle_trees.generated_merkle_trees.iter().flat_map(|tree| &tree.tree_nodes).count();
+
+        // heuristic to make sure we have enough funds to cover the rent costs if jito has many validators
+        assert!(balance >= node_count as u64 * ClaimStatus::SIZE as u64);
         let mut tip_claims_below_min_rent_count = 0;
         for tree in merkle_trees.generated_merkle_trees {
             // only claim for ones that have merkle root on-chain

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -57,10 +57,13 @@ pub fn claim_mev_tips(
     runtime.block_on(async move {
         let blockhash = rpc_client.get_latest_blockhash().await.expect("read blockhash");
         let balance = rpc_client.get_balance(&keypair.pubkey()).await.expect("failed to get balance");
-        let node_count = merkle_trees.generated_merkle_trees.iter().flat_map(|tree| &tree.tree_nodes).count();
-        // heuristic to make sure we have enough funds to cover the rent costs if jito has many validators
-        assert!(balance >= node_count as u64 * ClaimStatus::SIZE as u64);
 
+        // heuristic to make sure we have enough funds to cover the rent costs if jito has many validators
+        {
+            let node_count = merkle_trees.generated_merkle_trees.iter().flat_map(|tree| &tree.tree_nodes).count();
+            let min_rent = rpc_client.get_minimum_balance_for_rent_exemption(ClaimStatus::SIZE).await.expect("Failed to calculate min rent");
+            assert!(balance >= node_count as u64 * min_rent);
+        }
         let mut below_min_rent_count = 0;
         let mut zero_lamports_count = 0;
         for tree in merkle_trees.generated_merkle_trees {

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use {
     crate::{read_json_from_file, send_transactions_with_retry, GeneratedMerkleTreeCollection},
     anchor_lang::{AccountDeserialize, InstructionData, ToAccountMetas},
@@ -18,6 +19,8 @@ use {
     tokio::runtime::Builder,
 };
 
+use tip_distribution::state::ClaimStatus;
+
 #[derive(Error, Debug)]
 pub enum ClaimMevError {
     #[error(transparent)]
@@ -33,7 +36,7 @@ pub fn claim_mev_tips(
     tip_distribution_program_id: &Pubkey,
     keypair_path: &PathBuf,
 ) -> Result<(), ClaimMevError> {
-    // roughly how long before blockhash expires
+    /// roughly how long before blockhash expires
     const MAX_RETRY_DURATION: Duration = Duration::from_secs(60);
 
     let merkle_trees: GeneratedMerkleTreeCollection =
@@ -55,12 +58,13 @@ pub fn claim_mev_tips(
     let mut transactions = Vec::new();
 
     runtime.block_on(async move {
-        let blockhash = rpc_client
-            .get_latest_blockhash()
-            .await
-            .expect("read blockhash");
-
+        let blockhash = rpc_client.get_latest_blockhash().await.expect("read blockhash");
+        let balance = rpc_client.get_balance(&keypair.pubkey()).await.expect("failed to get balance");
+        let mut tip_claims_below_min_rent_count = 0;
         for tree in merkle_trees.generated_merkle_trees {
+            // only claim for ones that have merkle root on-chain
+            let account = rpc_client.get_account(&tree.tip_distribution_account).await.expect("expected to fetch tip distribution account");
+
             for node in tree.tree_nodes {
                 let (claim_status_pubkey, claim_status_bump) = Pubkey::find_program_address(
                     &[
@@ -70,71 +74,68 @@ pub fn claim_mev_tips(
                     ],
                     tip_distribution_program_id,
                 );
-
-                // only claim for ones that have merkle root on-chain
-                let account = rpc_client
-                    .get_account(&tree.tip_distribution_account)
-                    .await
-                    .expect("expected to fetch tip distribution account");
-
-                let mut data = account.data.as_slice();
-                let fetched_tip_distribution_account =
-                    TipDistributionAccount::try_deserialize(&mut data)
-                        .expect("failed to deserialize tip_distribution_account state");
-
-                if fetched_tip_distribution_account.merkle_root.is_some() {
-                    match rpc_client.get_account(&claim_status_pubkey).await {
-                        Ok(_) => {
-                            debug!(
-                                "claim status account already exists: {:?}",
-                                claim_status_pubkey
-                            );
-                        }
-                        Err(e) => {
-                            if matches!(e.kind(), ErrorKind::RpcError(RpcError::ForUser(_))) {
-                                info!("claiming for public key: {:?}", node.claimant);
-
-                                let ix = Instruction {
-                                    program_id: *tip_distribution_program_id,
-                                    data: tip_distribution::instruction::Claim {
-                                        proof: node.proof.unwrap(),
-                                        amount: node.amount,
-                                        bump: claim_status_bump,
-                                    }
-                                    .data(),
-                                    accounts: tip_distribution::accounts::Claim {
-                                        config: tip_distribution_config,
-                                        tip_distribution_account: tree.tip_distribution_account,
-                                        claimant: node.claimant,
-                                        claim_status: claim_status_pubkey,
-                                        payer: keypair.pubkey(),
-                                        system_program: system_program::id(),
-                                    }
-                                    .to_account_metas(None),
-                                };
-                                let transaction = Transaction::new_signed_with_payer(
-                                    &[ix],
-                                    Some(&keypair.pubkey()),
-                                    &[&keypair],
-                                    blockhash,
-                                );
-                                info!("tx: {:?}", transaction);
-                                transactions.push(transaction);
-                            } else {
-                                panic!("unexpected rpc error: {:?}", e);
-                            }
-                        }
-                    }
-                } else {
+                let fetched_tip_distribution_account = TipDistributionAccount::try_deserialize(&mut account.data.as_slice()).expect("failed to deserialize tip_distribution_account state");
+                if fetched_tip_distribution_account.merkle_root.is_none() {
                     info!(
-                        "not claiming because merkle root isn't uploaded yet claimant: {:?} tda: {:?}",
+                        "not claiming because merkle root isn't uploaded yet. claimant: {:?} tda: {:?}",
                         node.claimant,
                         tree.tip_distribution_account
                     );
+                    continue;
+                }
+
+                match rpc_client.get_account(&claim_status_pubkey).await {
+                    Ok(_) => {
+                        debug!(
+                                "claim status account already exists: {:?}",
+                                claim_status_pubkey
+                            );
+                    }
+                    Err(e) => {
+                        if !matches!(e.kind(), ErrorKind::RpcError(RpcError::ForUser(_))) {
+                            panic!("Invalid RPC Error")
+                        }
+                        info!("claiming for public key: {:?}", node.claimant);
+                        let account = rpc_client.get_account(&node.claimant).await.expect("Failed to fetch account");
+                        let min_rent = rpc_client.get_minimum_balance_for_rent_exemption(account.data.len()).await.expect("Failed to calculate min rent");
+                        if node.amount < min_rent {
+                            warn!("Tip claim amount={} is less than minimum rent={} for account={}.", node.amount, min_rent, node.claimant);
+                            tip_claims_below_min_rent_count += 1;
+                            continue;
+                        }
+                        let ix = Instruction {
+                            program_id: *tip_distribution_program_id,
+                            data: tip_distribution::instruction::Claim {
+                                proof: node.proof.unwrap(),
+                                amount: node.amount,
+                                bump: claim_status_bump,
+                            }.data(),
+                            accounts: tip_distribution::accounts::Claim {
+                                config: tip_distribution_config,
+                                tip_distribution_account: tree.tip_distribution_account,
+                                claimant: node.claimant,
+                                claim_status: claim_status_pubkey,
+                                payer: keypair.pubkey(),
+                                system_program: system_program::id(),
+                            }.to_account_metas(None),
+                        };
+                        let transaction = Transaction::new_signed_with_payer(
+                            &[ix],
+                            Some(&keypair.pubkey()),
+                            &[&keypair],
+                            blockhash,
+                        );
+                        info!("tx: {:?}", transaction);
+                        transactions.push(transaction);
+                    }
                 }
             }
         }
 
+        if tip_claims_below_min_rent_count > 0 {
+            info!("Skipped {} accounts where balance after tip would be below the minimum rent amount.", tip_claims_below_min_rent_count);
+        }
+        info!("Sending {} tip claim transactions.", &transactions.len());
         send_transactions_with_retry(&rpc_client, &transactions, MAX_RETRY_DURATION).await;
     });
 

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -116,7 +116,7 @@ pub fn claim_mev_tips(
                 // some older accounts can be rent-paying
                 // any new transfers will need to make the account rent-exempt (runtime enforced)
                 if current_balance + node.amount < stake_acct_min_rent {
-                    warn!("Current balance + tip claim amount={} is less than required amount to be rent-exempt={} for account={}. Skipping.", current_balance + node.amount, stake_acct_min_rent, node.claimant);
+                    warn!("Current balance + tip claim amount of {} is less than required rent-exempt of {} for pubkey: {}. Skipping.", current_balance + node.amount, stake_acct_min_rent, node.claimant);
                     below_min_rent_count += 1;
                     continue;
                 }

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -1,10 +1,12 @@
-use solana_program::stake::state::StakeState;
 use {
     crate::{read_json_from_file, send_transactions_with_retry, GeneratedMerkleTreeCollection},
     anchor_lang::{AccountDeserialize, InstructionData, ToAccountMetas},
     log::{debug, info, warn},
     solana_client::{nonblocking::rpc_client::RpcClient, rpc_request::RpcError},
-    solana_program::{fee_calculator::DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE, system_program},
+    solana_program::{
+        fee_calculator::DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE, stake::state::StakeState,
+        system_program,
+    },
     solana_rpc_client_api::client_error,
     solana_sdk::{
         commitment_config::CommitmentConfig,

--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -107,12 +107,7 @@ pub fn claim_mev_tips(
                     Err(err) => panic!("Unexpected RPC Error: {}", err),
                 }
 
-                let account = rpc_client.get_account(&node.claimant).await;
-                let current_balance = match account {
-                    Ok(acc) => acc.lamports,
-                    Err(_) => 0,
-                };
-
+                let current_balance= rpc_client.get_balance(&node.claimant).await.expect("Failed to get balance");
                 // some older accounts can be rent-paying
                 // any new transfers will need to make the account rent-exempt (runtime enforced)
                 if current_balance + node.amount < stake_acct_min_rent {

--- a/tip-distributor/src/lib.rs
+++ b/tip-distributor/src/lib.rs
@@ -431,8 +431,11 @@ pub async fn send_transactions_with_retry(
     }
 
     if !transactions_to_send.is_empty() {
-        error!("still have {} txns to send", transactions_to_send.len());
-        panic!("failed to send all transactions");
+        error!(
+            "failed to send {} of {} transactions",
+            transactions_to_send.len(),
+            transactions.len()
+        );
     }
 }
 

--- a/tip-distributor/src/lib.rs
+++ b/tip-distributor/src/lib.rs
@@ -3,7 +3,6 @@ pub mod merkle_root_generator_workflow;
 pub mod merkle_root_upload_workflow;
 pub mod stake_meta_generator_workflow;
 
-use anchor_lang::err;
 use {
     crate::{
         merkle_root_generator_workflow::MerkleRootGeneratorError,

--- a/tip-distributor/src/lib.rs
+++ b/tip-distributor/src/lib.rs
@@ -3,6 +3,7 @@ pub mod merkle_root_generator_workflow;
 pub mod merkle_root_upload_workflow;
 pub mod stake_meta_generator_workflow;
 
+use anchor_lang::err;
 use {
     crate::{
         merkle_root_generator_workflow::MerkleRootGeneratorError,
@@ -430,10 +431,10 @@ pub async fn send_transactions_with_retry(
         }
     }
 
-    assert!(
-        transactions_to_send.is_empty(),
-        "all transactions failed to send"
-    );
+    if !transactions_to_send.is_empty() {
+        error!("still have {} txns to send", transactions_to_send.len());
+        panic!("failed to send all transactions");
+    }
 }
 
 mod pubkey_string_conversion {

--- a/tip-distributor/src/lib.rs
+++ b/tip-distributor/src/lib.rs
@@ -431,7 +431,7 @@ pub async fn send_transactions_with_retry(
     }
 
     if !transactions_to_send.is_empty() {
-        error!(
+        panic!(
             "failed to send {} of {} transactions",
             transactions_to_send.len(),
             transactions.len()


### PR DESCRIPTION
#### Problem
See ticket: https://linear.app/jito/issue/JIT-460/when-claiming-mev-tips-skip-accounts-that-wont-have-min-rent-exempt

#### Summary of Changes
- Reduce TDA rpc calls
- Flatten error handling
- Add balance and rent checks
- Add logging for debugging transient errors

