### PR TITLE
Seg/rm bundle UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,6 @@ dependencies = [
  "tonic 0.5.2",
  "tonic-build 0.5.2",
  "trees",
- "uuid",
 ]
 
 [[package]]
@@ -6663,7 +6662,6 @@ dependencies = [
  "thiserror",
  "tiny-bip39",
  "uriparse",
- "uuid",
  "wasm-bindgen",
 ]
 
@@ -8354,16 +8352,6 @@ name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
-
-[[package]]
-name = "uuid"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
-dependencies = [
- "getrandom 0.2.8",
- "rand 0.8.5",
-]
 
 [[package]]
 name = "valuable"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -79,7 +79,6 @@ tokio = { version = "~1.14.1", features = ["full"] }
 tokio-stream = "0.1.8"
 tonic = { version = "0.5.2", features = ["tls"] }
 trees = "0.4.2"
-uuid = { version = "1.0.0", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 matches = "0.1.9"

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -3,7 +3,6 @@ use {
     solana_entry::entry::Entry,
     solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
     solana_sdk::{hash::Hash, signature::Keypair},
-    std::net::SocketAddr,
 };
 
 #[derive(Clone)]

--- a/core/src/bundle_account_locker.rs
+++ b/core/src/bundle_account_locker.rs
@@ -234,7 +234,6 @@ mod tests {
             system_transaction::transfer, transaction::VersionedTransaction,
         },
         std::{collections::HashSet, sync::Arc},
-        uuid::Uuid,
     };
 
     #[test]
@@ -266,11 +265,11 @@ mod tests {
 
         let packet_bundle0 = PacketBundle {
             batch: PacketBatch::new(vec![Packet::from_data(None, &tx0).unwrap()]),
-            uuid: Uuid::new_v4(),
+            bundle_id: tx0.signatures[0].to_string(),
         };
         let packet_bundle1 = PacketBundle {
             batch: PacketBatch::new(vec![Packet::from_data(None, &tx1).unwrap()]),
-            uuid: Uuid::new_v4(),
+            bundle_id: tx1.signatures[0].to_string(),
         };
 
         let mut transaction_errors = TransactionErrorMetrics::default();

--- a/core/src/bundle_sanitizer.rs
+++ b/core/src/bundle_sanitizer.rs
@@ -122,7 +122,7 @@ pub fn get_sanitized_bundle(
 
     Ok(SanitizedBundle {
         transactions,
-        uuid: packet_bundle.uuid,
+        bundle_id: packet_bundle.bundle_id,
     })
 }
 
@@ -176,7 +176,6 @@ mod tests {
             transaction::{SanitizedTransaction, Transaction, VersionedTransaction},
         },
         std::{collections::HashSet, sync::Arc},
-        uuid::Uuid,
     };
 
     #[test]
@@ -197,11 +196,12 @@ mod tests {
             1,
             genesis_config.hash(),
         ));
+        let bundle_id = tx.get_signature().to_string();
         let packet = Packet::from_data(None, &tx).unwrap();
 
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![packet]),
-            uuid: Uuid::new_v4(),
+            bundle_id,
         };
 
         let mut transaction_errors = TransactionErrorMetrics::default();
@@ -238,11 +238,12 @@ mod tests {
             1,
             genesis_config.hash(),
         ));
+        let bundle_id = tx.get_signature().to_string();
         let packet = Packet::from_data(None, &tx).unwrap();
 
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![packet]),
-            uuid: Uuid::new_v4(),
+            bundle_id,
         };
 
         let consensus_accounts_cache = HashSet::from([kp.pubkey()]);
@@ -275,12 +276,13 @@ mod tests {
             1,
             genesis_config.hash(),
         ));
+        let bundle_id = tx.get_signature().to_string();
         let packet = Packet::from_data(None, &tx).unwrap();
 
         // bundle with a duplicate transaction
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![packet.clone(), packet]),
-            uuid: Uuid::new_v4(),
+            bundle_id,
         };
 
         // fails to pop because bundle it locks the same transaction twice
@@ -309,11 +311,12 @@ mod tests {
 
         let tx =
             VersionedTransaction::from(transfer(&mint_keypair, &kp.pubkey(), 1, Hash::default()));
+        let bundle_id = tx.get_signature().to_string();
         let packet = Packet::from_data(None, &tx).unwrap();
 
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![packet.clone(), packet]),
-            uuid: Uuid::new_v4(),
+            bundle_id,
         };
 
         // fails to pop because bundle has bad blockhash
@@ -346,11 +349,12 @@ mod tests {
             1,
             genesis_config.hash(),
         ));
+        let bundle_id = tx.get_signature().to_string();
         let packet = Packet::from_data(None, &tx).unwrap();
 
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![packet.clone()]),
-            uuid: Uuid::new_v4(),
+            bundle_id,
         };
 
         let mut transaction_errors = TransactionErrorMetrics::default();
