### PR TITLE
Backport simulate_bundle updates

### DIFF
--- a/client/src/nonblocking/rpc_client.rs
+++ b/client/src/nonblocking/rpc_client.rs
@@ -5455,6 +5455,7 @@ impl RpcClient {
         T: serde::de::DeserializeOwned,
     {
         let response = self.sender.send_batch(requests_and_params).await?;
+        debug!("response: {:?}", response);
 
         serde_json::from_value(response).map_err(|err| ClientError {
             request: None,

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -49,8 +49,14 @@ pub struct RpcSimulateTransactionConfig {
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum SimulationSlotConfig {
+    /// Simulate on top of bank with the provided commitment.
     Commitment(CommitmentConfig),
+
+    /// Simulate on the provided slot's bank.
     Slot(Slot),
+
+    /// Simulates on top of the RPC's highest slot's bank i.e. the working bank.
+    Tip,
 }
 
 impl Default for SimulationSlotConfig {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3979,6 +3979,7 @@ pub mod rpc_full {
                 SimulationSlotConfig::Slot(slot) => meta.bank_from_slot(slot).ok_or_else(|| {
                     Error::invalid_params(format!("bank not found for the provided slot: {}", slot))
                 }),
+                SimulationSlotConfig::Tip => Ok(meta.bank_forks.read().unwrap().working_bank()),
             }?;
 
             // TODO: Come back to this and allow unfrozen bank as long as the parent is frozen.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3703,24 +3703,9 @@ impl Bank {
         pre_execution_accounts_requested: Vec<Option<Vec<Pubkey>>>,
         post_execution_accounts_requested: Vec<Option<Vec<Pubkey>>>,
     ) -> result::Result<BundleSimulationResult, Box<dyn Error>> {
-        assert!(self.is_frozen(), "simulation bank must be frozen");
         assert_eq!(pre_execution_accounts_requested.len(), bundle.len());
         assert_eq!(post_execution_accounts_requested.len(), bundle.len());
 
-        self.simulate_bundle_unchecked(
-            bundle,
-            pre_execution_accounts_requested,
-            post_execution_accounts_requested,
-        )
-    }
-
-    /// Run transactions against a bank without committing the results; does not check if the bank is frozen.
-    fn simulate_bundle_unchecked(
-        &self,
-        bundle: Vec<SanitizedTransaction>,
-        pre_execution_accounts_requested: Vec<Option<Vec<Pubkey>>>,
-        post_execution_accounts_requested: Vec<Option<Vec<Pubkey>>>,
-    ) -> result::Result<BundleSimulationResult, Box<dyn Error>> {
         // Used to cache account data in between batch execution iterations
         let mut account_overrides = AccountOverrides::default();
 
@@ -8136,14 +8121,6 @@ pub(crate) mod tests {
             |old, new| assert_eq!(old + some_lamports, new),
         );
         assert_eq!(account, bank.get_account(&pubkey).unwrap());
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_simulate_bundle_unfrozen_bank() {
-        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000);
-        let bank = Bank::new_for_tests(&genesis_config);
-        let _ = bank.simulate_bundle(vec![], vec![], vec![]);
     }
 
     #[test]


### PR DESCRIPTION
Backports the following:
- enable simulate_bundle to simulate on top of working bank
- removes frozen bank check in simulate_bundle

https://github.com/jito-foundation/jito-solana/pull/211