### PR TITLE
Fixed typo in: index.md

### DIFF
--- a/docs/src/cli/wallets/hardware/index.md
+++ b/docs/src/cli/wallets/hardware/index.md
@@ -38,7 +38,7 @@ usb://<MANUFACTURER>[/<WALLET_ID>][?key=<DERIVATION_PATH>]
 
 `WALLET_ID` is a globally unique key used to disambiguate multiple devices.
 
-`DERVIATION_PATH` is used to navigate to Solana keys within your hardware wallet.
+`DERIVATION_PATH` is used to navigate to Solana keys within your hardware wallet.
 The path has the form `<ACCOUNT>[/<CHANGE>]`, where each `ACCOUNT` and `CHANGE`
 are nonnegative integers.
 


### PR DESCRIPTION
Hi, 

There is a typo in "DERVIATION_PATH," which should be "DERIVATION_PATH":

"DERIVATION_PATH is used to navigate to Solana keys within your hardware wallet".

Thanks.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
