### PR TITLE
adds back max-rpc-payload-size option

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -18,6 +18,9 @@ while [[ -n $1 ]]; do
 done
 
 cargo_audit_ignores=(
+  # Not too severe. Main issue is don't create keypair from independently derived public and private keys.
+  --ignore RUSTSEC-2022-0093
+
   # `net2` crate has been deprecated; use `socket2` instead
   #
   # Blocked on https://github.com/paritytech/jsonrpc/issues/575

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -151,6 +151,7 @@ pub struct JsonRpcConfig {
     pub full_api: bool,
     pub obsolete_v1_7_api: bool,
     pub rpc_scan_and_fix_roots: bool,
+    pub max_request_payload_size: Option<usize>,
 }
 
 impl JsonRpcConfig {

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -449,6 +449,10 @@ impl JsonRpcService {
                 (None, None)
             };
 
+        let max_request_payload_size = config
+            .max_request_payload_size
+            .unwrap_or(MAX_REQUEST_PAYLOAD_SIZE);
+
         let full_api = config.full_api;
         let obsolete_v1_7_api = config.obsolete_v1_7_api;
         let (request_processor, receiver) = JsonRpcRequestProcessor::new(
@@ -525,7 +529,7 @@ impl JsonRpcService {
                 ]))
                 .cors_max_age(86400)
                 .request_middleware(request_middleware)
-                .max_request_body_size(MAX_REQUEST_PAYLOAD_SIZE)
+                .max_request_body_size(max_request_payload_size)
                 .start_http(&rpc_addr);
 
                 if let Err(e) = server {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1313,6 +1313,15 @@ pub fn main() {
                 .help("Number of threads to use for servicing RPC requests"),
         )
         .arg(
+            Arg::with_name("max_rpc_request_payload_size")
+                .long("max-rpc-request-payload-size")
+                .value_name("NUMBER")
+                .validator(is_parsable::<usize>)
+                .takes_value(true)
+                .required(false)
+                .help("Maximum payload size of RPC requests"),
+        )
+        .arg(
             Arg::with_name("rpc_niceness_adj")
                 .long("rpc-niceness-adjustment")
                 .value_name("ADJUSTMENT")
@@ -3003,6 +3012,7 @@ pub fn main() {
             rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             account_indexes: account_indexes.clone(),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
+            max_request_payload_size: value_t!(matches, "max_rpc_request_payload_size", usize).ok(),
         },
         geyser_plugin_config_files,
         rpc_addrs: value_t!(matches, "rpc_port", u16).ok().map(|rpc_port| {


### PR DESCRIPTION
This got removed in feature branches but is still in master. Need it for larger bundles.