### PR TITLE
TransactionError from sim RPC call

### DIFF
--- a/sdk/src/bundle/error.rs
+++ b/sdk/src/bundle/error.rs
@@ -10,7 +10,7 @@ pub enum BundleExecutionError {
     #[error("PoH max height reached in the middle of a bundle.")]
     PohMaxHeightError,
 
-    #[error("A transaction in the bundle failed")]
+    #[error("A transaction in the bundle failed {0}")]
     TransactionFailure(#[from] TransactionError),
 
     #[error("The bundle exceeds the cost model")]

--- a/sdk/src/bundle/error.rs
+++ b/sdk/src/bundle/error.rs
@@ -10,7 +10,7 @@ pub enum BundleExecutionError {
     #[error("PoH max height reached in the middle of a bundle.")]
     PohMaxHeightError,
 
-    #[error("A transaction in the bundle failed {0}")]
+    #[error("A transaction in the bundle failed with - {0}")]
     TransactionFailure(#[from] TransactionError),
 
     #[error("The bundle exceeds the cost model")]


### PR DESCRIPTION
#### Problem
When a bundle simulation fails, it returns a BundleExecutionError that only displays "A transaction in the bundle failed". It does not provide any other information on why it failed.

#### Summary of Changes
Include the source (TransactionError) in BundleExecutionError display.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
