### PR TITLE
Add better error handling around missing transaction signatures for bundle id generation

### DIFF
--- a/bundle-sdk/src/lib.rs
+++ b/bundle-sdk/src/lib.rs
@@ -11,8 +11,15 @@ pub struct VersionedBundle {
     pub transactions: Vec<VersionedTransaction>,
 }
 
-pub fn derive_bundle_id(transactions: &[VersionedTransaction]) -> String {
+/// Derives a bundle id from signatures, returning error if signature is missing
+pub fn derive_bundle_id(transactions: &[VersionedTransaction]) -> Result<String, usize> {
+    let signatures = transactions
+        .iter()
+        .enumerate()
+        .map(|(idx, tx)| tx.signatures.first().ok_or(idx))
+        .collect::<Result<Vec<_>, _>>()?;
+
     let mut hasher = Sha256::new();
-    hasher.update(transactions.iter().map(|tx| tx.signatures[0]).join(","));
-    format!("{:x}", hasher.finalize())
+    hasher.update(signatures.iter().join(","));
+    Ok(format!("{:x}", hasher.finalize()))
 }

--- a/core/src/bundle_stage/bundle_consumer.rs
+++ b/core/src/bundle_stage/bundle_consumer.rs
@@ -956,7 +956,7 @@ mod tests {
                         ))
                     })
                     .collect();
-                let bundle_id = derive_bundle_id(&transfers);
+                let bundle_id = derive_bundle_id(&transfers).unwrap();
 
                 PacketBundle {
                     batch: PacketBatch::new(

--- a/core/src/bundle_stage/bundle_packet_receiver.rs
+++ b/core/src/bundle_stage/bundle_packet_receiver.rs
@@ -201,7 +201,7 @@ mod tests {
                         ))
                     })
                     .collect();
-                let bundle_id = derive_bundle_id(&transfers);
+                let bundle_id = derive_bundle_id(&transfers).unwrap();
 
                 PacketBundle {
                     batch: PacketBatch::new(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4327,14 +4327,24 @@ pub mod rpc_full {
                 });
             }
 
+            // if one can't derive bundle id and we're not skipping signature verification then it's an error
             let bundle_id = derive_bundle_id(&decoded_transactions);
+            if let Err(missing_signature_index) = &bundle_id {
+                if !config.skip_sig_verify {
+                    return Err(Error::invalid_params(format!(
+                        "Transaction index {} missing signature",
+                        missing_signature_index
+                    )));
+                }
+            }
+
             let runtime_txs = decoded_transactions
                 .into_iter()
                 .map(|tx| sanitize_transaction(tx, bank.as_ref(), bank.get_reserved_account_keys()))
                 .collect::<Result<Vec<RuntimeTransaction<SanitizedTransaction>>>>()?;
             let sanitized_bundle = SanitizedBundle {
                 transactions: runtime_txs,
-                bundle_id,
+                bundle_id: bundle_id.unwrap_or("unknown".to_string()),
             };
 
             if !config.skip_sig_verify {


### PR DESCRIPTION
#### Problem
- Missing signatures cause failure of bundle id creation.
- Some providers likely stripping signatures to avoid having entire tx contents

#### Summary of Changes
- Re-order operations for signature verification
- If skipping sigverify, allow for bad bundle ids and use default