### PR TITLE
Fix: fix dead links and placeholders

### DIFF
--- a/docs/src/proposals.md
+++ b/docs/src/proposals.md
@@ -30,7 +30,7 @@ To submit a new design proposal for Solana:
 2. Add any relevant Solana maintainers to the PR review.
 3. Publish the PR for community review and feedback.
 
-> **NOTE:** All people submitting PRs to the Solana repo should consult the [CONTRIBUTING](https://github.com/solana-labs/solana/blob/master/CONTRIBUTING.md) doc in the repo.
+> **NOTE:** All people submitting PRs to the Solana repo should consult the [CONTRIBUTING](https://github.com/anza-xyz/agave/blob/master/CONTRIBUTING.md) doc in the repo.
 
 ### After Accepted
 

--- a/docs/src/validator/anatomy.md
+++ b/docs/src/validator/anatomy.md
@@ -5,7 +5,8 @@ sidebar_label: Anatomy
 pagination_label: Anatomy of a Validator
 ---
 
-![Validator block diagrams](/img/validator.svg)
+<!-- TODO: Add new validator.svg diagram to replace placeholder -->
+<!-- ![Validator block diagrams](/img/validator.svg) -->
 
 ## Pipelining
 

--- a/docs/src/validator/runtime.md
+++ b/docs/src/validator/runtime.md
@@ -23,7 +23,8 @@ Transactions are batched and processed in a pipeline. The TPU and TVU follow a s
 
 The TVU runtime ensures that PoH verification occurs before the runtime processes any transactions.
 
-![Runtime pipeline](/img/runtime.svg)
+<!-- TODO: Add new runtime.svg diagram to replace placeholder -->
+<!-- ![Runtime pipeline](/img/runtime.svg) -->
 
 At the _execute_ stage, the loaded accounts have no data dependencies, so all the programs can be executed in parallel.
 

--- a/docs/src/validator/tpu.md
+++ b/docs/src/validator/tpu.md
@@ -8,7 +8,8 @@ pagination_label: Validator's Transaction Processing Unit (TPU)
 TPU (Transaction Processing Unit) is the logic of the validator
 responsible for block production.
 
-![TPU Block Diagram](/img/tpu.svg)
+<!-- TODO: Add new tpu.svg diagram to replace placeholder -->
+<!-- ![TPU Block Diagram](/img/tpu.svg) -->
 
 Transactions are encoded and sent in QUIC streams into the validator
 from clients (other validators/users of the network) as follows:

--- a/docs/src/validator/tvu.md
+++ b/docs/src/validator/tvu.md
@@ -10,11 +10,13 @@ responsible for propagating blocks between validators and ensuring that
 those blocks' transactions reach the replay stage. Its principal external
 interface is the turbine protocol.
 
-![TVU Block Diagram](/img/tvu.svg)
+<!-- TODO: Add new tvu.svg diagram to replace placeholder -->
+<!-- ![TVU Block Diagram](/img/tvu.svg) -->
 
-## Retransmit Stage
+<!-- ## Retransmit Stage -->
 
-![Retransmit Block Diagram](/img/retransmit_stage.svg)
+<!-- TODO: Add new validator.svg diagram to replace placeholder -->
+<!-- ![Retransmit Block Diagram](/img/retransmit_stage.svg) -->
 
 ## TVU sockets
 


### PR DESCRIPTION
#### Problem

- Placeholders in `anatomy.md`, `tvu.md`, `tpu.md`, and `runtime.md` that should display an image do not work because the images have been removed.
- Broken link in `proposals.md` to archived solana-labs github

#### Summary of Changes

- Commented out placeholder image references
- Added TODO comments for future image implementation
- Added actual link to new solana-labs repo in `proposals.md`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
