### PR TITLE
Fix: Ensure set contact info to UDP port instead of QUIC

### DIFF
--- a/core/src/proxy/fetch_stage_manager.rs
+++ b/core/src/proxy/fetch_stage_manager.rs
@@ -108,8 +108,8 @@ impl FetchStageManager {
                             fetch_connected = true;
                             pending_disconnect = false;
 
-                            // unwrap safe here bc contact_info.tpu(Protocol::QUIC) and contact_info.tpu_forwards(Protocol::QUIC)
-                            // are checked on startup
+                            // yes, using UDP here is extremely confusing for the validator
+                            // since the entire network is running QUIC. However, it's correct.
                             if let Err(e) = Self::set_tpu_addresses(&cluster_info, my_fallback_contact_info.tpu(Protocol::UDP).unwrap(), my_fallback_contact_info.tpu_forwards(Protocol::UDP).unwrap()) {
                                 error!("error setting tpu or tpu_fwd to ({:?}, {:?}), error: {:?}", my_fallback_contact_info.tpu(Protocol::UDP).unwrap(), my_fallback_contact_info.tpu_forwards(Protocol::UDP).unwrap(), e);
                             }

--- a/core/src/proxy/fetch_stage_manager.rs
+++ b/core/src/proxy/fetch_stage_manager.rs
@@ -110,8 +110,8 @@ impl FetchStageManager {
 
                             // unwrap safe here bc contact_info.tpu(Protocol::QUIC) and contact_info.tpu_forwards(Protocol::QUIC)
                             // are checked on startup
-                            if let Err(e) = Self::set_tpu_addresses(&cluster_info, my_fallback_contact_info.tpu(Protocol::QUIC).unwrap(), my_fallback_contact_info.tpu_forwards(Protocol::QUIC).unwrap()) {
-                                error!("error setting tpu or tpu_fwd to ({:?}, {:?}), error: {:?}", my_fallback_contact_info.tpu(Protocol::QUIC).unwrap(), my_fallback_contact_info.tpu_forwards(Protocol::QUIC).unwrap(), e);
+                            if let Err(e) = Self::set_tpu_addresses(&cluster_info, my_fallback_contact_info.tpu(Protocol::UDP).unwrap(), my_fallback_contact_info.tpu_forwards(Protocol::UDP).unwrap()) {
+                                error!("error setting tpu or tpu_fwd to ({:?}, {:?}), error: {:?}", my_fallback_contact_info.tpu(Protocol::UDP).unwrap(), my_fallback_contact_info.tpu_forwards(Protocol::UDP).unwrap(), e);
                             }
                             heartbeats_received = 0;
                         }


### PR DESCRIPTION
#### Problem
When relayer disconnects, the validator sets it's QUIC port to Protocol::QUIC. This caused the validator to advertise an incorrect port for trsnactions.

Confusingly, this should be set to Protocol::UDP 🤦 

#### Summary of Changes
Set the QUIC port correctly on relayer disconnect