### PR TITLE
Preallocate Bundle Cost

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -42,7 +42,7 @@ export rust_nightly_docker_image=solanalabs/rust-nightly:"$nightly_version"
       echo "$0: Missing toolchain? Installing...: $toolchain" >&2
       rustup install "$toolchain"
       cargo +"$toolchain" -V
-      rustup component add rustfmt --toolchain $toolchain
+      rustup component add rustfmt --toolchain "$toolchain"
     fi
   }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1749,8 +1749,12 @@ impl BankingStage {
 
         let transaction_costs = qos_service.compute_transaction_costs(txs.iter());
 
-        let (transactions_qos_results, num_included) =
-            qos_service.select_transactions_per_cost(txs.iter(), transaction_costs.iter(), bank);
+        let (transactions_qos_results, num_included) = qos_service.select_transactions_per_cost(
+            txs.iter(),
+            transaction_costs.iter(),
+            bank.slot(),
+            &mut bank.write_cost_tracker().unwrap(),
+        );
 
         let cost_model_throttled_transactions_count = txs.len().saturating_sub(num_included);
 

--- a/core/src/bundle_sanitizer.rs
+++ b/core/src/bundle_sanitizer.rs
@@ -120,7 +120,10 @@ pub fn get_sanitized_bundle(
         return Err(BundleSanitizerError::FailedCheckTransactions);
     }
 
-    Ok(SanitizedBundle { transactions })
+    Ok(SanitizedBundle {
+        transactions,
+        uuid: packet_bundle.uuid,
+    })
 }
 
 // This function deserializes packets into transactions, computes the blake3 hash of transaction

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -143,7 +143,7 @@ impl BundleReservedSpace {
             .set_block_cost_limit(self.current_tx_block_limit);
 
         debug!(
-            "Slot: {}. Cost Limits Reset. Bundle: {}, TX: {}",
+            "slot: {}. cost limits reset. bundle: {}, txn: {}",
             working_bank.slot(),
             self.current_bundle_block_limit,
             self.current_tx_block_limit,
@@ -171,7 +171,7 @@ impl BundleReservedSpace {
                 .unwrap()
                 .set_block_cost_limit(self.current_tx_block_limit);
             debug!(
-                "Slot: {}. Increased Tx Cost Limit to {}",
+                "slot: {}. increased tx cost limit to {}",
                 working_bank.slot(),
                 self.current_tx_block_limit
             );
@@ -1447,7 +1447,7 @@ impl BundleStage {
                 // Re-Buffer any bundles that didn't fit into last block
                 if !cost_model_failed_bundles.is_empty() {
                     info!(
-                        "Slot {}: Re-buffering {} bundles that failed cost model!",
+                        "slot {}: re-buffering {} bundles that failed cost model.",
                         &bank_start.working_bank.slot(),
                         cost_model_failed_bundles.len()
                     );

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -365,6 +365,7 @@ impl BundleStage {
                 qos_service.compute_transaction_costs(sanitized_bundle.transactions.iter());
 
             let mut cost_tracker = bank_start.working_bank.write_cost_tracker().unwrap();
+
             // Increase block cost limit for bundles
             debug!(
                 "increasing cost limit for bundles: {}",
@@ -1520,7 +1521,7 @@ impl BundleStage {
             current_tx_block_limit: MAX_BLOCK_UNITS.saturating_sub(preallocated_bundle_cost),
             initial_allocated_cost: preallocated_bundle_cost,
             unreserved_ticks: poh_recorder
-                .lock()
+                .write()
                 .unwrap()
                 .ticks_per_slot()
                 .saturating_div(5),
@@ -1528,7 +1529,7 @@ impl BundleStage {
         debug!(
             "initialize bundled reserved space: {preallocated_bundle_cost} cu for {} ticks",
             poh_recorder
-                .lock()
+                .write()
                 .unwrap()
                 .ticks_per_slot()
                 .saturating_sub(reserved_space.unreserved_ticks)

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -35,6 +35,7 @@ use {
             TransactionBalancesSet, TransactionExecutionResult,
         },
         bank_utils,
+        block_cost_limits::MAX_BLOCK_UNITS,
         cost_model::{CostModel, TransactionCost},
         transaction_batch::TransactionBatch,
         vote_sender_types::ReplayVoteSender,
@@ -62,6 +63,7 @@ use {
         thread::{self, Builder, JoinHandle},
         time::{Duration, Instant},
     },
+    uuid::Uuid,
 };
 
 const MAX_BUNDLE_RETRY_DURATION: Duration = Duration::from_millis(10);
@@ -122,6 +124,61 @@ struct AllExecutionResults {
     pub post_balances: (TransactionBalances, TransactionTokenBalances),
 }
 
+struct BundleReservedSpace {
+    current_tx_block_limit: u64,
+    current_bundle_block_limit: u64,
+    initial_allocated_cost: u64,
+    unreserved_ticks: u64,
+}
+
+impl BundleReservedSpace {
+    fn reset_reserved_cost(&mut self, working_bank: &Arc<Bank>) {
+        self.current_tx_block_limit = self
+            .current_bundle_block_limit
+            .saturating_sub(self.initial_allocated_cost);
+
+        working_bank
+            .write_cost_tracker()
+            .unwrap()
+            .set_block_cost_limit(self.current_tx_block_limit);
+
+        debug!(
+            "Slot: {}. Cost Limits Reset. Bundle: {}, TX: {}",
+            working_bank.slot(),
+            self.current_bundle_block_limit,
+            self.current_tx_block_limit,
+        );
+    }
+
+    fn bundle_block_limit(&self) -> u64 {
+        self.current_bundle_block_limit
+    }
+
+    fn tx_block_limit(&self) -> u64 {
+        self.current_tx_block_limit
+    }
+
+    fn update_reserved_cost(&mut self, working_bank: &Arc<Bank>) {
+        if self.current_tx_block_limit != self.current_bundle_block_limit
+            && working_bank
+                .max_tick_height()
+                .saturating_sub(working_bank.tick_height())
+                < self.unreserved_ticks
+        {
+            self.current_tx_block_limit = self.current_bundle_block_limit;
+            working_bank
+                .write_cost_tracker()
+                .unwrap()
+                .set_block_cost_limit(self.current_tx_block_limit);
+            debug!(
+                "Slot: {}. Increased Tx Cost Limit to {}",
+                working_bank.slot(),
+                self.current_tx_block_limit
+            );
+        }
+    }
+}
+
 pub struct BundleStage {
     bundle_thread: JoinHandle<()>,
 }
@@ -140,6 +197,7 @@ impl BundleStage {
         tip_manager: TipManager,
         bundle_account_locker: BundleAccountLocker,
         block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        preallocated_bundle_cost: u64,
     ) -> Self {
         Self::start_bundle_thread(
             cluster_info,
@@ -153,6 +211,7 @@ impl BundleStage {
             bundle_account_locker,
             MAX_BUNDLE_RETRY_DURATION,
             block_builder_fee_info,
+            preallocated_bundle_cost,
         )
     }
 
@@ -169,6 +228,7 @@ impl BundleStage {
         bundle_account_locker: BundleAccountLocker,
         max_bundle_retry_duration: Duration,
         block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        preallocated_bundle_cost: u64,
     ) -> Self {
         const BUNDLE_STAGE_ID: u32 = 10_000;
         let poh_recorder = poh_recorder.clone();
@@ -191,6 +251,7 @@ impl BundleStage {
                     bundle_account_locker,
                     max_bundle_retry_duration,
                     block_builder_fee_info,
+                    preallocated_bundle_cost,
                 );
             })
             .unwrap();
@@ -292,17 +353,41 @@ impl BundleStage {
         bank_start: &BankStart,
         bundle_stage_leader_stats: &mut BundleStageLeaderStats,
         max_bundle_retry_duration: &Duration,
+        reserved_space: &mut BundleReservedSpace,
     ) -> BundleStageResult<()> {
         if sanitized_bundle.transactions.is_empty() {
             return Ok(());
         }
 
-        let tx_costs = qos_service.compute_transaction_costs(sanitized_bundle.transactions.iter());
-        let (transactions_qos_results, num_included) = qos_service.select_transactions_per_cost(
-            sanitized_bundle.transactions.iter(),
-            tx_costs.iter(),
-            &bank_start.working_bank,
-        );
+        // Try to fit bundle into block using modified limits (scoped to guarantee cost_tracker is dropped)
+        let (tx_costs, transactions_qos_results, num_included) = {
+            let tx_costs =
+                qos_service.compute_transaction_costs(sanitized_bundle.transactions.iter());
+
+            let mut cost_tracker = bank_start.working_bank.write_cost_tracker().unwrap();
+            // Increase block cost limit for bundles
+            debug!(
+                "increasing cost limit for bundles: {}",
+                reserved_space.bundle_block_limit()
+            );
+            cost_tracker.set_block_cost_limit(reserved_space.bundle_block_limit());
+            let (transactions_qos_results, num_included) = qos_service
+                .select_transactions_per_cost(
+                    sanitized_bundle.transactions.iter(),
+                    tx_costs.iter(),
+                    bank_start.working_bank.slot(),
+                    &mut cost_tracker,
+                );
+            debug!(
+                "resetting cost limit for normal transactions: {}",
+                reserved_space.tx_block_limit()
+            );
+
+            // Reset block cost limit for normal txs
+            cost_tracker.set_block_cost_limit(reserved_space.tx_block_limit());
+
+            (tx_costs, transactions_qos_results, num_included)
+        };
 
         // accumulates QoS to metrics
         qos_service.accumulate_estimated_transaction_costs(
@@ -312,14 +397,23 @@ impl BundleStage {
             ),
         );
 
-        // either qos rate-limited a tx in here or bundle exceeds max cost, drop the bundle
+        // qos rate-limited a tx in here, drop the bundle
         if sanitized_bundle.transactions.len() != num_included {
             QosService::remove_transaction_costs(
                 tx_costs.iter(),
                 transactions_qos_results.iter(),
                 &bank_start.working_bank,
             );
-            qos_service.report_metrics(bank_start.working_bank.clone());
+            warn!(
+                "bundle dropped, qos rate limit. uuid: {} bundle_cost: {},  block_cost: {}",
+                sanitized_bundle.uuid,
+                tx_costs.iter().map(|c| c.sum()).sum::<u64>(),
+                &bank_start
+                    .working_bank
+                    .read_cost_tracker()
+                    .unwrap()
+                    .block_cost()
+            );
             return Err(BundleExecutionError::ExceedsCostModel);
         }
 
@@ -742,6 +836,7 @@ impl BundleStage {
                 }
             }
         }
+
         Ok(commit_transaction_details)
     }
 
@@ -885,6 +980,7 @@ impl BundleStage {
         last_tip_update_slot: &mut Slot,
         bundle_stage_leader_stats: &mut BundleStageLeaderStats,
         block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        reserved_space: &mut BundleReservedSpace,
     ) {
         let (sanitized_bundles, sanitized_bundle_elapsed) = measure!(
             unprocessed_bundles
@@ -983,7 +1079,8 @@ impl BundleStage {
                 max_bundle_retry_duration,
                 last_tip_update_slot,
                 bundle_stage_leader_stats,
-                block_builder_fee_info
+                block_builder_fee_info,
+                reserved_space,
             ),
             "execute_locked_bundles_elapsed"
         );
@@ -1056,6 +1153,7 @@ impl BundleStage {
         tip_manager: &TipManager,
         max_bundle_retry_duration: &Duration,
         bundle_stage_leader_stats: &mut BundleStageLeaderStats,
+        reserved_space: &mut BundleReservedSpace,
     ) -> BundleStageResult<()> {
         let initialize_tip_accounts_bundle = SanitizedBundle {
             transactions: Self::get_initialize_tip_accounts_transactions(
@@ -1063,6 +1161,7 @@ impl BundleStage {
                 tip_manager,
                 cluster_info,
             )?,
+            uuid: Uuid::default(),
         };
         if !initialize_tip_accounts_bundle.transactions.is_empty() {
             debug!("initialize tip account");
@@ -1079,6 +1178,7 @@ impl BundleStage {
                 bank_start,
                 bundle_stage_leader_stats,
                 max_bundle_retry_duration,
+                reserved_space,
             );
 
             match &result {
@@ -1118,6 +1218,7 @@ impl BundleStage {
         max_bundle_retry_duration: &Duration,
         bundle_stage_leader_stats: &mut BundleStageLeaderStats,
         block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        reserved_space: &mut BundleReservedSpace,
     ) -> BundleStageResult<()> {
         let start_handle_tips = Instant::now();
 
@@ -1142,6 +1243,7 @@ impl BundleStage {
 
             let change_tip_receiver_bundle = SanitizedBundle {
                 transactions: vec![change_tip_receiver_tx],
+                uuid: Uuid::default(),
             };
             let locked_change_tip_receiver_bundle = bundle_account_locker
                 .prepare_locked_bundle(&change_tip_receiver_bundle, &bank_start.working_bank)
@@ -1155,6 +1257,7 @@ impl BundleStage {
                 bank_start,
                 bundle_stage_leader_stats,
                 max_bundle_retry_duration,
+                reserved_space,
             );
 
             bundle_stage_leader_stats
@@ -1198,6 +1301,7 @@ impl BundleStage {
         last_tip_update_slot: &mut Slot,
         bundle_stage_leader_stats: &mut BundleStageLeaderStats,
         block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        reserved_space: &mut BundleReservedSpace,
     ) -> Vec<BundleStageResult<()>> {
         let tip_pdas = tip_manager.get_tip_accounts();
 
@@ -1235,6 +1339,7 @@ impl BundleStage {
                             tip_manager,
                             max_bundle_retry_duration,
                             bundle_stage_leader_stats,
+                            reserved_space,
                         )?;
 
                         Self::maybe_change_tip_receiver(
@@ -1249,6 +1354,7 @@ impl BundleStage {
                             max_bundle_retry_duration,
                             bundle_stage_leader_stats,
                             block_builder_fee_info,
+                            reserved_space,
                         )?;
 
                         *last_tip_update_slot = bank_start.working_bank.slot();
@@ -1263,6 +1369,7 @@ impl BundleStage {
                         bank_start,
                         bundle_stage_leader_stats,
                         max_bundle_retry_duration,
+                        reserved_space,
                     )
                 }
             })
@@ -1302,6 +1409,7 @@ impl BundleStage {
         bundle_stage_stats: &mut BundleStageLoopStats,
         id: u32,
         block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        reserved_space: &mut BundleReservedSpace,
     ) {
         const DROP_BUNDLE_SLOT_OFFSET: u64 = 4;
 
@@ -1320,7 +1428,6 @@ impl BundleStage {
                 bundle_stage_stats.num_bundles_dropped,
                 unprocessed_bundles.len() as u64 + cost_model_failed_bundles.len() as u64
             );
-
             unprocessed_bundles.clear();
             cost_model_failed_bundles.clear();
             return;
@@ -1335,13 +1442,19 @@ impl BundleStage {
                 (None, Some(_)) => true,
                 (_, _) => false,
             };
-            if is_new_slot && !cost_model_failed_bundles.is_empty() {
-                debug!(
-                    "Slot {}: Re-buffering {} bundles that failed cost model!",
-                    &bank_start.working_bank.slot(),
-                    cost_model_failed_bundles.len()
-                );
-                unprocessed_bundles.extend(cost_model_failed_bundles.drain(..));
+            if is_new_slot {
+                reserved_space.reset_reserved_cost(&bank_start.working_bank);
+                // Re-Buffer any bundles that didn't fit into last block
+                if !cost_model_failed_bundles.is_empty() {
+                    info!(
+                        "Slot {}: Re-buffering {} bundles that failed cost model!",
+                        &bank_start.working_bank.slot(),
+                        cost_model_failed_bundles.len()
+                    );
+                    unprocessed_bundles.extend(cost_model_failed_bundles.drain(..));
+                }
+            } else {
+                reserved_space.update_reserved_cost(&bank_start.working_bank);
             }
 
             Self::execute_bundles_until_empty_or_end_of_slot(
@@ -1361,6 +1474,7 @@ impl BundleStage {
                 last_tip_update_slot,
                 bundle_stage_leader_stats.bundle_stage_leader_stats(),
                 block_builder_fee_info,
+                reserved_space,
             );
         }
     }
@@ -1379,6 +1493,7 @@ impl BundleStage {
         bundle_account_locker: BundleAccountLocker,
         max_bundle_retry_duration: Duration,
         block_builder_fee_info: Arc<Mutex<BlockBuilderFeeInfo>>,
+        preallocated_bundle_cost: u64,
     ) {
         const LOOP_STATS_METRICS_PERIOD: Duration = Duration::from_secs(1);
 
@@ -1399,6 +1514,26 @@ impl BundleStage {
 
         let mut unprocessed_bundles: VecDeque<PacketBundle> = VecDeque::with_capacity(1000);
         let mut cost_model_failed_bundles: VecDeque<PacketBundle> = VecDeque::with_capacity(1000);
+        // Initialize block limits and open up last 20% of ticks to non-bundle transactions
+        let mut reserved_space = BundleReservedSpace {
+            current_bundle_block_limit: MAX_BLOCK_UNITS,
+            current_tx_block_limit: MAX_BLOCK_UNITS.saturating_sub(preallocated_bundle_cost),
+            initial_allocated_cost: preallocated_bundle_cost,
+            unreserved_ticks: poh_recorder
+                .lock()
+                .unwrap()
+                .ticks_per_slot()
+                .saturating_div(5),
+        };
+        debug!(
+            "initialize bundled reserved space: {preallocated_bundle_cost} cu for {} ticks",
+            poh_recorder
+                .lock()
+                .unwrap()
+                .ticks_per_slot()
+                .saturating_sub(reserved_space.unreserved_ticks)
+        );
+
         while !exit.load(Ordering::Relaxed) {
             if !unprocessed_bundles.is_empty()
                 || last_leader_slots_update_time.elapsed() >= SLOT_BOUNDARY_CHECK_PERIOD
@@ -1422,7 +1557,8 @@ impl BundleStage {
                         &mut bundle_stage_leader_stats,
                         &mut bundle_stage_stats,
                         id,
-                        &block_builder_fee_info
+                        &block_builder_fee_info,
+                        &mut reserved_space,
                     ),
                     "process_buffered_bundles_elapsed"
                 );
@@ -1642,6 +1778,12 @@ mod tests {
             &bank_start,
             &mut bundle_stage_leader_stats,
             &TEST_MAX_RETRY_DURATION,
+            &mut BundleReservedSpace {
+                current_tx_block_limit: 1,
+                current_bundle_block_limit: 1,
+                initial_allocated_cost: 0,
+                unreserved_ticks: poh_recorder.lock().unwrap().ticks_per_slot(),
+            },
         );
 
         // This is ugly, not really an option for testing but a test itself.
@@ -1973,6 +2115,12 @@ mod tests {
             &bank_start,
             &mut bundle_stage_leader_stats,
             &TEST_MAX_RETRY_DURATION,
+            &mut BundleReservedSpace {
+                current_tx_block_limit: u64::MAX,
+                current_bundle_block_limit: u64::MAX,
+                initial_allocated_cost: 0,
+                unreserved_ticks: poh_recorder.lock().unwrap().ticks_per_slot(),
+            },
         );
         info!("test_bundle_max_retries result: {:?}", result);
         assert!(matches!(

--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -18,7 +18,7 @@ use {
     std::{
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
-            Arc, RwLock, RwLockWriteGuard,
+            Arc, RwLock,
         },
         thread::{self, Builder, JoinHandle},
         time::Duration,
@@ -127,7 +127,7 @@ impl QosService {
         transactions: impl Iterator<Item = &'a SanitizedTransaction>,
         transactions_costs: impl Iterator<Item = &'a TransactionCost>,
         slot: Slot,
-        cost_tracker: &mut RwLockWriteGuard<CostTracker>,
+        cost_tracker: &mut CostTracker,
     ) -> (Vec<transaction::Result<()>>, usize) {
         let mut cost_tracking_time = Measure::start("cost_tracking_time");
         let mut num_included = 0;

--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -9,7 +9,7 @@ use {
     solana_runtime::{
         bank::Bank,
         cost_model::{CostModel, TransactionCost},
-        cost_tracker::CostTrackerError,
+        cost_tracker::{CostTracker, CostTrackerError},
     },
     solana_sdk::{
         clock::Slot,
@@ -18,7 +18,7 @@ use {
     std::{
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
-            Arc, RwLock,
+            Arc, RwLock, RwLockWriteGuard,
         },
         thread::{self, Builder, JoinHandle},
         time::Duration,
@@ -126,22 +126,22 @@ impl QosService {
         &self,
         transactions: impl Iterator<Item = &'a SanitizedTransaction>,
         transactions_costs: impl Iterator<Item = &'a TransactionCost>,
-        bank: &Arc<Bank>,
+        slot: Slot,
+        cost_tracker: &mut RwLockWriteGuard<CostTracker>,
     ) -> (Vec<transaction::Result<()>>, usize) {
         let mut cost_tracking_time = Measure::start("cost_tracking_time");
-        let mut cost_tracker = bank.write_cost_tracker().unwrap();
         let mut num_included = 0;
         let select_results = transactions
             .zip(transactions_costs)
             .map(|(tx, cost)| match cost_tracker.try_add(cost) {
                 Ok(current_block_cost) => {
-                    debug!("slot {:?}, transaction {:?}, cost {:?}, fit into current block, current block cost {}", bank.slot(), tx, cost, current_block_cost);
+                    debug!("slot {:?}, transaction {:?}, cost {:?}, fit into current block, current block cost {}", slot, tx, cost, current_block_cost);
                     self.metrics.stats.selected_txs_count.fetch_add(1, Ordering::Relaxed);
                     num_included += 1;
                     Ok(())
                 },
                 Err(e) => {
-                    debug!("slot {:?}, transaction {:?}, cost {:?}, not fit into current block, '{:?}'", bank.slot(), tx, cost, e);
+                    debug!("slot {:?}, transaction {:?}, cost {:?}, not fit into current block, '{:?}'", slot, tx, cost, e);
                     match e {
                         CostTrackerError::WouldExceedBlockMaxLimit => {
                             Err(TransactionError::WouldExceedMaxBlockCostLimit)
@@ -640,8 +640,12 @@ mod tests {
         bank.write_cost_tracker()
             .unwrap()
             .set_limits(cost_limit, cost_limit, cost_limit);
-        let (results, num_selected) =
-            qos_service.select_transactions_per_cost(txs.iter(), txs_costs.iter(), &bank);
+        let (results, num_selected) = qos_service.select_transactions_per_cost(
+            txs.iter(),
+            txs_costs.iter(),
+            bank.slot(),
+            &mut bank.write_cost_tracker().unwrap(),
+        );
         assert_eq!(num_selected, 2);
 
         // verify that first transfer tx and first vote are allowed
@@ -675,8 +679,12 @@ mod tests {
             let qos_service = QosService::new(Arc::new(RwLock::new(CostModel::default())), 1);
             let txs_costs = qos_service.compute_transaction_costs(txs.iter());
             let total_txs_cost: u64 = txs_costs.iter().map(|cost| cost.sum()).sum();
-            let (qos_results, _num_included) =
-                qos_service.select_transactions_per_cost(txs.iter(), txs_costs.iter(), &bank);
+            let (qos_results, _num_included) = qos_service.select_transactions_per_cost(
+                txs.iter(),
+                txs_costs.iter(),
+                bank.slot(),
+                &mut bank.write_cost_tracker().unwrap(),
+            );
             assert_eq!(
                 total_txs_cost,
                 bank.read_cost_tracker().unwrap().block_cost()
@@ -728,8 +736,12 @@ mod tests {
             let qos_service = QosService::new(Arc::new(RwLock::new(CostModel::default())), 1);
             let txs_costs = qos_service.compute_transaction_costs(txs.iter());
             let total_txs_cost: u64 = txs_costs.iter().map(|cost| cost.sum()).sum();
-            let (qos_results, _num_included) =
-                qos_service.select_transactions_per_cost(txs.iter(), txs_costs.iter(), &bank);
+            let (qos_results, _num_included) = qos_service.select_transactions_per_cost(
+                txs.iter(),
+                txs_costs.iter(),
+                bank.slot(),
+                &mut bank.write_cost_tracker().unwrap(),
+            );
             assert_eq!(
                 total_txs_cost,
                 bank.read_cost_tracker().unwrap().block_cost()
@@ -768,8 +780,12 @@ mod tests {
             let qos_service = QosService::new(Arc::new(RwLock::new(CostModel::default())), 1);
             let txs_costs = qos_service.compute_transaction_costs(txs.iter());
             let total_txs_cost: u64 = txs_costs.iter().map(|cost| cost.sum()).sum();
-            let (qos_results, _num_included) =
-                qos_service.select_transactions_per_cost(txs.iter(), txs_costs.iter(), &bank);
+            let (qos_results, _num_included) = qos_service.select_transactions_per_cost(
+                txs.iter(),
+                txs_costs.iter(),
+                bank.slot(),
+                &mut bank.write_cost_tracker().unwrap(),
+            );
             assert_eq!(
                 total_txs_cost,
                 bank.read_cost_tracker().unwrap().block_cost()

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -119,6 +119,7 @@ impl Tpu {
         shred_receiver_address: Option<SocketAddr>,
         shared_staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
         tpu_enable_udp: bool,
+        preallocated_bundle_cost: u64,
     ) -> Self {
         let TpuSockets {
             transactions: transactions_sockets,
@@ -325,6 +326,7 @@ impl Tpu {
             tip_manager,
             bundle_account_locker,
             &block_builder_fee_info,
+            preallocated_bundle_cost,
         );
 
         let broadcast_stage = broadcast_type.new_broadcast_stage(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -184,6 +184,7 @@ pub struct ValidatorConfig {
     pub maybe_block_engine_config: Option<BlockEngineConfig>,
     pub shred_receiver_address: Option<SocketAddr>,
     pub tip_manager_config: TipManagerConfig,
+    pub preallocated_bundle_cost: u64,
 }
 
 impl Default for ValidatorConfig {
@@ -253,6 +254,7 @@ impl Default for ValidatorConfig {
             maybe_block_engine_config: None,
             shred_receiver_address: None,
             tip_manager_config: TipManagerConfig::default(),
+            preallocated_bundle_cost: u64::default(),
         }
     }
 }
@@ -1045,6 +1047,7 @@ impl Validator {
             config.shred_receiver_address,
             config.staked_nodes_overrides.clone(),
             tpu_enable_udp,
+            config.preallocated_bundle_cost,
         );
 
         datapoint_info!(

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -47,4 +47,3 @@ RUN --mount=type=cache,mode=0777,target=/solana/target \
 # keep CI_COMMIT at bottom since it breaks caching: https://stackoverflow.com/a/57017745/3408577
 ARG ci_commit
 ENV CI_COMMIT=$ci_commit
-

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -32,8 +32,6 @@ RUN mkdir -p docker-output
 
 ARG debug
 
-ARG debug
-
 # Uses docker buildkit to cache the image.
 # /usr/local/cargo/git needed for crossbeam patch
 RUN --mount=type=cache,mode=0777,target=/solana/target \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -32,6 +32,8 @@ RUN mkdir -p docker-output
 
 ARG debug
 
+ARG debug
+
 # Uses docker buildkit to cache the image.
 # /usr/local/cargo/git needed for crossbeam patch
 RUN --mount=type=cache,mode=0777,target=/solana/target \
@@ -47,3 +49,4 @@ RUN --mount=type=cache,mode=0777,target=/solana/target \
 # keep CI_COMMIT at bottom since it breaks caching: https://stackoverflow.com/a/57017745/3408577
 ARG ci_commit
 ENV CI_COMMIT=$ci_commit
+

--- a/f
+++ b/f
@@ -13,9 +13,11 @@ echo "Git hash: $GIT_SHA"
 
 DEBUG_FLAGS=${1-false}
 
+DEBUG_FLAGS=${1-false}
+
 DOCKER_BUILDKIT=1 docker build \
-  --build-arg debug="$DEBUG_FLAGS" \
-  --build-arg ci_commit="$GIT_SHA" \
+  --build-arg debug=$DEBUG_FLAGS \
+  --build-arg ci_commit=$GIT_SHA \
   -t jitolabs/build-solana \
   -f dev/Dockerfile . \
   --progress=plain

--- a/f
+++ b/f
@@ -13,8 +13,6 @@ echo "Git hash: $GIT_SHA"
 
 DEBUG_FLAGS=${1-false}
 
-DEBUG_FLAGS=${1-false}
-
 DOCKER_BUILDKIT=1 docker build \
   --build-arg debug=$DEBUG_FLAGS \
   --build-arg ci_commit=$GIT_SHA \

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -71,6 +71,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         maybe_block_engine_config: config.maybe_block_engine_config.clone(),
         shred_receiver_address: config.shred_receiver_address,
         tip_manager_config: config.tip_manager_config.clone(),
+        preallocated_bundle_cost: config.preallocated_bundle_cost,
     }
 }
 

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -89,6 +89,10 @@ impl CostTracker {
         self.vote_cost_limit = vote_cost_limit;
     }
 
+    pub fn set_block_cost_limit(&mut self, new_limit: u64) {
+        self.block_cost_limit = new_limit;
+    }
+
     pub fn try_add(&mut self, tx_cost: &TransactionCost) -> Result<u64, CostTrackerError> {
         self.would_fit(tx_cost)?;
         self.add_transaction_cost(tx_cost);
@@ -136,6 +140,10 @@ impl CostTracker {
 
     pub fn block_cost(&self) -> u64 {
         self.block_cost
+    }
+
+    pub fn block_cost_limit(&self) -> u64 {
+        self.block_cost_limit
     }
 
     pub fn transaction_count(&self) -> u64 {

--- a/sdk/src/bundle/sanitized.rs
+++ b/sdk/src/bundle/sanitized.rs
@@ -1,8 +1,9 @@
 #![cfg(feature = "full")]
 
-use solana_sdk::transaction::SanitizedTransaction;
+use {solana_sdk::transaction::SanitizedTransaction, uuid::Uuid};
 
 #[derive(Clone, Debug)]
 pub struct SanitizedBundle {
     pub transactions: Vec<SanitizedTransaction>,
+    pub uuid: Uuid,
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -114,6 +114,7 @@ const DEFAULT_MIN_SNAPSHOT_DOWNLOAD_SPEED: u64 = 10485760;
 // The maximum times of snapshot download abort and retry
 const MAX_SNAPSHOT_DOWNLOAD_ABORT: u32 = 5;
 const MILLIS_PER_SECOND: u64 = 1000;
+const DEFAULT_PREALLOCATED_BUNDLE_COST: u64 = 3000000;
 
 fn monitor_validator(ledger_path: &Path) {
     let dashboard = Dashboard::new(ledger_path, None, None).unwrap_or_else(|err| {
@@ -508,6 +509,7 @@ pub fn main() {
     let default_accounts_shrink_ratio = &DEFAULT_ACCOUNTS_SHRINK_RATIO.to_string();
     let default_tpu_connection_pool_size = &DEFAULT_TPU_CONNECTION_POOL_SIZE.to_string();
     let default_rpc_max_request_body_size = &MAX_REQUEST_BODY_SIZE.to_string();
+    let default_preallocated_bundle_cost = &DEFAULT_PREALLOCATED_BUNDLE_COST.to_string();
 
     let matches = App::new(crate_name!()).about(crate_description!())
         .version(solana_version::version!())
@@ -1846,6 +1848,14 @@ pub fn main() {
                 .help("The commission validator takes from tips expressed in basis points.")
         )
         .arg(
+            Arg::with_name("preallocated_bundle_cost")
+                .long("preallocated-bundle-cost")
+                .value_name("PREALLOCATED_BUNDLE_COST")
+                .takes_value(true)
+                .default_value(default_preallocated_bundle_cost)
+                .help("Number of CUs to allocate for bundles at beginning of slot.")
+        )
+        .arg(
             Arg::with_name("shred_receiver_address")
                 .long("shred-receiver-address")
                 .value_name("SHRED_RECEIVER_ADDRESS")
@@ -2883,6 +2893,8 @@ pub fn main() {
             .map(|address| SocketAddr::from_str(address).expect("shred_receiver_address invalid")),
         staked_nodes_overrides: staked_nodes_overrides.clone(),
         replay_slots_concurrently: matches.is_present("replay_slots_concurrently"),
+        preallocated_bundle_cost: value_of(&matches, "preallocated_bundle_cost")
+            .unwrap_or(DEFAULT_PREALLOCATED_BUNDLE_COST),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem
Bundles are not landing due to maximum block cost errors.

#### Summary of Changes
Preallocate space for bundles as soon as leader slot starts.


ToDo:

- [x] Release Reserved Space at 80% slot ticks. 
- [ ] initialize Reserved Space with current block limit instead of MAX_BLOCK_UNITS