### PR TITLE
Buffer bundles that exceed processing time and make the allowed processing time longer

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -122,19 +122,19 @@ impl BankingStageStats {
             .load(Ordering::Relaxed) as u64
             + self.dropped_packets_count.load(Ordering::Relaxed) as u64
             + self
-            .dropped_duplicated_packets_count
-            .load(Ordering::Relaxed) as u64
+                .dropped_duplicated_packets_count
+                .load(Ordering::Relaxed) as u64
             + self.dropped_forward_packets_count.load(Ordering::Relaxed) as u64
             + self.newly_buffered_packets_count.load(Ordering::Relaxed) as u64
             + self.current_buffered_packets_count.load(Ordering::Relaxed) as u64
             + self.rebuffered_packets_count.load(Ordering::Relaxed) as u64
             + self.consumed_buffered_packets_count.load(Ordering::Relaxed) as u64
             + self
-            .consume_buffered_packets_elapsed
-            .load(Ordering::Relaxed)
+                .consume_buffered_packets_elapsed
+                .load(Ordering::Relaxed)
             + self
-            .receive_and_buffer_packets_elapsed
-            .load(Ordering::Relaxed)
+                .receive_and_buffer_packets_elapsed
+                .load(Ordering::Relaxed)
             + self.filter_pending_packets_elapsed.load(Ordering::Relaxed)
             + self.packet_conversion_elapsed.load(Ordering::Relaxed)
             + self.transaction_processing_elapsed.load(Ordering::Relaxed)
@@ -1250,7 +1250,7 @@ mod tests {
                     20,
                     start_hash,
                 ))
-                    .unwrap();
+                .unwrap();
             }
 
             // Send a bunch of votes and transfers
@@ -1309,17 +1309,17 @@ mod tests {
                 (tpu_packet_batches, tpu_vote_sender),
                 (gossip_packet_batches, gossip_vote_sender),
             ]
-                .into_iter()
-                .map(|(packet_batches, sender)| {
-                    Builder::new()
-                        .spawn(move || {
-                            sender
-                                .send(BankingPacketBatch::new((packet_batches, None)))
-                                .unwrap()
-                        })
-                        .unwrap()
-                })
-                .for_each(|handle| handle.join().unwrap());
+            .into_iter()
+            .map(|(packet_batches, sender)| {
+                Builder::new()
+                    .spawn(move || {
+                        sender
+                            .send(BankingPacketBatch::new((packet_batches, None)))
+                            .unwrap()
+                    })
+                    .unwrap()
+            })
+            .for_each(|handle| handle.join().unwrap());
 
             banking_stage.join().unwrap();
             exit.store(true, Ordering::Relaxed);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -122,19 +122,19 @@ impl BankingStageStats {
             .load(Ordering::Relaxed) as u64
             + self.dropped_packets_count.load(Ordering::Relaxed) as u64
             + self
-                .dropped_duplicated_packets_count
-                .load(Ordering::Relaxed) as u64
+            .dropped_duplicated_packets_count
+            .load(Ordering::Relaxed) as u64
             + self.dropped_forward_packets_count.load(Ordering::Relaxed) as u64
             + self.newly_buffered_packets_count.load(Ordering::Relaxed) as u64
             + self.current_buffered_packets_count.load(Ordering::Relaxed) as u64
             + self.rebuffered_packets_count.load(Ordering::Relaxed) as u64
             + self.consumed_buffered_packets_count.load(Ordering::Relaxed) as u64
             + self
-                .consume_buffered_packets_elapsed
-                .load(Ordering::Relaxed)
+            .consume_buffered_packets_elapsed
+            .load(Ordering::Relaxed)
             + self
-                .receive_and_buffer_packets_elapsed
-                .load(Ordering::Relaxed)
+            .receive_and_buffer_packets_elapsed
+            .load(Ordering::Relaxed)
             + self.filter_pending_packets_elapsed.load(Ordering::Relaxed)
             + self.packet_conversion_elapsed.load(Ordering::Relaxed)
             + self.transaction_processing_elapsed.load(Ordering::Relaxed)
@@ -1250,7 +1250,7 @@ mod tests {
                     20,
                     start_hash,
                 ))
-                .unwrap();
+                    .unwrap();
             }
 
             // Send a bunch of votes and transfers
@@ -1309,17 +1309,17 @@ mod tests {
                 (tpu_packet_batches, tpu_vote_sender),
                 (gossip_packet_batches, gossip_vote_sender),
             ]
