### PR TITLE
Use `git rev-parse` to get git sha when building jito-solana with `./f`

### DIFF
--- a/f
+++ b/f
@@ -7,7 +7,7 @@ set -eux
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-GIT_SHA="$(git describe --always --dirty)"
+GIT_SHA="$(git rev-parse --short HEAD)"
 
 echo "Git hash: $GIT_SHA"
 


### PR DESCRIPTION
#### Problem
`git describe --always --dirty` would get the git tag/branch instead of the git sha. One can't tell what commit is runnning when running `solana-validator --version`

#### Summary of Changes
Use `git rev-parse` instead so the commit works

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
