### PR TITLE
Simplify bootstrapping

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-BANK_HASH=$(cargo run --bin solana-ledger-tool -- -l config/bootstrap-validator bank-hash)
+BANK_HASH=$(cargo run --release --bin solana-ledger-tool -- -l config/bootstrap-validator bank-hash)
 
 # increase max file handle limit
 ulimit -Hn 1000000

--- a/bootstrap
+++ b/bootstrap
@@ -11,7 +11,7 @@ ulimit -Hn 1000000
 
 # NOTE: make sure tip-payment and tip-distribution program are deployed using the correct pubkeys
 RUST_LOG=INFO,solana_core::bundle_stage=DEBUG \
-	NDEBUG=1 ./multinode-demo/bootstrap-validator.sh  \
+  NDEBUG=1 ./multinode-demo/bootstrap-validator.sh \
   --wait-for-supermajority 0 \
   --expected-bank-hash "$BANK_HASH" \
   --block-engine-address http://127.0.0.1:1003 \

--- a/bootstrap
+++ b/bootstrap
@@ -4,8 +4,8 @@ set -eu
 BANK_HASH=$(cargo run --bin solana-ledger-tool -- -l config/bootstrap-validator bank-hash)
 
 # increase max file handle limit
-
 ulimit -Hn 1000000
+
 # if above fails, run:
 # sudo bash -c 'echo "*               hard    nofile          1000000" >> /etc/security/limits.conf'
 

--- a/bootstrap
+++ b/bootstrap
@@ -1,11 +1,19 @@
-#!/usr/bin/env sh
-bank_hash=$(./target/release/solana-ledger-tool -l config/bootstrap-validator bank-hash)
+#!/usr/bin/env bash
+set -eu
+
+BANK_HASH=$(cargo run --bin solana-ledger-tool -- -l config/bootstrap-validator bank-hash)
+
+# increase max file handle limit
+
+ulimit -Hn 1000000
+# if above fails, run:
+# sudo bash -c 'echo "*               hard    nofile          1000000" >> /etc/security/limits.conf'
 
 # NOTE: make sure tip-payment and tip-distribution program are deployed using the correct pubkeys
 RUST_LOG=INFO,solana_core::bundle_stage=DEBUG \
 	NDEBUG=1 ./multinode-demo/bootstrap-validator.sh  \
   --wait-for-supermajority 0 \
-  --expected-bank-hash $bank_hash \
+  --expected-bank-hash "$BANK_HASH" \
   --block-engine-address http://127.0.0.1:1003 \
   --block-engine-auth-service-address http://127.0.0.1:1005 \
   --relayer-auth-service-address http://127.0.0.1:11226 \

--- a/start
+++ b/start
@@ -1,9 +1,9 @@
-#!/usr/bin/env sh
-solana_keygen=./target/release/solana-keygen
+#!/usr/bin/env bash
+set -eu
+
 SOLANA_CONFIG_DIR=./config
 
-mkdir $SOLANA_CONFIG_DIR
-
+mkdir -p $SOLANA_CONFIG_DIR
 NDEBUG=1 ./multinode-demo/setup.sh
-./target/release/solana-ledger-tool -l config/bootstrap-validator/ create-snapshot 0
+cargo run --bin solana-ledger-tool -- -l config/bootstrap-validator/ create-snapshot 0
 NDEBUG=1 ./multinode-demo/faucet.sh

--- a/start
+++ b/start
@@ -5,5 +5,5 @@ SOLANA_CONFIG_DIR=./config
 
 mkdir -p $SOLANA_CONFIG_DIR
 NDEBUG=1 ./multinode-demo/setup.sh
-cargo run --bin solana-ledger-tool -- -l config/bootstrap-validator/ create-snapshot 0
+cargo run --release --bin solana-ledger-tool -- -l config/bootstrap-validator/ create-snapshot 0
 NDEBUG=1 ./multinode-demo/faucet.sh

--- a/start_multi
+++ b/start_multi
@@ -1,29 +1,30 @@
-#!/usr/bin/env sh
-solana_keygen=./target/release/solana-keygen
+#!/usr/bin/env bash
+set -eu
+
+SOLANA_KEYGEN="cargo run --bin solana-keygen --"
 SOLANA_CONFIG_DIR=./config
 
-mkdir $SOLANA_CONFIG_DIR
-if [ $? -eq 0 ] ; then
-    echo "New Config!  Generating Identities"
-    $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/a/identity.json
-    $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/a/stake-account.json
-    $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/a/vote-account.json
+if [[ ! -d $SOLANA_CONFIG_DIR ]]; then
+  echo "New Config! Generating Identities"
+  mkdir $SOLANA_CONFIG_DIR
+  $SOLANA_KEYGEN new --no-passphrase -so "$SOLANA_CONFIG_DIR"/a/identity.json
+  $SOLANA_KEYGEN new --no-passphrase -so "$SOLANA_CONFIG_DIR"/a/stake-account.json
+  $SOLANA_KEYGEN new --no-passphrase -so "$SOLANA_CONFIG_DIR"/a/vote-account.json
 
-    $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/b/identity.json
-    $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/b/stake-account.json
-    $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/b/vote-account.json
+  $SOLANA_KEYGEN new --no-passphrase -so "$SOLANA_CONFIG_DIR"/b/identity.json
+  $SOLANA_KEYGEN new --no-passphrase -so "$SOLANA_CONFIG_DIR"/b/stake-account.json
+  $SOLANA_KEYGEN new --no-passphrase -so "$SOLANA_CONFIG_DIR"/b/vote-account.json
 fi
 
-
 NDEBUG=1 ./multinode-demo/setup.sh \
-      --bootstrap-validator \
-        "$SOLANA_CONFIG_DIR"/a/identity.json \
-        "$SOLANA_CONFIG_DIR"/a/vote-account.json \
-        "$SOLANA_CONFIG_DIR"/a/stake-account.json \
-      --bootstrap-validator \
-        "$SOLANA_CONFIG_DIR"/b/identity.json \
-        "$SOLANA_CONFIG_DIR"/b/vote-account.json \
-        "$SOLANA_CONFIG_DIR"/b/stake-account.json
+  --bootstrap-validator \
+  "$SOLANA_CONFIG_DIR"/a/identity.json \
+  "$SOLANA_CONFIG_DIR"/a/vote-account.json \
+  "$SOLANA_CONFIG_DIR"/a/stake-account.json \
+  --bootstrap-validator \
+  "$SOLANA_CONFIG_DIR"/b/identity.json \
+  "$SOLANA_CONFIG_DIR"/b/vote-account.json \
+  "$SOLANA_CONFIG_DIR"/b/stake-account.json
 
-./target/release/solana-ledger-tool -l config/bootstrap-validator/ create-snapshot 0
+cargo run --bin solana-ledger-tool -- -l config/bootstrap-validator/ create-snapshot 0
 NDEBUG=1 ./multinode-demo/faucet.sh

--- a/start_multi
+++ b/start_multi
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-SOLANA_KEYGEN="cargo run --bin solana-keygen --"
+SOLANA_KEYGEN="cargo run --release --bin solana-keygen --"
 SOLANA_CONFIG_DIR=./config
 
 if [[ ! -d $SOLANA_CONFIG_DIR ]]; then


### PR DESCRIPTION
#### Problem
- Fails to start when run on clean cargo directory
- Doesn't set open file handle limit

#### Summary of Changes
- Use cargo to run binaries (eg solana-ledger-tool)
- Fix some shellcheck warnings
- Format files

Start with:
```bash
# in terminal 1
./start

# in terminal 2
./bootstrap
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