-            .into_iter()
-            .map(|(packet_batches, sender)| {
-                Builder::new()
-                    .spawn(move || {
-                        sender
-                            .send(BankingPacketBatch::new((packet_batches, None)))
-                            .unwrap()
-                    })
-                    .unwrap()
-            })
-            .for_each(|handle| handle.join().unwrap());
+                .into_iter()
+                .map(|(packet_batches, sender)| {
+                    Builder::new()
+                        .spawn(move || {
+                            sender
+                                .send(BankingPacketBatch::new((packet_batches, None)))
+                                .unwrap()
+                        })
+                        .unwrap()
+                })
+                .for_each(|handle| handle.join().unwrap());
 
             banking_stage.join().unwrap();
             exit.store(true, Ordering::Relaxed);

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -1,4 +1,3 @@
-use solana_bundle::bundle_execution::LoadAndExecuteBundleError;
 use {
     super::{
         forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
@@ -22,7 +21,7 @@ use {
     itertools::Itertools,
     min_max_heap::MinMaxHeap,
     solana_accounts_db::transaction_error_metrics::TransactionErrorMetrics,
-    solana_bundle::BundleExecutionError,
+    solana_bundle::{bundle_execution::LoadAndExecuteBundleError, BundleExecutionError},
     solana_measure::measure,
     solana_runtime::bank::Bank,
     solana_sdk::{

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -1,3 +1,4 @@
+use solana_bundle::bundle_execution::LoadAndExecuteBundleError;
 use {
     super::{
         forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
@@ -1249,17 +1250,31 @@ impl BundleStorage {
                         rebuffered_bundles.push(deserialized_bundle);
                         is_slot_over = true;
                     }
+                    Err(BundleExecutionError::ExceedsCostModel) => {
+                        // cost model buffered bundles contain most recent bundles at the front of the queue
+                        debug!(
+                            "bundle={} exceeds cost model, rebuffering",
+                            sanitized_bundle.bundle_id
+                        );
+                        self.push_back_cost_model_buffered_bundles(vec![deserialized_bundle]);
+                    }
+                    Err(BundleExecutionError::TransactionFailure(
+                        LoadAndExecuteBundleError::ProcessingTimeExceeded(_),
+                    )) => {
+                        // these are treated the same as exceeds cost model and are rebuferred to be completed
+                        // at the beginning of the next slot
+                        debug!(
+                            "bundle={} processing time exceeded, rebuffering",
+                            sanitized_bundle.bundle_id
+                        );
+                        self.push_back_cost_model_buffered_bundles(vec![deserialized_bundle]);
+                    }
                     Err(BundleExecutionError::TransactionFailure(e)) => {
                         debug!(
                             "bundle={} execution error: {:?}",
                             sanitized_bundle.bundle_id, e
                         );
                         // do nothing
-                    }
-                    Err(BundleExecutionError::ExceedsCostModel) => {
-                        // cost model buffered bundles contain most recent bundles at the front of the queue
-                        debug!("bundle={} exceeds cost model", sanitized_bundle.bundle_id);
-                        self.push_back_cost_model_buffered_bundles(vec![deserialized_bundle]);
                     }
                     Err(BundleExecutionError::TipError(e)) => {
                         debug!("bundle={} tip error: {}", sanitized_bundle.bundle_id, e);

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -45,7 +45,7 @@ mod bundle_reserved_space_manager;
 pub(crate) mod bundle_stage_leader_metrics;
 mod committer;
 
-const MAX_BUNDLE_RETRY_DURATION: Duration = Duration::from_millis(10);
+const MAX_BUNDLE_RETRY_DURATION: Duration = Duration::from_millis(40);
 const SLOT_BOUNDARY_CHECK_PERIOD: Duration = Duration::from_millis(10);
 
 // Stats emitted periodically


### PR DESCRIPTION
#### Problem
The allowed processing time for bundles is too short and ones that exceed the max processing length (due to retrying from account locks or higher compute) are getting dropped.
This PR does the following:
- increases the max duration a bundle can execute from 10ms to 40ms
- any bundles that exceed the allowed time are buffered similar to ones that exceed the cost for a block.

Some metrics from the last ~12 hours on rates of simulated cus and land/forward rate
- >500k CUs: 49%
- >1M CUs: 49%
- <200k CUs: 70%
- <100k CUs: 81%
- <50k CUs: 86%

Running this commit on Jito1 and Jito2, we notice a decrease in execution timeouts.
![Screenshot 2024-04-10 at 10 54 34 PM](https://github.com/jito-foundation/jito-solana/assets/85544055/66244310-cf81-44df-a5b2-ddec260bfb40)

cumsum execution timeouts
![telegram-cloud-photo-size-1-4952065952367881245-x](https://github.com/jito-foundation/jito-solana/assets/85544055/88918fb8-6c46-426f-ab8e-dd2c8d277638)

otoh, we notice an increase in execution retries, which is expected as bundles are given more time to execute before getting rebuferred
![Screenshot 2024-04-10 at 10 55 37 PM](https://github.com/jito-foundation/jito-solana/assets/85544055/f63ac864-43a3-494b-840f-0c715ee7ce10)