### PR TITLE
demote frequent relayer_stage-stream_error to warn

### DIFF
--- a/core/src/proxy/relayer_stage.rs
+++ b/core/src/proxy/relayer_stage.rs
@@ -197,7 +197,7 @@ impl RelayerStage {
                         Ok(_) => {}
                         Err(e) => {
                             stream_error_count += 1;
-                            datapoint_error!(
+                            datapoint_warn!(
                                 "relayer_stage-stream_error",
                                 ("count", stream_error_count, i64),
                                 ("error", e.to_string(), String),


### PR DESCRIPTION
#### Problem
This log is very frequent and very scary. Gave me heart-attack because ERROR usually means validator has crashed.

#### Summary of Changes
Demote to WARN.

