### PR TITLE
Add missing rustfmt install for rust-version toolchain

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -42,6 +42,7 @@ export rust_nightly_docker_image=solanalabs/rust-nightly:"$nightly_version"
       echo "$0: Missing toolchain? Installing...: $toolchain" >&2
       rustup install "$toolchain"
       cargo +"$toolchain" -V
+      rustup component add rustfmt --toolchain $toolchain
     fi
   }
 


### PR DESCRIPTION
Backporting #240 on v1.14 had missing rustfmt install that master has. Added that to fix `./f`