### PR TITLE
Return JSON parsed token accounts from simulateTransaction

### DIFF
--- a/accounts-db/src/account_overrides.rs
+++ b/accounts-db/src/account_overrides.rs
@@ -10,6 +10,10 @@ pub struct AccountOverrides {
 }
 
 impl AccountOverrides {
+    pub fn new(accounts: HashMap<Pubkey, AccountSharedData>) -> Self {
+        AccountOverrides { accounts }
+    }
+
     pub fn upsert_account_overrides(&mut self, other: AccountOverrides) {
         self.accounts.extend(other.accounts);
     }

--- a/rpc/src/account_resolver.rs
+++ b/rpc/src/account_resolver.rs
@@ -1,0 +1,16 @@
+use solana_accounts_db::account_overrides::AccountOverrides;
+
+use {
+    solana_runtime::bank::Bank,
+    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+};
+
+pub(crate) fn get_account_from_overwrites_or_bank(
+    pubkey: &Pubkey,
+    bank: &Bank,
+    account_overrides: Option<&AccountOverrides>,
+) -> Option<AccountSharedData> {
+    account_overrides
+        .and_then(|accounts| accounts.get(pubkey).cloned())
+        .or_else(|| bank.get_account(pubkey))
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::arithmetic_side_effects)]
+mod account_resolver;
 mod cluster_tpu_info;
 pub mod max_slots;
 pub mod optimistically_confirmed_bank_tracker;

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -383,7 +383,7 @@ fn filter_account_result(
         if is_known_spl_token_id(account.owner())
             && params.encoding == UiAccountEncoding::JsonParsed
         {
-            get_parsed_token_account(&bank, &params.pubkey, account)
+            get_parsed_token_account(&bank, &params.pubkey, account, None)
         } else {
             UiAccount::encode(&params.pubkey, &account, params.encoding, None, None)
         }


### PR DESCRIPTION
#### Problem

See https://github.com/solana-labs/solana/issues/34693

TLDR: When we call `simulateTransaction` and request JSON parsed token accounts, they are always returned as base64

#### Summary of Changes

This PR is very similar to the open upstream PR: https://github.com/solana-labs/solana/pull/34619

It works by calling `get_encoded_account` instead of `encode_account`, which means that for token accounts we now fetch the token mint to get the decimals, which allows parsing correctly.

`get_parsed_token_account` is modified to use a new helper function `common::get_account`, which gets an account from the `bank` only if it is not present in `accountOverrides`. The upstream PR uses a `&HashMap<Pubkey, AccountSharedData>` for this overrides data structure, but I noticed that it matches Jito's existing `AccountOverrides` and used that instead.

When we simulate a transaction we get back `post_simulation_accounts` which includes all accounts from the transaction (not only those we requested). We use this to populate the `AccountOverrides` used, so that accounts from the transaction are used over accounts from the bank. This is necessary because it means that if for example a mint was created in the transaction, and we request a token account of that mint, then it will be used when we fetch the mint account for the token account.

#### Limitation

This PR doesn't introduce the same fix for `simulateBundle`, which currently has the same issue if you request JSON parsed accounts in `preExecutionAccountsConfigs` or `postExecutionAccountsConfigs`.

The reason for this is that I can't see a way to get at `post_simulation_accounts` per transaction, to create an override of all accounts in `rpc_bundle_result_from_bank_result`. This means that if a mint was created in one transaction, we wouldn't have access to it when encoding `post_execution_accounts`.

I'm happy to add the same fix using the bank from `simulate_bundle` to this PR if that's preferred. This would fix it in any case where the mint is already part of the bank before the bundle - ie any existing token transfer. It just wouldn't be able to encode a token for a mint that didn't exist before the bundle was simulated. I think we'd need to pass a bit more state back from `load_and_execute_bundle` to make it work correctly in all cases. 

Update: PR open for `simulateBundle` on my fork, will PR it here if this is merged. https://github.com/mcintyre94/jito-solana/pull/1 