### PR TITLE
feat: collect balances only on locked accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3317,6 +3317,15 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest 0.10.5",
+]
+
+[[package]]
+name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
@@ -5477,35 +5486,23 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.14.5"
+version = "1.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f07a997db3dac7b9da06b007d4a8df6dbd8281182e6ebbbd8a56f935f540b0a"
+checksum = "d343b3838e95561548a2a651787d17aebf0a3f490f193746ee58f174f65bd7c3"
 dependencies = [
- "ahash",
- "blake3",
- "block-buffer 0.9.0",
  "bs58 0.4.0",
  "bv",
- "byteorder",
- "cc",
- "either",
  "generic-array",
- "getrandom 0.1.16",
- "hashbrown 0.12.3",
  "im",
  "lazy_static",
  "log",
  "memmap2",
- "once_cell",
- "rand_core 0.6.4",
  "rustc_version",
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_json",
  "sha2 0.10.6",
- "solana-frozen-abi-macro 1.14.5",
- "subtle",
+ "solana-frozen-abi-macro 1.10.41",
  "thiserror",
 ]
 
@@ -5544,9 +5541,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.14.5"
+version = "1.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd7d529da0fa5b3b5ca71645122fc94c2aaf867744497969c109e1d4b8ad02d"
+checksum = "a37211ec8dff16b08fcb422807fa7f046bbc6417bc43e00a2f2effd8fafec6bc"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -5869,9 +5866,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.14.5"
+version = "1.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c690a6ae623bdd2d71229880a9f668ff714b5c6a9bc180a1abef4887da8b6f27"
+checksum = "7201d64123c46afa4246194c7bdd3530b78b78ee47b9c71716ee0527c6534df2"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -6045,9 +6042,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.14.5"
+version = "1.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f835be7a20e172209538241cdf46451c08b38eaaca65cf16e65658700c447b17"
+checksum = "f9622af117fe254208f1fe99a533ea523624d64745d6cffecd986da6753662ef"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -6058,38 +6055,31 @@ dependencies = [
  "bs58 0.4.0",
  "bv",
  "bytemuck",
- "cc",
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom 0.2.8",
+ "getrandom 0.1.16",
  "itertools",
  "js-sys",
  "lazy_static",
- "libc",
  "libsecp256k1",
  "log",
- "memoffset",
  "num-derive",
  "num-traits",
  "parking_lot 0.12.1",
  "rand 0.7.3",
- "rand_chacha 0.2.2",
  "rustc_version",
  "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_json",
  "sha2 0.10.6",
  "sha3 0.10.6",
- "solana-frozen-abi 1.14.5",
- "solana-frozen-abi-macro 1.14.5",
- "solana-sdk-macro 1.14.5",
+ "solana-frozen-abi 1.10.41",
+ "solana-frozen-abi-macro 1.10.41",
+ "solana-sdk-macro 1.10.41",
  "thiserror",
- "tiny-bip39",
  "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]
@@ -6469,9 +6459,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.14.5"
+version = "1.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74e8d699c3a441a5b0cd94c718e75b25c1a4295c2180a714b12fb1bcf66a51e"
+checksum = "d9efdeb6e4c4d3f8a93876a1d60d0734ad8c43ced6033b33e78771129bbbcc6a"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
@@ -6496,7 +6486,7 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
- "pbkdf2 0.11.0",
+ "pbkdf2 0.10.1",
  "qstring",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
@@ -6508,11 +6498,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "sha3 0.10.6",
- "solana-frozen-abi 1.14.5",
- "solana-frozen-abi-macro 1.14.5",
- "solana-logger 1.14.5",
- "solana-program 1.14.5",
- "solana-sdk-macro 1.14.5",
+ "solana-frozen-abi 1.10.41",
+ "solana-frozen-abi-macro 1.10.41",
+ "solana-logger 1.10.41",
+ "solana-program 1.10.41",
+ "solana-sdk-macro 1.10.41",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -6577,9 +6567,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.14.5"
+version = "1.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ffde9b5b7313629780baca10eaffec7421d53be725c76031ca409a5298705c"
+checksum = "8d036e3a52e5570114ec9ab56a1d0a6659e1ebd1c948605318b4e35eafca4515"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2 1.0.47",
@@ -7083,9 +7073,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.14.5"
+version = "1.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a23a2c443027e8cc2981131a38928cb37e554970c497b5735e888049cc85d3f"
+checksum = "ab4359c3382a88fb175d4213cea4a846889edb3cda237714c70516306d058dad"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -7096,7 +7086,6 @@ dependencies = [
  "cipher 0.4.3",
  "curve25519-dalek",
  "getrandom 0.1.16",
- "itertools",
  "lazy_static",
  "merlin",
  "num-derive",
@@ -7105,8 +7094,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.14.5",
- "solana-sdk 1.14.5",
+ "solana-program 1.10.41",
+ "solana-sdk 1.10.41",
  "subtle",
  "thiserror",
  "zeroize",
@@ -7191,7 +7180,7 @@ dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
- "solana-program 1.14.5",
+ "solana-program 1.10.41",
  "spl-token",
  "spl-token-2022",
  "thiserror",
@@ -7203,7 +7192,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.14.5",
+ "solana-program 1.10.41",
 ]
 
 [[package]]
@@ -7217,7 +7206,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.14.5",
+ "solana-program 1.10.41",
  "thiserror",
 ]
 
@@ -7232,8 +7221,8 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.14.5",
- "solana-zk-token-sdk 1.14.5",
+ "solana-program 1.10.41",
+ "solana-zk-token-sdk 1.10.41",
  "spl-memo",
  "spl-token",
  "thiserror",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4320,7 +4320,7 @@ impl Bank {
                     }
                     balances.push(transaction_balances);
                 }
-                Err(e) => continue,
+                Err(_e) => continue,
             }
         }
         balances
@@ -14878,16 +14878,13 @@ pub(crate) mod tests {
         let txs = vec![tx0, tx1];
         let batch = bank0.prepare_batch_for_tests(txs.clone());
         let balances = bank0.collect_balances(&batch);
-        assert_eq!(balances.len(), 2);
+        assert_eq!(balances.len(), 1);
         assert_eq!(balances[0], vec![8, 11, 1]);
-        assert_eq!(balances[1], vec![8, 0, 1]);
 
         let txs: Vec<_> = txs.into_iter().rev().collect();
         let batch = bank0.prepare_batch_for_tests(txs);
         let balances = bank0.collect_balances(&batch);
-        assert_eq!(balances.len(), 2);
-        assert_eq!(balances[0], vec![8, 0, 1]);
-        assert_eq!(balances[1], vec![8, 11, 1]);
+        assert_eq!(balances.len(), 0);
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4320,7 +4320,7 @@ impl Bank {
                     }
                     balances.push(transaction_balances);
                 }
-                Err(e) => println!("{:?}", e),
+                Err(e) => continue,
             }
         }
         balances


### PR DESCRIPTION
Earlier balances were collected even on accounts that weren't locked. Here we check if the account is locked and only then update the balances. Fixes #50 