### PR TITLE
Remove unwrap from authentication

### DIFF
--- a/core/src/proxy/auth.rs
+++ b/core/src/proxy/auth.rs
@@ -33,7 +33,7 @@ impl Interceptor for AuthInterceptor {
             "authorization",
             format!("Bearer {}", self.access_token.lock().unwrap().value)
                 .parse()
-                .unwrap(),
+                .map_err(|_| Status::invalid_argument("Failed to parse authorization token"))?,
         );
 
         Ok(request)


### PR DESCRIPTION
#### Problem
Unwrap on a bad authentication token is bad.

#### Summary of Changes
Ensures that bad authentication tokens are handled properly.