### PR TITLE
Add better error handling around signatures

### DIFF
--- a/core/src/bundle_stage/bundle_consumer.rs
+++ b/core/src/bundle_stage/bundle_consumer.rs
@@ -931,7 +931,7 @@ mod tests {
                         ))
                     })
                     .collect();
-                let bundle_id = derive_bundle_id(&transfers);
+                let bundle_id = derive_bundle_id(&transfers).unwrap();
 
                 PacketBundle {
                     batch: PacketBatch::new(

--- a/core/src/bundle_stage/bundle_packet_receiver.rs
+++ b/core/src/bundle_stage/bundle_packet_receiver.rs
@@ -215,7 +215,7 @@ mod tests {
                         ))
                     })
                     .collect();
-                let bundle_id = derive_bundle_id(&transfers);
+                let bundle_id = derive_bundle_id(&transfers).unwrap();
 
                 PacketBundle {
                     batch: PacketBatch::new(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4409,6 +4409,17 @@ pub mod rpc_full {
                 });
             }
 
+            // if one can't derive bundle id and we're not skipping signature verification then it's an error
+            let bundle_id = derive_bundle_id(&decoded_transactions);
+            if let Err(missing_signature_index) = &bundle_id {
+                if !config.skip_sig_verify {
+                    return Err(Error::invalid_params(format!(
+                        "Transaction index {} missing signature",
+                        missing_signature_index
+                    )));
+                }
+            }
+
             let runtime_txs = decoded_transactions
                 .into_iter()
                 .map(|tx| sanitize_transaction(tx, bank.as_ref(), bank.get_reserved_account_keys()))
@@ -4419,19 +4430,9 @@ pub mod rpc_full {
                 }
             }
 
-            // if one can't derive bundle id and we're not skipping signature verification then it's an error
-            let bundle_id = derive_bundle_id(&decoded_transactions);
-            if let Err(missing_signature_index) = bundle_id {
-                if !config.skip_sig_verify {
-                    return Err(Error::invalid_params(format!(
-                        "Transaction index {} missing signature",
-                        missing_signature_index
-                    )));
-                }
-            }
             let sanitized_bundle = SanitizedBundle {
                 transactions: runtime_txs,
-                bundle_id: bundle_id.unwrap_or_default(),
+                bundle_id: bundle_id.unwrap_or("unknown".to_string()),
             };
 
             let pre_execution_accounts =

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4424,16 +4424,16 @@ pub mod rpc_full {
                 .into_iter()
                 .map(|tx| sanitize_transaction(tx, bank.as_ref(), bank.get_reserved_account_keys()))
                 .collect::<Result<Vec<SanitizedTransaction>>>()?;
-            if !config.skip_sig_verify {
-                for tx in &runtime_txs {
-                    verify_transaction(tx, &bank.feature_set)?;
-                }
-            }
-
             let sanitized_bundle = SanitizedBundle {
                 transactions: runtime_txs,
                 bundle_id: bundle_id.unwrap_or("unknown".to_string()),
             };
+
+            if !config.skip_sig_verify {
+                for tx in &sanitized_bundle.transactions {
+                    verify_transaction(tx, &bank.feature_set)?;
+                }
+            }
 
             let pre_execution_accounts =
                 account_configs_to_accounts(&config.pre_execution_accounts_configs)?;

--- a/sdk/src/bundle/mod.rs
+++ b/sdk/src/bundle/mod.rs
@@ -14,7 +14,7 @@ pub fn derive_bundle_id(transactions: &[VersionedTransaction]) -> Result<String,
     let signatures = transactions
         .iter()
         .enumerate()
-        .map(|(idx, tx)| tx.signatures.get(0).ok_or(idx))
+        .map(|(idx, tx)| tx.signatures.first().ok_or(idx))
         .collect::<Result<Vec<_>, _>>()?;
 
     let mut hasher = Sha256::new();

--- a/sdk/src/bundle/mod.rs
+++ b/sdk/src/bundle/mod.rs
@@ -9,8 +9,15 @@ pub struct VersionedBundle {
     pub transactions: Vec<VersionedTransaction>,
 }
 
-pub fn derive_bundle_id(transactions: &[VersionedTransaction]) -> String {
+/// Derives a bundle id from signatures, returning error if signature is missing
+pub fn derive_bundle_id(transactions: &[VersionedTransaction]) -> Result<String, usize> {
+    let signatures = transactions
+        .iter()
+        .enumerate()
+        .map(|(idx, tx)| tx.signatures.get(0).ok_or(idx))
+        .collect::<Result<Vec<_>, _>>()?;
+
     let mut hasher = Sha256::new();
-    hasher.update(transactions.iter().map(|tx| tx.signatures[0]).join(","));
-    format!("{:x}", hasher.finalize())
+    hasher.update(signatures.join(","));
+    Ok(format!("{:x}", hasher.finalize()))
 }

--- a/sdk/src/bundle/mod.rs
+++ b/sdk/src/bundle/mod.rs
@@ -18,6 +18,6 @@ pub fn derive_bundle_id(transactions: &[VersionedTransaction]) -> Result<String,
         .collect::<Result<Vec<_>, _>>()?;
 
     let mut hasher = Sha256::new();
-    hasher.update(signatures.join(","));
+    hasher.update(signatures.iter().join(","));
     Ok(format!("{:x}", hasher.finalize()))
 }


### PR DESCRIPTION
#### Problem
- Missing signatures cause failure of bundle id creation.
- Some providers likely stripping signatures to avoid having entire tx contents

#### Summary of Changes
- Re-order operations for signature verification
- If skipping sigverify, allow for bad bundle ids and use default
