### PR TITLE
Don't unlock accounts in TransactionBatches used during simulation

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4364,7 +4364,12 @@ impl Bank {
         let mut account_locks = AccountLocks::default();
         let lock_results =
             Accounts::lock_accounts_sequential(&mut account_locks, tx_account_locks_results);
-        TransactionBatch::new(lock_results, self, Cow::Borrowed(transactions))
+        let mut batch = TransactionBatch::new(lock_results, self, Cow::Borrowed(transactions));
+        // this is required to ensure that accounts aren't unlocked accidentally, which can be problematic during replay.
+        // more specifically, during process_entries, if the lock counts are accidentally decremented,
+        // one might end up replaying a block incorrectly
+        batch.set_needs_unlock(false);
+        batch
     }
 
     /// Prepare a transaction batch from a single transaction without locking accounts


### PR DESCRIPTION
#### Problem
When simulating bundles, the code did not tell the batches to not unlock on drop. This is problematic, especially when simulating on a working_bank, because the locks aren't grabbed, but they would get released.

If one were to release these locks during [process_entries](https://github.com/jito-foundation/jito-solana/blob/1dda669816c8eab4fe9413e125c078013b62ed88/ledger/src/blockstore_processor.rs#L512), then you could potentially replay a batch with multiple conflicting accounts. This would then result in the wrong replay result, which would cause account hash mismatches and other unexpected issues.

#### Summary of Changes
Make sure batch doesn't unlock accounts when dropped.

Fixes #
https://github.com/jito-foundation/jito-solana/issues/313
https://github.com/solana-labs/solana/issues/34027