### PR TITLE
rpc: simulate_bundle: return details about failed txs

### DIFF
--- a/bundle/src/bundle_execution.rs
+++ b/bundle/src/bundle_execution.rs
@@ -408,12 +408,23 @@ pub fn load_and_execute_bundle<'a>(
                 failing_tx.signature(),
                 exec_result
             );
+            let pre_tx_execution_accounts_len = pre_tx_execution_accounts.len();
+            let failing_tx_signature = *failing_tx.signature();
+            let exec_result = exec_result.clone();
+            bundle_transaction_results.push(BundleTransactionsOutput {
+                transactions: chunk,
+                load_and_execute_transactions_output,
+                pre_balance_info,
+                post_balance_info: (TransactionBalances::default(), TransactionTokenBalances::default()),
+                pre_tx_execution_accounts,
+                post_tx_execution_accounts: vec![None; pre_tx_execution_accounts_len ],
+            });
             return LoadAndExecuteBundleOutput {
                 bundle_transaction_results,
                 metrics,
                 result: Err(LoadAndExecuteBundleError::TransactionError {
-                    signature: *failing_tx.signature(),
-                    execution_result: Box::new(exec_result.clone()),
+                    signature: failing_tx_signature,
+                    execution_result: Box::new(exec_result),
                 }),
             };
         }


### PR DESCRIPTION
#### Problem
When calling the simulate_bundle RPC method and one of transactions fails due to e.g. custom thrown error from an instruction, the result does not contain neither logs nor consumed compute units, and the error itself is returned only as string which makes it cumbersome to parse.

#### Summary of Changes


Fixes #678
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