@@ -376,7 +380,7 @@ mod tests {
         // try to process the same one again shall fail
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![packet]),
-            uuid: Uuid::new_v4(),
+            bundle_id,
         };
 
         assert!(get_sanitized_bundle(
@@ -418,12 +422,12 @@ mod tests {
                 genesis_config.hash(),
             ))
             .unwrap();
-
+        let bundle_id = tx.signature().to_string();
         let packet = Packet::from_data(None, &tx.to_versioned_transaction()).unwrap();
 
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![packet]),
-            uuid: Uuid::new_v4(),
+            bundle_id,
         };
 
         // fails to pop because bundle mentions tip program
@@ -453,12 +457,12 @@ mod tests {
                 genesis_config.hash(),
             ))
             .unwrap();
-
+        let bundle_id = tx.signature().to_string();
         let packet = Packet::from_data(None, &tx.to_versioned_transaction()).unwrap();
 
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![packet]),
-            uuid: Uuid::new_v4(),
+            bundle_id,
         };
 
         let mut transaction_errors = TransactionErrorMetrics::default();
@@ -480,7 +484,7 @@ mod tests {
 
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![]),
-            uuid: Uuid::new_v4(),
+            bundle_id: String::default(),
         };
         // fails to pop because empty bundle
         let mut transaction_errors = TransactionErrorMetrics::default();
@@ -517,7 +521,7 @@ mod tests {
         });
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(packets.collect()),
-            uuid: Uuid::new_v4(),
+            bundle_id: Uuid::new_v4(),
         };
         // fails to pop because too many packets in a bundle
         let mut transaction_errors = TransactionErrorMetrics::default();
@@ -554,7 +558,7 @@ mod tests {
 
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![packet]),
-            uuid: Uuid::new_v4(),
+            bundle_id: Uuid::new_v4(),
         };
 
         // fails to pop because one of the packets is marked as discard
@@ -599,7 +603,7 @@ mod tests {
 
         let packet_bundle = PacketBundle {
             batch: PacketBatch::new(vec![packet]),
-            uuid: Uuid::new_v4(),
+            bundle_id: Uuid::new_v4(),
         };
         let mut transaction_errors = TransactionErrorMetrics::default();
         assert!(get_sanitized_bundle(

--- a/core/src/packet_bundle.rs
+++ b/core/src/packet_bundle.rs
@@ -1,7 +1,7 @@
-use {solana_perf::packet::PacketBatch, uuid::Uuid};
+use solana_perf::packet::PacketBatch;
 
 #[derive(Clone, Debug)]
 pub struct PacketBundle {
     pub batch: PacketBatch,
-    pub uuid: Uuid,
+    pub bundle_id: String,
 }

--- a/core/src/proxy/block_engine_stage.rs
+++ b/core/src/proxy/block_engine_stage.rs
@@ -41,7 +41,6 @@ use {
         transport::{Channel, Endpoint},
         Status, Streaming,
     },
-    uuid::Uuid,
 };
 
 const CONNECTION_TIMEOUT_S: u64 = 10;
@@ -461,7 +460,7 @@ impl BlockEngineStage {
                             .map(proto_packet_to_packet)
                             .collect(),
                     ),
-                    uuid: Uuid::from_str(&bundle.uuid).ok()?,
+                    bundle_id: bundle.uuid,
                 })
             })
             .collect();

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -34,7 +34,6 @@ full = [
     "libsecp256k1",
     "sha3",
     "digest",
-    "uuid"
 ]
 
 [dependencies]
@@ -81,7 +80,6 @@ solana-program = { path = "program", version = "=1.15.0" }
 solana-sdk-macro = { path = "macro", version = "=1.15.0" }
 thiserror = "1.0"
 uriparse = "0.6.4"
-uuid = { version = "1.0.0", features = ["v4", "fast-rng"], optional = true }
 wasm-bindgen = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/src/bundle/sanitized.rs
+++ b/sdk/src/bundle/sanitized.rs
@@ -1,9 +1,20 @@
 #![cfg(feature = "full")]
 
-use solana_sdk::transaction::SanitizedTransaction;
+use {
+    crate::transaction::VersionedTransaction,
+    itertools::Itertools,
+    sha2::{Digest, Sha256},
+    solana_sdk::transaction::SanitizedTransaction,
+};
 
 #[derive(Clone, Debug)]
 pub struct SanitizedBundle {
     pub transactions: Vec<SanitizedTransaction>,
     pub bundle_id: String,
+}
+
+pub fn derive_bundle_id(transactions: &[VersionedTransaction]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(transactions.iter().map(|tx| tx.signatures[0]).join(","));
+    format!("{:x}", hasher.finalize())
 }

--- a/sdk/src/bundle/sanitized.rs
+++ b/sdk/src/bundle/sanitized.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "full")]
 
-use {solana_sdk::transaction::SanitizedTransaction, uuid::Uuid};
+use solana_sdk::transaction::SanitizedTransaction;
 
 #[derive(Clone, Debug)]
 pub struct SanitizedBundle {
     pub transactions: Vec<SanitizedTransaction>,
-    pub uuid: Uuid,
+    pub bundle_id: String,
 }


### PR DESCRIPTION
The Block-Engine no longer generates bundle ids in Uuid format, so remove that constraint here to avoid bundles getting dropped and ids being mismatched