### PR TITLE
take a snapshot of all bundle accounts before sim (#13)

### DIFF
--- a/bundle/src/bundle_execution.rs
+++ b/bundle/src/bundle_execution.rs
@@ -17,8 +17,9 @@ use {
         transaction::{SanitizedTransaction, TransactionError, VersionedTransaction},
     },
     solana_svm::{
-        account_loader::TransactionLoadResult, account_overrides::AccountOverrides,
-        transaction_processor::ExecutionRecordingConfig,
+        account_loader::TransactionLoadResult,
+        account_overrides::AccountOverrides,
+        transaction_processor::{ExecutionRecordingConfig, TransactionProcessingCallback},
         transaction_results::TransactionExecutionResult,
     },
     solana_transaction_status::{token_balances::TransactionTokenBalances, PreBalanceInfo},
@@ -264,6 +265,17 @@ pub fn load_and_execute_bundle<'a>(
                 account_overrides.upsert_account_overrides(
                     bank.get_account_overrides_for_simulation(&account_keys),
                 );
+
+                // NOTE (seg): If simulating on an unfrozen bank, then take a snapshot of all accounts to minimize chance of race condition.
+                // State constantly changing is still an issue and needs to be resolved.
+                if !bank.is_frozen() {
+                    for pk in account_keys.iter() {
+                        // Save on a disk read.
+                        if account_overrides.get(pk).is_none() {
+                            account_overrides.set_account(pk, bank.get_account_shared_data(pk));
+                        }
+                    }
+                }
             });
     }
 


### PR DESCRIPTION
#### Problem
Solana state is constantly changing leading to potential race conditions when simulating.

#### Summary of Changes
Take a snapshot of all accounts to simulate account locks.