### PR TITLE
Discard Empty Packet Batches

### DIFF
--- a/core/src/proxy/block_engine_stage.rs
+++ b/core/src/proxy/block_engine_stage.rs
@@ -355,6 +355,11 @@ impl BlockEngineStage {
         block_engine_stats: &mut BlockEngineStageStats,
     ) -> crate::proxy::Result<()> {
         if let Some(batch) = resp.batch {
+            if batch.packets.is_empty() {
+                saturating_add_assign!(block_engine_stats.num_empty_packets, 1);
+                return Ok(());
+            }
+
             let packet_batch = PacketBatch::new(
                 batch
                     .packets

--- a/core/src/proxy/relayer_stage.rs
+++ b/core/src/proxy/relayer_stage.rs
@@ -328,6 +328,11 @@ impl RelayerStage {
                 saturating_add_assign!(relayer_stats.num_empty_messages, 1);
             }
             Some(relayer::subscribe_packets_response::Msg::Batch(proto_batch)) => {
+                if proto_batch.packets.is_empty() {
+                    saturating_add_assign!(relayer_stats.num_empty_messages, 1);
+                    return Ok(());
+                }
+
                 let packet_batch = PacketBatch::new(
                     proto_batch
                         .packets


### PR DESCRIPTION
#### Problem
Empty packet batches from block engine and relayer not handled correctly.

#### Summary of Changes
Detect and discard empty packet batches.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
