### PR TITLE
limit number of concurrent rpc calls

### DIFF
--- a/tip-distributor/src/claim_mev_workflow.rs
+++ b/tip-distributor/src/claim_mev_workflow.rs
@@ -48,7 +48,7 @@ pub fn claim_mev_tips(
         Pubkey::find_program_address(&[Config::SEED], tip_distribution_program_id).0;
 
     let rpc_client =
-        RpcClient::new_with_commitment(rpc_url.to_string(), CommitmentConfig::confirmed());
+        RpcClient::new_with_commitment(rpc_url.to_string(), CommitmentConfig::finalized());
 
     let runtime = Builder::new_multi_thread()
         .worker_threads(16)

--- a/tip-distributor/src/lib.rs
+++ b/tip-distributor/src/lib.rs
@@ -26,7 +26,7 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signature},
         stake_history::Epoch,
-        transaction::Transaction,
+        transaction::{Transaction, TransactionError::AlreadyProcessed},
     },
     std::{
         collections::HashMap,
@@ -522,7 +522,11 @@ pub async fn sign_and_send_transactions_with_retries(
                     }
                     Err(e) => {
                         error!("error sending transaction {sig:?} error: {e:?}");
-                        Err(e)
+                        if e == AlreadyProcessed {
+                            Ok(())
+                        } else {
+                            Err(e)
+                        }
                     }
                 };
 

--- a/tip-distributor/src/lib.rs
+++ b/tip-distributor/src/lib.rs
@@ -522,7 +522,7 @@ pub async fn sign_and_send_transactions_with_retries(
                     }
                     Err(e) => {
                         error!("error sending transaction {sig:?} error: {e:?}");
-                        if e == AlreadyProcessed {
+                        if let ErrorKind::TransactionError(AlreadyProcessed) = e.kind {
                             Ok(())
                         } else {
                             Err(e)


### PR DESCRIPTION
can overload system when spawning too many concurrent network calls