### PR TITLE
Remove Deprecated Cli Args

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -14,10 +14,8 @@ RUST_LOG=INFO,solana_core::bundle_stage=DEBUG \
   NDEBUG=1 ./multinode-demo/bootstrap-validator.sh \
   --wait-for-supermajority 0 \
   --expected-bank-hash "$BANK_HASH" \
-  --block-engine-address http://127.0.0.1:1003 \
-  --block-engine-auth-service-address http://127.0.0.1:1005 \
-  --relayer-auth-service-address http://127.0.0.1:11226 \
-  --relayer-address http://127.0.0.1:11226 \
+  --block-engine-url http://127.0.0.1 \
+  --relayer-url http://127.0.0.1:11226 \
   --rpc-pubsub-enable-block-subscription \
   --enable-rpc-transaction-history \
   --tip-payment-program-pubkey T1pyyaTNZsKv2WcRAB8oVnk93mLJw2XzjtVYqCsaHqt \

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1883,22 +1883,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             }
         }));
     add_arg!(
-        Arg::with_name("block_engine_address")
-            .long("block-engine-address")
-            .value_name("block_engine_address")
-            .takes_value(true)
-            .help("Deprecated: Please use block_engine_url.")
-            .conflicts_with("block_engine_url"),
-        replaced_by: "block-engine-url");
-    add_arg!(
-        Arg::with_name("block_engine_auth_service_address")
-                .long("block-engine-auth-service-address")
-                .value_name("block_engine_auth_service_address")
-                .takes_value(true)
-                .help("Deprecated: Please use block_engine_url.")
-                .conflicts_with("block_engine_url"),
-        replaced_by: "block-engine-url");
-    add_arg!(
         Arg::with_name("disable_quic_servers")
             .long("disable-quic-servers")
             .takes_value(false),
@@ -1965,22 +1949,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .long("no-rocksdb-compaction")
         .takes_value(false)
         .help("Disable manual compaction of the ledger database"));
-    add_arg!(
-        Arg::with_name("relayer_address")
-                .long("relayer-address")
-                .value_name("relayer_address")
-                .takes_value(true)
-                .help("Deprecated: Please use relayer_url.")
-                .conflicts_with("relayer_url"),
-        replaced_by: "relayer-url");
-    add_arg!(
-        Arg::with_name("relayer_auth_service_address")
-                .long("relayer-auth-service-address")
-                .value_name("relayer_auth_service_address")
-                .takes_value(true)
-                .help("Deprecated: Please use relayer_url.")
-                .conflicts_with("relayer_url"),
-        replaced_by: "relayer-url");
     add_arg!(Arg::with_name("rocksdb_compaction_interval")
         .long("rocksdb-compaction-interval-slots")
         .value_name("ROCKSDB_COMPACTION_INTERVAL_SLOTS")


### PR DESCRIPTION
#### Problem
These cli arguments were deprecated, but would result in a silent failure to connect to the back-end:
```
block-engine-address
block-engine-auth-service-address
relayer-address
relayer-auth-service-address
```

#### Summary of Changes
The arguments have been completely removed so that the validator application will fail if they are supplied.
