### PR TITLE
fix: simulate bundle rpc was returning sucess on empty list

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -9126,10 +9126,6 @@ pub mod tests {
     #[test]
     fn test_rpc_simulate_bundle_error_on_empty_list() {
         // setup
-        let rpc = RpcHandler::start();
-        let bank = rpc.working_bank();
-
-        let recent_blockhash = bank.confirmed_last_blockhash();
         let RpcHandler {
             ref meta, ref io, ..
         } = rpc;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4010,7 +4010,7 @@ pub mod rpc_full {
 
             if rpc_bundle_request.encoded_transactions.len() == 0 {
                 return Err(Error::invalid_params(
-                    "supplied empty list of transactions to bundle",
+                    "bundles must contain a non-empty list of transactions",
                 ));
             }
 


### PR DESCRIPTION
#### Problem
The function simulate_bundle in rpc.rs would return success even if list of encoded transactions was empty, this is misleading.

#### Summary of Changes
- Changed simulate_bundle to early return error if rpc_bundle_request has empty list of encoded transactions
- Added test case test_rpc_simulate_bundle_error_on_empty_list that verifies that the function returns the InvalidParams error if an empty list is passed

Fixes #165 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
