### PR TITLE
Add validator identity pubkey to StakeMeta

### DIFF
--- a/tip-distributor/src/lib.rs
+++ b/tip-distributor/src/lib.rs
@@ -281,6 +281,9 @@ pub struct StakeMeta {
     #[serde(with = "pubkey_string_conversion")]
     pub validator_vote_account: Pubkey,
 
+    #[serde(with = "pubkey_string_conversion")]
+    pub validator_node_pubkey: Pubkey,
+
     /// The validator's tip-distribution meta if it exists.
     pub maybe_tip_distribution_meta: Option<TipDistributionMeta>,
 

--- a/tip-distributor/src/stake_meta_generator_workflow.rs
+++ b/tip-distributor/src/stake_meta_generator_workflow.rs
@@ -242,13 +242,15 @@ pub fn generate_stake_meta_collection(
                 None
             };
 
+            let vote_state = vote_account.vote_state().as_ref().unwrap();
             delegations.sort();
             stake_metas.push(StakeMeta {
                 maybe_tip_distribution_meta,
+                validator_node_pubkey: vote_state.node_pubkey,
                 validator_vote_account: vote_pubkey,
                 delegations,
                 total_delegated,
-                commission: vote_account.vote_state().as_ref().unwrap().commission,
+                commission: vote_state.commission,
             });
         } else {
             warn!(


### PR DESCRIPTION
#### Problem
The vote account associated with a validator is not a permanent link.

#### Summary of Changes
So log the validator identity as well.

Let me know if you all are amenable to pushing this or not; no biggie if you don't want to change it too