### PR TITLE
Print TX error in Bundles

### DIFF
--- a/sdk/src/bundle/error.rs
+++ b/sdk/src/bundle/error.rs
@@ -10,7 +10,7 @@ pub enum BundleExecutionError {
     #[error("PoH max height reached in the middle of a bundle.")]
     PohMaxHeightError,
 
-    #[error("A transaction in the bundle failed")]
+    #[error("A transaction in the bundle failed with - {0}")]
     TransactionFailure(#[from] TransactionError),
 
     #[error("The bundle exceeds the cost model")]


### PR DESCRIPTION
#### Problem
When a transaction in a bundle fails, the transaction Error is not contained in the bundle error.

#### Summary of Changes
Add TransactionError output to BundleExecutionError.

