### PR TITLE
Add packet flag for from staked sender (v1.18)

### DIFF
--- a/.buildkite/scripts/build-stable.test.sh
+++ b/.buildkite/scripts/build-stable.test.sh
@@ -12,7 +12,7 @@ want=$(
     steps:
       - name: "partitions"
         command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/stable/run-partition.sh"
-        timeout_in_minutes: 40
+        timeout_in_minutes: 60
         agents:
           queue: "solana"
         parallelism: 3

--- a/core/benches/proto_to_packet.rs
+++ b/core/benches/proto_to_packet.rs
@@ -25,7 +25,7 @@ fn get_proto_packet(i: u8) -> PbPacket {
                 repair: false,
                 simple_vote_tx: false,
                 tracer_packet: false,
-                from_staked_node: false
+                from_staked_node: false,
             }),
             sender_stake: 0,
         }),

--- a/core/benches/proto_to_packet.rs
+++ b/core/benches/proto_to_packet.rs
@@ -25,6 +25,7 @@ fn get_proto_packet(i: u8) -> PbPacket {
                 repair: false,
                 simple_vote_tx: false,
                 tracer_packet: false,
+                from_staked_node: false
             }),
             sender_stake: 0,
         }),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -108,6 +108,12 @@ pub fn proto_packet_to_packet(p: jito_protos::proto::packet::Packet) -> Packet {
             if flags.repair {
                 packet.meta_mut().flags.insert(PacketFlags::REPAIR);
             }
+            if flags.from_staked_node {
+                packet
+                    .meta_mut()
+                    .flags
+                    .insert(PacketFlags::FROM_STAKED_NODE)
+            }
         }
     }
     packet


### PR DESCRIPTION
#### Problem
The staked sending packet flag isn't propagated from the relayer through the validator.

#### Summary of Changes
Pull in new protobufs and propagate flag to packet.