### PR TITLE
add geyser-plugin-config path to bootstrap arguments

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -145,6 +145,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --log-messages-bytes-limit ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 = --geyser-plugin-config ]]; then
+      arg+=("$1" "$2")
+      shift 2
     else
       echo "Unknown argument: $1"
       $program --help


### PR DESCRIPTION
#### Problem

Currently there is no way to pass in a geyser config path when running `./bootstrap`

#### Summary of Changes
Add config path into bootstrap-validator

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
