### PR TITLE
Loosen requirements on tip accounts touchable in BankingStage

### DIFF
--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -299,11 +299,9 @@ impl Tpu {
 
         let bundle_account_locker = BundleAccountLocker::default();
 
-        // tip accounts can't be used in BankingStage to avoid someone from stealing tips mid-slot.
-        // it also helps reduce surface area for potential account contention
+        // The tip program can't be used in BankingStage to avoid someone from stealing tips mid-slot.
         let mut blacklisted_accounts = HashSet::new();
-        blacklisted_accounts.insert(tip_manager.tip_payment_config_pubkey());
-        blacklisted_accounts.extend(tip_manager.get_tip_accounts());
+        blacklisted_accounts.insert(tip_manager.tip_payment_program_id());
         let banking_stage = BankingStage::new(
             block_production_method,
             cluster_info,


### PR DESCRIPTION
#### Problem
Tips should be able to get processed in BankingStage. This PR relaxes the constraint around not being able to touch any of the tip accounts.

#### Summary of Changes
Loosen tip requirements, but ensure the tips can't be changed inside banking stage.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
