### PR TITLE
 [JIT-1712] Fix BundleStorage rebuffering

### DIFF
--- a/core/src/bundle_stage/bundle_packet_receiver.rs
+++ b/core/src/bundle_stage/bundle_packet_receiver.rs
@@ -223,13 +223,17 @@ mod tests {
 
     fn assert_bundles_same(
         packet_bundles: &[PacketBundle],
-        bundles_to_process: &[(ImmutableDeserializedBundle, SanitizedBundle)],
+        bundles_to_process: &[(
+            u8, /* attempts remaining */
+            ImmutableDeserializedBundle,
+            SanitizedBundle,
+        )],
     ) {
         assert_eq!(packet_bundles.len(), bundles_to_process.len());
         packet_bundles
             .iter()
             .zip(bundles_to_process.iter())
-            .for_each(|(packet_bundle, (_, sanitized_bundle))| {
+            .for_each(|(packet_bundle, (_, _, sanitized_bundle))| {
                 assert_eq!(packet_bundle.bundle_id, sanitized_bundle.bundle_id);
                 assert_eq!(
                     packet_bundle.batch.len(),


### PR DESCRIPTION
#### Problem
Bundles may be rebuffered for longer than necessary when cost model checks fail.

#### Summary of Changes
- Add TTL to bundles to limit amount of retries

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
