### PR TITLE
Seg/dev

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -73,8 +73,8 @@ solana-vote-program = { path = "../programs/vote", version = "=1.15.0" }
 sys-info = "0.9.1"
 tempfile = "3.3.0"
 thiserror = "1.0"
-tip-distribution = { path = "../jito-programs/src/programs/tip-distribution", features = ["no-entrypoint"] }
-tip-payment = { path = "../jito-programs/src/programs/tip-payment", features = ["no-entrypoint"] }
+tip-distribution = { path = "../jito-programs/mev-programs/programs/tip-distribution", features = ["no-entrypoint"] }
+tip-payment = { path = "../jito-programs/mev-programs/programs/tip-payment", features = ["no-entrypoint"] }
 tokio = { version = "~1.14.1", features = ["full"] }
 tokio-stream = "0.1.8"
 tonic = { version = "0.5.2", features = ["tls"] }

--- a/tip-distributor/Cargo.toml
+++ b/tip-distributor/Cargo.toml
@@ -27,8 +27,8 @@ solana-runtime = { path = "../runtime", version = "=1.15.0" }
 solana-sdk = { path = "../sdk", version = "=1.15.0" }
 solana-stake-program = { path = "../programs/stake", version = "=1.15.0" }
 thiserror = "1.0.31"
-tip-distribution = { path = "../jito-programs/src/programs/tip-distribution", features = ["no-entrypoint"] }
-tip-payment = { path = "../jito-programs/src/programs/tip-payment", features = ["no-entrypoint"] }
+tip-distribution = { path = "../jito-programs/mev-programs/programs/tip-distribution", features = ["no-entrypoint"] }
+tip-payment = { path = "../jito-programs/mev-programs/programs/tip-payment", features = ["no-entrypoint"] }
 tokio = { version = "1.12.0", features = ["rt-multi-thread", "macros", "sync", "time", "full"] }
 
 [[bin]]

--- a/tip-distributor/src/bin/reclaim-rent.rs
+++ b/tip-distributor/src/bin/reclaim-rent.rs
@@ -29,6 +29,10 @@ struct Args {
     #[arg(long, env)]
     keypair_path: PathBuf,
 
+    /// High timeout b/c of get_program_accounts call
+    #[arg(long, env, default_value_t = 180)]
+    rpc_timeout_secs: u64,
+
     /// Specifies whether to reclaim rent on behalf of validators from respective TDAs.
     #[arg(long, env)]
     should_reclaim_tdas: bool,
@@ -44,8 +48,7 @@ fn main() {
     if let Err(e) = runtime.block_on(reclaim_rent(
         RpcClient::new_with_timeout_and_commitment(
             args.rpc_url,
-            // High timeout b/c of get_program_accounts call
-            Duration::from_secs(60),
+            Duration::from_secs(args.rpc_timeout_secs),
             CommitmentConfig::confirmed(),
         ),
         args.tip_distribution_program_id,


### PR DESCRIPTION
- Points to new jito-programs submodule.
- Paramertirizes rent-reclaim rpc client timeout and sets a higher default.