### PR TITLE
Reverts simulate_transaction result calls 

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -77,7 +77,8 @@ impl AccountsHashVerifier {
                     )) = Self::get_next_accounts_package(
                         &accounts_package_sender,
                         &accounts_package_receiver,
-                    ) else {
+                    )
+                    else {
                         std::thread::sleep(LOOP_LIMITER);
                         continue;
                     };

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -77,8 +77,7 @@ impl AccountsHashVerifier {
                     )) = Self::get_next_accounts_package(
                         &accounts_package_sender,
                         &accounts_package_receiver,
-                    )
-                    else {
+                    ) else {
                         std::thread::sleep(LOOP_LIMITER);
                         continue;
                     };

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3795,6 +3795,7 @@ pub mod rpc_full {
                 commitment: preflight_commitment,
                 min_context_slot,
             })?;
+
             let transaction = sanitize_transaction(unsanitized_tx, preflight_bank)?;
             let signature = *transaction.signature();
 


### PR DESCRIPTION
#### Problem
Bank::simulate_transaction_unchecked had some diffs from upstream for no good reason. v1.16 and v1.17 have these same issues.

#### Summary of Changes
Make these lines match master.