### PR TITLE
Backport #240 on v1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,17 +2384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "jito-programs-vote-state"
-version = "0.1.2"
-dependencies = [
- "anchor-lang",
- "bincode",
- "serde",
- "serde_derive",
- "solana-program 1.13.7",
-]
-
-[[package]]
 name = "jito-protos"
 version = "1.13.7"
 dependencies = [
@@ -7513,8 +7502,8 @@ name = "tip-distribution"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "jito-programs-vote-state",
  "solana-program 1.13.7",
+ "vote-state",
 ]
 
 [[package]]
@@ -8155,6 +8144,17 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vote-state"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-program 1.13.7",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,6 +2384,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "jito-programs-vote-state"
+version = "0.1.2"
+dependencies = [
+ "anchor-lang",
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-program 1.13.7",
+]
+
+[[package]]
 name = "jito-protos"
 version = "1.13.7"
 dependencies = [
@@ -7502,8 +7513,8 @@ name = "tip-distribution"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
+ "jito-programs-vote-state",
  "solana-program 1.13.7",
- "vote-state",
 ]
 
 [[package]]
@@ -8144,17 +8155,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "vote-state"
-version = "0.1.0"
-dependencies = [
- "anchor-lang",
- "bincode",
- "serde",
- "serde_derive",
- "solana-program 1.13.7",
-]
 
 [[package]]
 name = "wait-timeout"

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -33,9 +33,15 @@ RUN mkdir -p docker-output
 ARG ci_commit
 ENV CI_COMMIT=$ci_commit
 
+ARG debug
+
 # Uses docker buildkit to cache the image.
 # /usr/local/cargo/git needed for crossbeam patch
 RUN --mount=type=cache,mode=0777,target=/solana/target \
     --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
     --mount=type=cache,mode=0777,target=/usr/local/cargo/git \
-    cargo build --release && cp target/release/solana* ./docker-output
+    if [ "$debug" = "false" ] ; then \
+      ./cargo stable build --release && cp target/release/solana* ./docker-output; \
+    else \
+      RUSTFLAGS='-g -C force-frame-pointers=yes' ./cargo stable build --release && cp target/release/solana* ./docker-output; \
+    fi

--- a/f
+++ b/f
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 # Builds jito-solana in a docker container.
 # Useful for running on machines that might not have cargo installed but can run docker (Flatcar Linux).
+# run `./f true` to compile with debug flags
+
 set -eux
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
@@ -9,7 +11,10 @@ GIT_SHA="$(git describe --always --dirty)"
 
 echo $GIT_SHA
 
+DEBUG_FLAGS=${1-false}
+
 DOCKER_BUILDKIT=1 docker build \
+  --build-arg debug=$DEBUG_FLAGS \
   --build-arg ci_commit=$GIT_SHA \
   -t jitolabs/build-solana \
   -f dev/Dockerfile . \


### PR DESCRIPTION
Backport #240 on v1.13
Uses ./cargo to build in docker instead of docker cargo version