### PR TITLE
Backport #240 on 1.14

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -33,9 +33,15 @@ RUN mkdir -p docker-output
 ARG ci_commit
 ENV CI_COMMIT=$ci_commit
 
+ARG debug
+
 # Uses docker buildkit to cache the image.
 # /usr/local/cargo/git needed for crossbeam patch
 RUN --mount=type=cache,mode=0777,target=/solana/target \
     --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
     --mount=type=cache,mode=0777,target=/usr/local/cargo/git \
-    cargo build --release && cp target/release/solana* ./docker-output
+    if [ "$debug" = "false" ] ; then \
+      ./cargo stable build --release && cp target/release/solana* ./docker-output; \
+    else \
+      RUSTFLAGS='-g -C force-frame-pointers=yes' ./cargo stable build --release && cp target/release/solana* ./docker-output; \
+    fi

--- a/f
+++ b/f
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 # Builds jito-solana in a docker container.
 # Useful for running on machines that might not have cargo installed but can run docker (Flatcar Linux).
+# run `./f true` to compile with debug flags
+
 set -eux
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
@@ -9,7 +11,10 @@ GIT_SHA="$(git describe --always --dirty)"
 
 echo $GIT_SHA
 
+DEBUG_FLAGS=${1-false}
+
 DOCKER_BUILDKIT=1 docker build \
+  --build-arg debug=$DEBUG_FLAGS \
   --build-arg ci_commit=$GIT_SHA \
   -t jitolabs/build-solana \
   -f dev/Dockerfile . \


### PR DESCRIPTION
Backports #240 onto v1.14.
Adds use of ./cargo instead of normal cargo