### PR TITLE
Publish releases to S3 and GCS

### DIFF
--- a/ci/publish-installer.sh
+++ b/ci/publish-installer.sh
@@ -35,6 +35,11 @@ cat install/agave-install-init.sh >>release.jito.wtf-install
 
 echo --- GCS: "install"
 upload-gcs-artifact "/solana/release.jito.wtf-install" "gs://jito-release/$CHANNEL_OR_TAG/install"
+
+# Jito added - releases need to support S3
+echo --- AWS S3 Store: "install"
+upload-s3-artifact "/solana/release.jito.wtf-install" "s3://release.jito.wtf/$CHANNEL_OR_TAG/install"
+
 echo Published to:
 ci/format-url.sh https://release.jito.wtf/"$CHANNEL_OR_TAG"/install
 

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -121,6 +121,10 @@ for file in "${TARBALL_BASENAME}"-$TARGET.tar.bz2 "${TARBALL_BASENAME}"-$TARGET.
     echo --- GCS Store: "$file"
     upload-gcs-artifact "/solana/$file" gs://jito-release/"$CHANNEL_OR_TAG"/"$file"
 
+    # Jito added - releases need to support S3
+    echo --- AWS S3 Store: "$file"
+    upload-s3-artifact "/solana/$file" s3://release.jito.wtf/"$CHANNEL_OR_TAG"/"$file"
+
     echo Published to:
     $DRYRUN ci/format-url.sh https://release.jito.wtf/"$CHANNEL_OR_TAG"/"$file"
 


### PR DESCRIPTION
#### Problem
2.0 changed releases to get published to GCS only. Jito-solana releases require they be uploaded to S3.

#### Summary of Changes
Added publishing of releases to S3 and GCS