### PR TITLE
Ignore buildkite curl errors and try to keep curling

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -20,7 +20,7 @@ name: "Rebase jito-solana from upstream solana-labs/solana"
 
 on:
   schedule:
-    - cron: "30 18 * * 1-5"
+    - cron: "00 19 * * 1-5"
 
 jobs:
   rebase:
@@ -94,8 +94,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.REBASE_BRANCH }}
-      - name: Wait for buildkite to start build
-        run: sleep 20
       - name: Wait for buildkite to finish
         id: wait_for_buildkite
         timeout-minutes: 300
@@ -103,8 +101,10 @@ jobs:
           while true; do
             response=$(curl -s -f -H "Authorization: Bearer ${{ secrets.BUILDKITE_TOKEN }}" "https://api.buildkite.com/v2/organizations/jito/pipelines/jito-solana/builds?commit=${{ env.REBASE_SHA }}")
             if [ $? -ne 0 ]; then
+              # Buildkite occasionally takes awhile to start the job. Assume it starts and let the job time out if not
               echo "Curl request failed."
-              exit 1
+              sleep 30
+              continue
             fi
 
             state=$(echo $response | jq --exit-status -r '.[0].state')


### PR DESCRIPTION
#### Problem
Buildkite can take awhile to start a job sometimes

#### Summary of Changes
Ignore buildkite curl errors and try to keep curling until the job times out