### PR TITLE
Remove trusted relayer packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6940,9 +6940,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -378,7 +378,6 @@ impl Tpu {
             cluster_info.clone(),
             heartbeat_tx,
             sigverify_stage_sender,
-            banking_stage_sender,
             exit.clone(),
         );
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5727,9 +5727,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -279,7 +279,6 @@ pub trait AdminRpc {
         &self,
         meta: Self::Metadata,
         relayer_url: String,
-        trust_packets: bool,
         expected_heartbeat_interval_ms: u64,
         max_failed_heartbeats: u64,
     ) -> Result<()>;
@@ -587,7 +586,6 @@ impl AdminRpc for AdminRpcImpl {
         &self,
         meta: Self::Metadata,
         relayer_url: String,
-        trust_packets: bool,
         expected_heartbeat_interval_ms: u64,
         max_failed_heartbeats: u64,
     ) -> Result<()> {
@@ -599,7 +597,6 @@ impl AdminRpc for AdminRpcImpl {
             relayer_url,
             expected_heartbeat_interval,
             oldest_allowed_heartbeat,
-            trust_packets,
         };
         // Detailed log messages are printed inside validate function
         if RelayerStage::is_valid_relayer_config(&config) {

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -154,6 +154,14 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .long("disable-accounts-disk-index")
         .help("Disable the disk-based accounts index if it is enabled by default."));
 
+    add_arg!(
+        Arg::with_name("trust_relayer_packets")
+            .long("trust-relayer-packets")
+            .takes_value(false)
+            .help("(DEPRECATED): Not used anymore."),
+        usage_warning: "The trust_relayer_packets argument is obsolete",
+    );
+
     res
 }
 

--- a/validator/src/commands/relayer/mod.rs
+++ b/validator/src/commands/relayer/mod.rs
@@ -16,12 +16,6 @@ pub fn command(default_args: &DefaultArgs) -> App<'_, '_> {
                 .required(true)
         )
         .arg(
-            Arg::with_name("trust_relayer_packets")
-                .long("trust-relayer-packets")
-                .takes_value(false)
-                .help("Skip signature verification on relayer packets. Not recommended unless the relayer is trusted.")
-        )
-        .arg(
             Arg::with_name("relayer_expected_heartbeat_interval_ms")
                 .long("relayer-expected-heartbeat-interval-ms")
                 .takes_value(true)
@@ -41,7 +35,6 @@ pub fn command(default_args: &DefaultArgs) -> App<'_, '_> {
 
 pub fn execute(subcommand_matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     let relayer_url = value_t_or_exit!(subcommand_matches, "relayer_url", String);
-    let trust_packets = subcommand_matches.is_present("trust_relayer_packets");
     let expected_heartbeat_interval_ms: u64 =
         value_of(subcommand_matches, "relayer_expected_heartbeat_interval_ms").unwrap();
     let max_failed_heartbeats: u64 =
@@ -52,7 +45,6 @@ pub fn execute(subcommand_matches: &ArgMatches, ledger_path: &Path) -> Result<()
             .await?
             .set_relayer_config(
                 relayer_url,
-                trust_packets,
                 expected_heartbeat_interval_ms,
                 max_failed_heartbeats,
             )

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1670,12 +1670,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
     )
     .arg(
-        Arg::with_name("trust_relayer_packets")
-            .long("trust-relayer-packets")
-            .takes_value(false)
-            .help("Skip signature verification on relayer packets. Not recommended unless the relayer is trusted.")
-    )
-    .arg(
         Arg::with_name("relayer_expected_heartbeat_interval_ms")
             .long("relayer-expected-heartbeat-interval-ms")
             .takes_value(true)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -584,7 +584,6 @@ pub fn execute(
         oldest_allowed_heartbeat: Duration::from_millis(
             max_failed_heartbeats * expected_heartbeat_interval_ms,
         ),
-        trust_packets: matches.is_present("trust_relayer_packets"),
     }));
 
     let shred_receiver_address =


### PR DESCRIPTION
#### Problem
Sigverify handles emitting packets to packet forwarder and by trusting relayer packets, we lose that flow. Also sigverify is fast, so this optimization of offloading to the relayer doesn't do as much as it previously did.

#### Summary of Changes
- Removes trusted relayer packets + forwards all relayer packets through sigverify, which then lets them get forwarded if enabled.
- Update slab library for rustsec