### PR TITLE
Account for block builder fee when generating excess tip balance

### DIFF
--- a/tip-distributor/src/stake_meta_generator_workflow.rs
+++ b/tip-distributor/src/stake_meta_generator_workflow.rs
@@ -189,9 +189,9 @@ pub fn generate_stake_meta_collection(
     // matches math in tip payment program
     let block_builder_tips = excess_tip_balances
         .checked_mul(bb_commission_pct)
-        .expect("bb_commission overflow")
+        .expect("block_builder_tips overflow")
         .checked_div(100)
-        .expect("division");
+        .expect("block_builder_tips division error");
     let tip_receiver_fee = excess_tip_balances
         .checked_sub(block_builder_tips)
         .expect("tip_receiver_fee doesnt underflow");


### PR DESCRIPTION
#### Problem
The block builder fee wasn't taken into account when doing mev claims. This was resulting in the mev claim process thinking it had more lamports than it did, causing the claim process to distribute too much to entities and the last jito-solana leader in an epoch having a failed claim on the last claim account.

#### Summary of Changes
Add more stringent checks around accounts existing.
Take into account block builder fee