### PR TITLE
Revert Jito-Solana WorkingBankEntry changes

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -32,11 +32,11 @@ jobs:
           - branch: master
             upstream_branch: master
             upstream_repo: https://github.com/anza-xyz/agave.git
-          - branch: v2.1
-            upstream_branch: v2.1
-            upstream_repo: https://github.com/anza-xyz/agave.git
           - branch: v2.2
             upstream_branch: v2.2
+            upstream_repo: https://github.com/anza-xyz/agave.git
+          - branch: v2.3
+            upstream_branch: v2.3
             upstream_repo: https://github.com/anza-xyz/agave.git
       fail-fast: false
     steps:

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -60,15 +60,9 @@ fn check_txs(
     let now = Instant::now();
     let mut no_bank = false;
     loop {
-        if let Ok(WorkingBankEntry {
-            bank: _,
-            entries_ticks,
-        }) = receiver.recv_timeout(Duration::from_millis(10))
+        if let Ok((_bank, (entry, _tick_height))) = receiver.recv_timeout(Duration::from_millis(10))
         {
-            total += entries_ticks
-                .iter()
-                .map(|e| e.0.transactions.len())
-                .sum::<usize>();
+            total += entry.transactions.len();
         }
         if total >= ref_tx_count {
             break;

--- a/core/src/bundle_stage/bundle_consumer.rs
+++ b/core/src/bundle_stage/bundle_consumer.rs
@@ -1083,19 +1083,9 @@ mod tests {
         );
 
         let mut transactions = Vec::new();
-        while let Ok(WorkingBankEntry {
-            bank: wbe_bank,
-            entries_ticks,
-        }) = entry_receiver.recv()
-        {
+        while let Ok((wbe_bank, (entry, _ticks))) = entry_receiver.recv() {
             assert_eq!(bank.slot(), wbe_bank.slot());
-            for (entry, _) in entries_ticks {
-                if !entry.transactions.is_empty() {
-                    // transactions in this test are all overlapping, so each entry will contain 1 transaction
-                    assert_eq!(entry.transactions.len(), 1);
-                    transactions.extend(entry.transactions);
-                }
-            }
+            transactions.extend(entry.transactions);
             if transactions.len() == sanitized_bundle.transactions.len() {
                 break;
             }
@@ -1227,13 +1217,9 @@ mod tests {
         // and another with the tip
 
         let mut transactions = Vec::new();
-        while let Ok(WorkingBankEntry {
-            bank: wbe_bank,
-            entries_ticks,
-        }) = entry_receiver.recv()
-        {
+        while let Ok((wbe_bank, (entry, _ticks))) = entry_receiver.recv() {
             assert_eq!(bank.slot(), wbe_bank.slot());
-            transactions.extend(entries_ticks.into_iter().flat_map(|(e, _)| e.transactions));
+            transactions.extend(entry.transactions);
             if transactions.len() == 5 {
                 break;
             }
@@ -1355,13 +1341,9 @@ mod tests {
         );
 
         let mut transactions = Vec::new();
-        while let Ok(WorkingBankEntry {
-            bank: wbe_bank,
-            entries_ticks,
-        }) = entry_receiver.recv()
-        {
+        while let Ok((wbe_bank, (entry, _ticks))) = entry_receiver.recv() {
             assert_eq!(bank.slot(), wbe_bank.slot());
-            transactions.extend(entries_ticks.into_iter().flat_map(|(e, _)| e.transactions));
+            transactions.extend(entry.transactions);
             if transactions.len() == 4 {
                 break;
             }

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -61,44 +61,39 @@ impl TpuEntryNotifier {
         current_index: &mut usize,
         current_transaction_index: &mut usize,
     ) -> Result<(), RecvTimeoutError> {
-        let WorkingBankEntry {
-            bank,
-            entries_ticks,
-        } = entry_receiver.recv_timeout(Duration::from_secs(1))?;
+        let (bank, (entry, tick_height)) = entry_receiver.recv_timeout(Duration::from_secs(1))?;
         let slot = bank.slot();
-        if slot != *current_slot {
+        let index = if slot != *current_slot {
             *current_index = 0;
             *current_transaction_index = 0;
             *current_slot = slot;
-        }
-
-        for (entry, _ticks) in &entries_ticks {
-            let entry_summary = EntrySummary {
-                num_hashes: entry.num_hashes,
-                hash: entry.hash,
-                num_transactions: entry.transactions.len() as u64,
-            };
-            if let Err(err) = entry_notification_sender.send(EntryNotification {
-                slot,
-                index: *current_index,
-                entry: entry_summary,
-                starting_transaction_index: *current_transaction_index,
-            }) {
-                warn!(
-                "Failed to send slot {slot:?} entry {current_index:?} from Tpu to EntryNotifierService, \
-                 error {err:?}",
-            );
-            }
-            *current_transaction_index += entry.transactions.len();
+            0
+        } else {
             *current_index += 1;
-        }
+            *current_index
+        };
 
-        if let Err(err) = broadcast_entry_sender.send(WorkingBankEntry {
-            bank,
-            entries_ticks,
+        let entry_summary = EntrySummary {
+            num_hashes: entry.num_hashes,
+            hash: entry.hash,
+            num_transactions: entry.transactions.len() as u64,
+        };
+        if let Err(err) = entry_notification_sender.send(EntryNotification {
+            slot,
+            index,
+            entry: entry_summary,
+            starting_transaction_index: *current_transaction_index,
         }) {
             warn!(
-                "Failed to send slot {slot:?} entry {current_index:?} from Tpu to BroadcastStage, error \
+                "Failed to send slot {slot:?} entry {index:?} from Tpu to EntryNotifierService, \
+                 error {err:?}",
+            );
+        }
+        *current_transaction_index += entry.transactions.len();
+
+        if let Err(err) = broadcast_entry_sender.send((bank, (entry, tick_height))) {
+            warn!(
+                "Failed to send slot {slot:?} entry {index:?} from Tpu to BroadcastStage, error \
                  {err:?}",
             );
             // If the BroadcastStage channel is closed, the validator has halted. Try to exit

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -18,13 +18,14 @@ use {
         replay_stage::ReplayStage,
         unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
     },
+    solana_entry::entry::Entry,
     solana_gossip::cluster_info::{ClusterInfo, Node},
     solana_ledger::{
         blockstore::Blockstore, create_new_tmp_ledger_auto_delete,
         genesis_utils::create_genesis_config, leader_schedule_cache::LeaderScheduleCache,
     },
     solana_perf::packet::to_packet_batches,
-    solana_poh::poh_recorder::{create_test_recorder, WorkingBankEntry},
+    solana_poh::poh_recorder::create_test_recorder,
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, genesis_utils::GenesisConfigInfo,
         installed_scheduler_pool::SchedulingContext,
@@ -297,18 +298,9 @@ fn test_scheduler_producing_blocks() {
 
     // Verify transactions are committed and poh-recorded
     assert_eq!(tpu_bank.transaction_count(), 1);
-    let wbe = signal_receiver
-        .into_iter()
-        .find(
-            |WorkingBankEntry {
-                 bank: _,
-                 entries_ticks,
-             }| !entries_ticks[0].0.is_tick(),
-        )
-        .unwrap();
-    assert_eq!(
-        wbe.entries_ticks[0].0.transactions,
-        [tx.to_versioned_transaction()]
+    assert_matches!(
+        signal_receiver.into_iter().find(|(_, (entry, _))| !entry.is_tick()),
+        Some((_, (Entry {transactions, ..}, _))) if transactions == [tx.to_versioned_transaction()]
     );
 
     // Stop things.

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -373,7 +373,6 @@ impl PohService {
 mod tests {
     use {
         super::*,
-        crate::poh_recorder::WorkingBankEntry,
         crossbeam_channel::unbounded,
         rand::{thread_rng, Rng},
         solana_clock::DEFAULT_HASHES_PER_TICK,
@@ -501,12 +500,7 @@ mod tests {
 
         let time = Instant::now();
         while run_time != 0 || need_tick || need_entry || need_partial {
-            let WorkingBankEntry {
-                bank: _,
-                mut entries_ticks,
-            } = entry_receiver.recv().unwrap();
-            assert_eq!(entries_ticks.len(), 1);
-            let entry = entries_ticks.pop().unwrap().0;
+            let (_bank, (entry, _tick_height)) = entry_receiver.recv().unwrap();
 
             if entry.is_tick() {
                 num_ticks += 1;

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -760,10 +760,7 @@ pub mod test {
             let ticks = create_ticks(max_tick_height - start_tick_height, 0, Hash::default());
             for (i, tick) in ticks.into_iter().enumerate() {
                 entry_sender
-                    .send(WorkingBankEntry {
-                        bank: bank.clone(),
-                        entries_ticks: vec![(tick, i as u64 + 1)],
-                    })
+                    .send((bank.clone(), (tick, i as u64 + 1)))
                     .expect("Expect successful send to broadcast service");
             }
         }

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -31,23 +31,13 @@ pub(super) fn recv_slot_entries(receiver: &Receiver<WorkingBankEntry>) -> Result
         32 * ShredData::capacity(/*merkle_proof_size*/ None).unwrap() as u64;
     let timer = Duration::new(1, 0);
     let recv_start = Instant::now();
-
-    let WorkingBankEntry {
-        mut bank,
-        entries_ticks,
-    } = receiver.recv_timeout(timer)?;
-    let mut last_tick_height = entries_ticks.iter().last().unwrap().1;
-    let mut entries: Vec<Entry> = entries_ticks.into_iter().map(|(e, _)| e).collect();
-
+    let (mut bank, (entry, mut last_tick_height)) = receiver.recv_timeout(timer)?;
+    let mut entries = vec![entry];
     assert!(last_tick_height <= bank.max_tick_height());
 
     // Drain channel
     while last_tick_height != bank.max_tick_height() {
-        let Ok(WorkingBankEntry {
-            bank: try_bank,
-            entries_ticks: new_entries_ticks,
-        }) = receiver.try_recv()
-        else {
+        let Ok((try_bank, (entry, tick_height))) = receiver.try_recv() else {
             break;
         };
         // If the bank changed, that implies the previous slot was interrupted and we do not have to
@@ -57,8 +47,8 @@ pub(super) fn recv_slot_entries(receiver: &Receiver<WorkingBankEntry>) -> Result
             entries.clear();
             bank = try_bank;
         }
-        last_tick_height = new_entries_ticks.iter().last().unwrap().1;
-        entries.extend(new_entries_ticks.into_iter().map(|(entry, _)| entry));
+        last_tick_height = tick_height;
+        entries.push(entry);
         assert!(last_tick_height <= bank.max_tick_height());
     }
 
@@ -69,10 +59,8 @@ pub(super) fn recv_slot_entries(receiver: &Receiver<WorkingBankEntry>) -> Result
     while last_tick_height != bank.max_tick_height()
         && serialized_batch_byte_count < target_serialized_batch_byte_count
     {
-        let Ok(WorkingBankEntry {
-            bank: try_bank,
-            entries_ticks: new_entries_ticks,
-        }) = receiver.recv_deadline(coalesce_start + ENTRY_COALESCE_DURATION)
+        let Ok((try_bank, (entry, tick_height))) =
+            receiver.recv_deadline(coalesce_start + ENTRY_COALESCE_DURATION)
         else {
             break;
         };
@@ -85,12 +73,10 @@ pub(super) fn recv_slot_entries(receiver: &Receiver<WorkingBankEntry>) -> Result
             bank = try_bank;
             coalesce_start = Instant::now();
         }
-        last_tick_height = new_entries_ticks.iter().last().unwrap().1;
-
-        for (entry, _) in &new_entries_ticks {
-            serialized_batch_byte_count += serialized_size(entry)?;
-        }
-        entries.extend(new_entries_ticks.into_iter().map(|(entry, _)| entry));
+        last_tick_height = tick_height;
+        let entry_bytes = serialized_size(&entry)?;
+        serialized_batch_byte_count += entry_bytes;
+        entries.push(entry);
         assert!(last_tick_height <= bank.max_tick_height());
     }
     let time_coalesced = coalesce_start.elapsed();
@@ -175,11 +161,7 @@ mod tests {
             .map(|i| {
                 let entry = Entry::new(&last_hash, 1, vec![tx.clone()]);
                 last_hash = entry.hash;
-                s.send(WorkingBankEntry {
-                    bank: bank1.clone(),
-                    entries_ticks: vec![(entry.clone(), i)],
-                })
-                .unwrap();
+                s.send((bank1.clone(), (entry.clone(), i))).unwrap();
                 entry
             })
             .collect();
@@ -213,18 +195,11 @@ mod tests {
                 last_hash = entry.hash;
                 // Interrupt slot 1 right before the last tick
                 if tick_height == expected_last_height {
-                    s.send(WorkingBankEntry {
-                        bank: bank2.clone(),
-                        entries_ticks: vec![(entry.clone(), tick_height)],
-                    })
-                    .unwrap();
+                    s.send((bank2.clone(), (entry.clone(), tick_height)))
+                        .unwrap();
                     Some(entry)
                 } else {
-                    s.send(WorkingBankEntry {
-                        bank: bank1.clone(),
-                        entries_ticks: vec![(entry, tick_height)],
-                    })
-                    .unwrap();
+                    s.send((bank1.clone(), (entry, tick_height))).unwrap();
                     None
                 }
             })

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -4107,11 +4107,10 @@ mod tests {
                         TransactionStatusBatch { .. }
                     ))
                 );
-                assert_eq!(
-                    signal_receiver.try_recv().unwrap().entries_ticks[0]
-                        .0
-                        .transactions,
-                    vec![tx.to_versioned_transaction()]
+                assert_matches!(
+                    signal_receiver.try_recv(),
+                    Ok((_, (solana_entry::entry::Entry {transactions, ..} , _)))
+                        if transactions == vec![tx.to_versioned_transaction()]
                 );
             } else {
                 assert_eq!(result, &expected_tx_result);


### PR DESCRIPTION
#### Problem
Jito-Solana unnecessarily uses a custom data structure between poh service + broadcast stage, which makes rebases more difficult. This custom data structure is not needed and can go away.

#### Summary of Changes
Reverts WorkingBankEntry to Agave upstream.