### PR TITLE
Enable forwarding for trusted relayer packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6940,9 +6940,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -338,7 +338,7 @@ impl Tpu {
         let vote_sigverify_stage = {
             let verifier = TransactionSigVerifier::new_reject_non_vote(
                 tpu_vote_sender,
-                Some(forward_stage_sender),
+                Some(forward_stage_sender.clone()),
             );
             SigVerifyStage::new(
                 vote_packet_receiver,
@@ -379,6 +379,7 @@ impl Tpu {
             heartbeat_tx,
             sigverify_stage_sender,
             banking_stage_sender,
+            enable_block_production_forwarding.then(|| forward_stage_sender),
             exit.clone(),
         );
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -379,7 +379,7 @@ impl Tpu {
             heartbeat_tx,
             sigverify_stage_sender,
             banking_stage_sender,
-            enable_block_production_forwarding.then(|| forward_stage_sender),
+            enable_block_production_forwarding.then_some(forward_stage_sender),
             exit.clone(),
         );
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5727,9 +5727,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
#### Problem
V2.3 changed how packets are forwarded. Packets are no longer forwarded through banking stage but instead through a forward stage, the entrypoint of which is signature verification.

#### Summary of Changes
If a validator trusts the relayer packets and forwarding is enabled, a copy of packets should flow to forward stage in addition to banking stage.