### PR TITLE
add new args to support single relayer and block-engine endpoints

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -112,7 +112,13 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --trust-block-engine-packets ]]; then
       args+=("$1")
       shift
+    elif [[ $1 == --relayer-url ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 == --relayer-address ]]; then
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 == --block-engine-url ]]; then
       args+=("$1" "$2")
       shift 2
     elif [[ $1 == --block-engine-address ]]; then

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -89,10 +89,16 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --relayer-address ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --block-engine-url ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 == --block-engine-address ]]; then
       args+=("$1" "$2")
       shift 2
     elif [[ $1 == --block-engine-auth-service-address ]]; then
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 == --relayer-url ]]; then
       args+=("$1" "$2")
       shift 2
     elif [[ $1 == --relayer-auth-service-address ]]; then

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1782,32 +1782,16 @@ pub fn main() {
                 .hidden(true),
         )
         .arg(
-            Arg::with_name("relayer_address")
-                .long("relayer-address")
-                .value_name("relayer_address")
+            Arg::with_name("block_engine_url")
+                .long("block-engine-url")
+                .help("Block engine url")
                 .takes_value(true)
-                .help("Address of the relayer")
         )
         .arg(
-            Arg::with_name("block_engine_address")
-                .long("block-engine-address")
-                .value_name("block_engine_address")
+            Arg::with_name("relayer_url")
+                .long("relayer-url")
+                .help("Relayer url")
                 .takes_value(true)
-                .help("Address of the block engine")
-        )
-        .arg(
-            Arg::with_name("block_engine_auth_service_address")
-                .long("block-engine-auth-service-address")
-                .value_name("block_engine_auth_service_address")
-                .takes_value(true)
-                .help("Address of the block engine's authentication service.")
-        )
-        .arg(
-            Arg::with_name("relayer_auth_service_address")
-                .long("relayer-auth-service-address")
-                .value_name("relayer_auth_service_address")
-                .takes_value(true)
-                .help("Address of the block engine's authentication service.")
         )
         .arg(
             Arg::with_name("trust_relayer_packets")
@@ -2679,22 +2663,26 @@ pub fn main() {
     let voting_disabled = matches.is_present("no_voting") || restricted_repair_only_mode;
     let tip_manager_config = tip_manager_config_from_matches(&matches, voting_disabled);
 
-    let is_block_engine_enabled = matches.is_present("block_engine_address")
+    let is_block_engine_enabled = matches.is_present("block_engine_url")
+        || matches.is_present("block_engine_address")
         || matches.is_present("block_engine_auth_service_address")
         || matches.is_present("trust_block_engine_packets");
     let maybe_block_engine_config = is_block_engine_enabled.then(|| {
-        let addr: String = value_of(&matches, "block_engine_auth_service_address")
-            .expect("missing block-engine-auth-service-address");
-        let mut auth_service_endpoint = Endpoint::from_shared(addr.clone())
-            .expect("invalid block-engine-auth-service-address value");
+        let addr: String = value_of(&matches, "block_engine_url").unwrap_or_else(|| {
+            value_of(&matches, "block_engine_auth_service_address")
+                .expect("missing block-engine-url")
+        });
+        let mut auth_service_endpoint =
+            Endpoint::from_shared(addr.clone()).expect("invalid block-engine-url value");
         if addr.contains("https") {
             auth_service_endpoint = auth_service_endpoint
                 .tls_config(tonic::transport::ClientTlsConfig::new())
                 .expect("failed to set tls_config");
         }
 
-        let addr: String =
-            value_of(&matches, "block_engine_address").expect("missing block-engine-address");
+        let addr: String = value_of(&matches, "block_engine_url").unwrap_or_else(|| {
+            value_of(&matches, "block_engine_address").expect("missing block-engine-url")
+        });
         let mut backend_endpoint = Endpoint::from_shared(addr.clone())
             .expect("invalid block-engine-address value")
             .tcp_keepalive(Some(Duration::from_secs(60)));
@@ -2711,23 +2699,26 @@ pub fn main() {
         }
     });
 
-    let is_relayer_enabled = matches.is_present("relayer_auth_service_address")
+    let is_relayer_enabled = matches.is_present("relayer_url")
+        || matches.is_present("relayer_auth_service_address")
         || matches.is_present("relayer_address")
         || matches.is_present("trust_relayer_packets")
         || matches.is_present("relayer_expected_heartbeat_interval_ms")
         || matches.is_present("relayer_max_failed_heartbeats");
     let maybe_relayer_config = is_relayer_enabled.then(|| {
-        let addr: String = value_of(&matches, "relayer_auth_service_address")
-            .expect("missing relayer-auth-service-address");
-        let mut auth_service_endpoint = Endpoint::from_shared(addr.clone())
-            .expect("invalid relayer-auth-service-address value");
+        let addr: String = value_of(&matches, "relayer_url").unwrap_or_else(|| {
+            value_of(&matches, "relayer_auth_service_address").expect("missing relayer-url")
+        });
+        let mut auth_service_endpoint =
+            Endpoint::from_shared(addr.clone()).expect("invalid relayer-url value");
         if addr.contains("https") {
             auth_service_endpoint = auth_service_endpoint
                 .tls_config(tonic::transport::ClientTlsConfig::new())
                 .expect("failed to set tls_config");
         }
 
-        let addr: String = value_of(&matches, "relayer_address").expect("missing relayer-address");
+        let addr: String = value_of(&matches, "relayer_url")
+            .unwrap_or_else(|| value_of(&matches, "relayer_address").expect("missing relayer-url"));
         let mut backend_endpoint =
             Endpoint::from_shared(addr.clone()).expect("invalid relayer-address value");
         if addr.contains("https") {
@@ -3409,6 +3400,30 @@ fn process_account_indexes(matches: &ArgMatches) -> AccountSecondaryIndexes {
 // avoid breaking validator startup commands
 fn get_deprecated_arguments() -> Vec<Arg<'static, 'static>> {
     vec![
+        Arg::with_name("block_engine_address")
+            .long("block-engine-address")
+            .value_name("block_engine_address")
+            .takes_value(true)
+            .help("Address of the block engine")
+            .conflicts_with("block_engine_url"),
+        Arg::with_name("block_engine_auth_service_address")
+            .long("block-engine-auth-service-address")
+            .value_name("block_engine_auth_service_address")
+            .takes_value(true)
+            .help("Address of the block engine's authentication service.")
+            .conflicts_with("block_engine_url"),
+        Arg::with_name("relayer_auth_service_address")
+            .long("relayer-auth-service-address")
+            .value_name("relayer_auth_service_address")
+            .takes_value(true)
+            .help("Address of the block engine's authentication service.")
+            .conflicts_with("relayer_url"),
+        Arg::with_name("relayer_address")
+            .long("relayer-address")
+            .value_name("relayer_address")
+            .takes_value(true)
+            .help("Address of the relayer")
+            .conflicts_with("relayer_url"),
         Arg::with_name("accounts_db_caching_enabled")
             .long("accounts-db-caching-enabled")
             .conflicts_with("no_accounts_db_caching")
@@ -3513,6 +3528,10 @@ lazy_static! {
             "Vote account sanity checks are no longer performed by default.",
         ),
         ("no_rocksdb_compaction", ""),
+        ("block_engine_address", "You can now use a single endpoint to connect to the block-engine. Please use block-engine-url."),
+        ("block_engine_auth_service_address", "You can now use a single endpoint to connect to the block-engine. Please use block-engine-url."),
+        ("relayer_address", ""),
+        ("relayer_auth_service_address", ""),
     ];
 }
 


### PR DESCRIPTION
We now support a single DNS entry routing to the different block-engine services. Relayer will support the same Soon TM.

TODO:
- test new args