### PR TITLE
Add packet flag for staked node

### DIFF
--- a/core/benches/proto_to_packet.rs
+++ b/core/benches/proto_to_packet.rs
@@ -25,6 +25,7 @@ fn get_proto_packet(i: u8) -> PbPacket {
                 repair: false,
                 simple_vote_tx: false,
                 tracer_packet: false,
+                from_staked_node: false,
             }),
             sender_stake: 0,
         }),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -106,6 +106,12 @@ pub fn proto_packet_to_packet(p: jito_protos::proto::packet::Packet) -> Packet {
             if flags.repair {
                 packet.meta_mut().flags.insert(PacketFlags::REPAIR);
             }
+            if flags.from_staked_node {
+                packet
+                    .meta_mut()
+                    .flags
+                    .insert(PacketFlags::FROM_STAKED_NODE);
+            }
         }
     }
     packet


### PR DESCRIPTION
#### Problem
Missing propagation of staked node packet flag for relayer.
