### PR TITLE
[Master] Automatically use optimal Block Engine region

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ name = "agave-validator"
 version = "3.1.0"
 dependencies = [
  "agave-geyser-plugin-interface",
+ "arc-swap",
  "assert_cmd",
  "chrono",
  "clap 2.33.3",
@@ -8558,6 +8559,7 @@ dependencies = [
  "ahash 0.8.11",
  "anchor-lang",
  "anyhow",
+ "arc-swap",
  "arrayvec",
  "assert_matches",
  "async-trait",
@@ -12743,6 +12745,7 @@ version = "3.1.0"
 dependencies = [
  "agave-feature-set",
  "agave-xdp",
+ "arc-swap",
  "assert_matches",
  "bencher",
  "bincode",
@@ -14341,9 +14344,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -14363,9 +14366,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.7"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "sharded-slab",
  "thread_local",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,6 +49,7 @@ agave-votor = { workspace = true, features = ["agave-unstable-api"] }
 ahash = { workspace = true }
 anchor-lang = { workspace = true }
 anyhow = { workspace = true }
+arc-swap = { workspace = true }
 arrayvec = { workspace = true }
 assert_matches = { workspace = true }
 async-trait = { workspace = true }

--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -4,6 +4,7 @@ use {
         proxy::{block_engine_stage::BlockEngineConfig, relayer_stage::RelayerConfig},
         repair::{outstanding_requests::OutstandingRequests, serve_repair::ShredRepairType},
     },
+    arc_swap::ArcSwap,
     solana_gossip::{cluster_info::ClusterInfo, node::NodeMultihoming},
     solana_pubkey::Pubkey,
     solana_quic_definitions::NotifyKeyUpdate,
@@ -82,6 +83,6 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub node: Option<Arc<NodeMultihoming>>,
     pub block_engine_config: Arc<Mutex<BlockEngineConfig>>,
     pub relayer_config: Arc<Mutex<RelayerConfig>>,
-    pub shred_receiver_address: Arc<RwLock<Option<SocketAddr>>>,
-    pub shred_retransmit_receiver_address: Arc<RwLock<Option<SocketAddr>>>,
+    pub shred_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
+    pub shred_retransmit_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
 }

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -12,6 +12,7 @@ use {
         validator::{BlockProductionMethod, TransactionStructure},
     },
     agave_banking_stage_ingress_types::BankingPacketBatch,
+    arc_swap::ArcSwap,
     assert_matches::assert_matches,
     bincode::deserialize_from,
     crossbeam_channel::{unbounded, Sender},
@@ -818,7 +819,8 @@ impl BankingSimulator {
             shred_version,
             sender,
             None,
-            Arc::new(RwLock::new(None)),
+            Arc::new(ArcSwap::default()),
+            Arc::new(ArcSwap::default()),
         );
 
         info!("Start banking stage!...");

--- a/core/src/proxy/block_engine_stage.rs
+++ b/core/src/proxy/block_engine_stage.rs
@@ -14,12 +14,14 @@ use {
             ProxyError,
         },
     },
+    arc_swap::ArcSwap,
     crossbeam_channel::Sender,
+    itertools::Itertools,
     jito_protos::proto::{
         auth::{auth_service_client::AuthServiceClient, Token},
         block_engine::{
             self, block_engine_validator_client::BlockEngineValidatorClient,
-            BlockBuilderFeeInfoRequest,
+            BlockBuilderFeeInfoRequest, BlockEngineEndpoint, GetBlockEngineEndpointRequest,
         },
     },
     solana_gossip::cluster_info::ClusterInfo,
@@ -28,6 +30,8 @@ use {
     solana_pubkey::Pubkey,
     solana_signer::Signer,
     std::{
+        collections::hash_map::Entry,
+        net::{SocketAddr, ToSocketAddrs},
         ops::AddAssign,
         str::FromStr,
         sync::{
@@ -37,13 +41,14 @@ use {
         thread::{self, Builder, JoinHandle},
         time::Duration,
     },
+    thiserror::Error,
     tokio::{
         task,
         time::{interval, sleep, timeout},
     },
     tonic::{
         codegen::InterceptedService,
-        transport::{Channel, Endpoint},
+        transport::{Channel, Endpoint, Uri},
         Status, Streaming,
     },
 };
@@ -81,6 +86,9 @@ pub struct BlockEngineConfig {
     /// Block Engine URL
     pub block_engine_url: String,
 
+    /// Disables Block Engine auto-configuration. This stops the validator client from using the most performant Block Engine region. Values provided to `--block-engine-url` will be used as-is.
+    pub disable_block_engine_autoconfig: bool,
+
     /// If set then it will be assumed the backend verified packets so signature verification will be bypassed in the validator.
     pub trust_packets: bool,
 }
@@ -88,8 +96,24 @@ pub struct BlockEngineConfig {
 pub struct BlockEngineStage {
     t_hdls: Vec<JoinHandle<()>>,
 }
+#[derive(Error, Debug)]
+enum PingError<'a> {
+    #[error("Failed to send ping: {0}")]
+    CommandFailure(#[from] std::io::Error),
+
+    #[error("Ping command exited with non-zero status: {1:?} for host: {0}")]
+    NonZeroExit(&'a str, Option<i32>),
+
+    #[error("No valid RTT found in ping output")]
+    NoRttFound,
+
+    #[error("Failed to parse RTT: {0}")]
+    ParseFloatError(#[from] std::num::ParseFloatError),
+}
 
 impl BlockEngineStage {
+    const CONNECTION_TIMEOUT: Duration = Duration::from_secs(CONNECTION_TIMEOUT_S);
+    const CONNECTION_BACKOFF: Duration = Duration::from_secs(CONNECTION_BACKOFF_S);
     pub fn new(
         block_engine_config: Arc<Mutex<BlockEngineConfig>>,
         // Channel that bundles get piped through.
@@ -102,6 +126,7 @@ impl BlockEngineStage {
         banking_packet_sender: BankingPacketSender,
         exit: Arc<AtomicBool>,
         block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> Self {
         let block_builder_fee_info = block_builder_fee_info.clone();
 
@@ -120,6 +145,7 @@ impl BlockEngineStage {
                     banking_packet_sender,
                     exit,
                     block_builder_fee_info,
+                    shredstream_receiver_address,
                 ));
             })
             .unwrap();
@@ -145,24 +171,22 @@ impl BlockEngineStage {
         banking_packet_sender: BankingPacketSender,
         exit: Arc<AtomicBool>,
         block_builder_fee_info: Arc<Mutex<BlockBuilderFeeInfo>>,
+        shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     ) {
-        const CONNECTION_TIMEOUT: Duration = Duration::from_secs(CONNECTION_TIMEOUT_S);
-        const CONNECTION_BACKOFF: Duration = Duration::from_secs(CONNECTION_BACKOFF_S);
         let mut error_count: u64 = 0;
 
         while !exit.load(Ordering::Relaxed) {
             // Wait until a valid config is supplied (either initially or by admin rpc)
             // Use if!/else here to avoid extra CONNECTION_BACKOFF wait on successful termination
-            let local_block_engine_config = {
-                let block_engine_config = block_engine_config.clone();
-                task::spawn_blocking(move || block_engine_config.lock().unwrap().clone())
-                    .await
-                    .unwrap()
-            };
+            let local_block_engine_config =
+                task::block_in_place(|| block_engine_config.lock().unwrap().clone());
             if !Self::is_valid_block_engine_config(&local_block_engine_config) {
-                sleep(CONNECTION_BACKOFF).await;
-            } else if let Err(e) = Self::connect_auth_and_stream(
-                &local_block_engine_config,
+                shredstream_receiver_address.store(Arc::new(None));
+                sleep(Self::CONNECTION_BACKOFF).await;
+                continue;
+            }
+
+            if let Err(e) = Self::connect_auth_and_stream_maybe_autoconfig(
                 &block_engine_config,
                 &cluster_info,
                 &bundle_tx,
@@ -170,16 +194,16 @@ impl BlockEngineStage {
                 &banking_packet_sender,
                 &exit,
                 &block_builder_fee_info,
-                &CONNECTION_TIMEOUT,
+                &shredstream_receiver_address,
+                &mut error_count,
+                &local_block_engine_config,
             )
             .await
             {
                 match e {
                     // This error is frequent on hot spares, and the parsed string does not work
                     // with datapoints (incorrect escaping).
-                    ProxyError::AuthenticationPermissionDenied => {
-                        warn!("block engine permission denied. not on leader schedule. ignore if hot-spare.")
-                    }
+                    ProxyError::AuthenticationPermissionDenied => warn!("block engine permission denied. not on leader schedule. ignore if hot-spare."),
                     e => {
                         error_count += 1;
                         datapoint_warn!(
@@ -189,12 +213,201 @@ impl BlockEngineStage {
                         );
                     }
                 }
-                sleep(CONNECTION_BACKOFF).await;
+                sleep(Self::CONNECTION_BACKOFF).await;
             }
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn connect_auth_and_stream_maybe_autoconfig(
+        block_engine_config: &Arc<Mutex<BlockEngineConfig>>,
+        cluster_info: &Arc<ClusterInfo>,
+        bundle_tx: &Sender<Vec<PacketBundle>>,
+        packet_tx: &Sender<PacketBatch>,
+        banking_packet_sender: &BankingPacketSender,
+        exit: &Arc<AtomicBool>,
+        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        shredstream_receiver_address: &Arc<ArcSwap<Option<SocketAddr>>>,
+        error_count: &mut u64,
+        local_block_engine_config: &BlockEngineConfig,
+    ) -> crate::proxy::Result<()> {
+        let endpoint = Self::get_endpoint(local_block_engine_config.block_engine_url.clone())?;
+        if !local_block_engine_config.disable_block_engine_autoconfig {
+            return Self::connect_auth_and_stream_autoconfig(
+                endpoint,
+                local_block_engine_config,
+                block_engine_config,
+                cluster_info,
+                bundle_tx,
+                packet_tx,
+                banking_packet_sender,
+                exit,
+                block_builder_fee_info,
+                error_count,
+                shredstream_receiver_address,
+            )
+            .await;
+        }
+
+        shredstream_receiver_address.store(Arc::new(None));
+        Self::connect_auth_and_stream(
+            endpoint,
+            local_block_engine_config,
+            block_engine_config,
+            cluster_info,
+            bundle_tx,
+            packet_tx,
+            banking_packet_sender,
+            exit,
+            block_builder_fee_info,
+            &Self::CONNECTION_TIMEOUT,
+            local_block_engine_config.block_engine_url.as_str(),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn connect_auth_and_stream_autoconfig(
+        mut backend_endpoint: Endpoint,
+        local_block_engine_config: &BlockEngineConfig,
+        global_block_engine_config: &Arc<Mutex<BlockEngineConfig>>,
+        cluster_info: &Arc<ClusterInfo>,
+        bundle_tx: &Sender<Vec<PacketBundle>>,
+        packet_tx: &Sender<PacketBatch>,
+        banking_packet_sender: &BankingPacketSender,
+        exit: &Arc<AtomicBool>,
+        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        error_count: &mut u64,
+        shredstream_receiver_address: &Arc<ArcSwap<Option<SocketAddr>>>,
+    ) -> crate::proxy::Result<()> {
+        let mut endpoint_discovery = BlockEngineValidatorClient::connect(backend_endpoint.clone())
+            .await
+            .map_err(|e| ProxyError::BlockEngineConnectionError(e.to_string()))?;
+        let endpoints = endpoint_discovery
+            .get_block_engine_endpoints(GetBlockEngineEndpointRequest {})
+            .await
+            .map_err(|e| ProxyError::BlockEngineConnectionError(e.to_string()))?
+            .into_inner();
+        let endpoint_latencies = Self::ping_and_rank_endpoints(&endpoints.regioned_endpoints).await;
+
+        // If no endpoints were reachable via ping (or ping is unavailable), fall back to the global
+        // endpoint returned by discovery.
+        if endpoint_latencies.is_empty() {
+            let Some(global) = endpoints.global_endpoint else {
+                return Err(ProxyError::BlockEngineConnectionError("autoconfig failed: no reachable endpoints via ping and no global endpoint provided".to_string()));
+            };
+
+            let Some(ss) = global
+                .shredstream_receiver_address
+                .to_socket_addrs()
+                .inspect_err(|e| {
+                    warn!(
+                        "Failed to resolve global shredstream address {}, error: {e}",
+                        global.shredstream_receiver_address
+                    )
+                })
+                .ok()
+                .and_then(|mut shredstream_sockets| shredstream_sockets.next())
+            else {
+                return Err(ProxyError::BlockEngineConnectionError(
+                    "Failed to resolve global shredstream receiver address".to_string(),
+                ));
+            };
+
+            shredstream_receiver_address.store(Arc::new(Some(ss)));
+            datapoint_info!(
+                "block_engine_stage-autoconfig_fallback_global",
+                ("endpoint", global.block_engine_url, String),
+                ("count", 1, i64),
+            );
+
+            return Self::connect_auth_and_stream(
+                Self::get_endpoint(global.block_engine_url.clone())?,
+                local_block_engine_config,
+                global_block_engine_config,
+                cluster_info,
+                bundle_tx,
+                packet_tx,
+                banking_packet_sender,
+                exit,
+                block_builder_fee_info,
+                &Self::CONNECTION_TIMEOUT,
+                global.block_engine_url.as_str(),
+            )
+            .await;
+        }
+
+        // try connecting to best block engine
+        let mut attempted = false;
+        let endpoint_count = endpoint_latencies.len();
+        for (block_engine_url, (shredstream_socket, latency_us)) in endpoint_latencies
+            .into_iter()
+            .sorted_unstable_by_key(|(_endpoint, (_shredstream_socket, latency_us))| *latency_us)
+        {
+            if block_engine_url != local_block_engine_config.block_engine_url {
+                debug!("Selected best Block Engine url: {block_engine_url}, Shredstream socket: {shredstream_socket}, ping: ({:?})",
+                    Duration::from_micros(latency_us)
+                );
+                backend_endpoint = Self::get_endpoint(block_engine_url.to_owned())?;
+            }
+            shredstream_receiver_address.store(Arc::new(Some(shredstream_socket)));
+            attempted = true;
+            match Self::connect_auth_and_stream(
+                backend_endpoint.clone(),
+                local_block_engine_config,
+                global_block_engine_config,
+                cluster_info,
+                bundle_tx,
+                packet_tx,
+                banking_packet_sender,
+                exit,
+                block_builder_fee_info,
+                &Self::CONNECTION_TIMEOUT,
+                block_engine_url,
+            )
+            .await
+            {
+                Ok(()) => {
+                    info!(
+                        "Closed block engine connection to {}",
+                        backend_endpoint.uri()
+                    );
+                    return Ok(());
+                }
+                Err(e) => {
+                    // log each connection error
+                    match e {
+                        // This error is frequent on hot spares, and the parsed string does not work
+                        // with datapoints (incorrect escaping).
+                        ProxyError::AuthenticationPermissionDenied => warn!(
+                            "block engine permission denied. not on leader schedule. ignore if hot-spare."
+                        ),
+                        other => {
+                            *error_count += 1;
+                            datapoint_warn!(
+                                "block_engine_stage-proxy_error",
+                                ("count", *error_count, i64),
+                                ("error", other.to_string(), String),
+                            );
+                        }
+                    }
+                    // try next endpoint without delay; caller handles backoff on overall failure
+                }
+            }
+        }
+        if !attempted {
+            return Err(ProxyError::BlockEngineConnectionError(
+                "autoconfig failed: no endpoints available after ping ranking".to_string(),
+            ));
+        }
+        Err(ProxyError::BlockEngineConnectionError(format!(
+            "autoconfig failed: all {endpoint_count} candidate endpoints failed to connect",
+        )))
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn connect_auth_and_stream(
+        backend_endpoint: Endpoint,
         local_block_engine_config: &BlockEngineConfig,
         global_block_engine_config: &Arc<Mutex<BlockEngineConfig>>,
         cluster_info: &Arc<ClusterInfo>,
@@ -204,36 +417,12 @@ impl BlockEngineStage {
         exit: &Arc<AtomicBool>,
         block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
         connection_timeout: &Duration,
+        block_engine_url: &str,
     ) -> crate::proxy::Result<()> {
         // Get a copy of configs here in case they have changed at runtime
         let keypair = cluster_info.keypair().clone();
 
-        let mut backend_endpoint =
-            Endpoint::from_shared(local_block_engine_config.block_engine_url.clone())
-                .map_err(|_| {
-                    ProxyError::BlockEngineConnectionError(format!(
-                        "invalid block engine url value: {}",
-                        local_block_engine_config.block_engine_url
-                    ))
-                })?
-                .tcp_keepalive(Some(Duration::from_secs(60)));
-        if local_block_engine_config
-            .block_engine_url
-            .starts_with("https")
-        {
-            backend_endpoint = backend_endpoint
-                .tls_config(tonic::transport::ClientTlsConfig::new())
-                .map_err(|_| {
-                    ProxyError::BlockEngineConnectionError(
-                        "failed to set tls_config for block engine service".to_string(),
-                    )
-                })?;
-        }
-
-        debug!(
-            "connecting to auth: {}",
-            local_block_engine_config.block_engine_url
-        );
+        debug!("connecting to auth: {}", backend_endpoint.uri());
         let auth_channel = timeout(*connection_timeout, backend_endpoint.connect())
             .await
             .map_err(|_| ProxyError::AuthenticationConnectionTimeout)?
@@ -251,14 +440,11 @@ impl BlockEngineStage {
 
         datapoint_info!(
             "block_engine_stage-tokens_generated",
-            ("url", local_block_engine_config.block_engine_url, String),
+            ("url", &block_engine_url, String),
             ("count", 1, i64),
         );
 
-        debug!(
-            "connecting to block engine: {}",
-            local_block_engine_config.block_engine_url
-        );
+        debug!("connecting to block engine: {}", backend_endpoint.uri());
         let block_engine_channel = timeout(*connection_timeout, backend_endpoint.connect())
             .await
             .map_err(|_| ProxyError::BlockEngineConnectionTimeout)?
@@ -285,8 +471,155 @@ impl BlockEngineStage {
             connection_timeout,
             keypair,
             cluster_info,
+            block_engine_url,
         )
         .await
+    }
+
+    /// Build an Endpoint from the URL provided
+    fn get_endpoint(block_engine_url: String) -> Result<Endpoint, ProxyError> {
+        let mut backend_endpoint = Endpoint::from_shared(block_engine_url.clone())
+            .map_err(|_| {
+                ProxyError::BlockEngineConnectionError(format!(
+                    "invalid block engine url value: {block_engine_url}",
+                ))
+            })?
+            .tcp_keepalive(Some(Duration::from_secs(60)));
+        if block_engine_url.starts_with("https") {
+            backend_endpoint = backend_endpoint
+                .tls_config(tonic::transport::ClientTlsConfig::new())
+                .map_err(|_| {
+                    ProxyError::BlockEngineConnectionError(
+                        "failed to set tls_config for block engine service".to_owned(),
+                    )
+                })?;
+        }
+        Ok(backend_endpoint)
+    }
+
+    /// Runs a single `ping -c 1 <ip>` command and returns the RTT in microseconds, or an error.
+    async fn ping(host: &str) -> Result<u64, PingError> {
+        let output = tokio::process::Command::new("ping")
+            .arg("-c")
+            .arg("1") // ping once
+            .arg("-w")
+            .arg("2") // don't wait more than 2 secs for a response
+            .arg(host)
+            .output()
+            .await?; // can produce std::io::Error -> PingError::CommandFailure
+
+        if !output.status.success() {
+            warn!(
+                "Ping error to host: {host}. Stdout: {}, Stderr:{}, return code: {:?}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+                output.status.code()
+            );
+            return Err(PingError::NonZeroExit(host, output.status.code()));
+        }
+
+        // Example line to parse: `64 bytes from 8.8.8.8: icmp_seq=1 ttl=57 time=12.3 ms`
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            let Some(rtt_str) = line
+                .find("time=")
+                .map(|index| &line[index + "time=".len()..])
+                .and_then(|rtt_str| rtt_str.find(" ms").map(|index| &rtt_str[..index]))
+            else {
+                continue;
+            };
+
+            let rtt = rtt_str.parse::<f64>()?; // might return ParseFloatError
+            return Ok((rtt * 1000.0).round() as u64);
+        }
+
+        Err(PingError::NoRttFound)
+    }
+
+    /// Ping all candidate endpoints concurrently, aggregate best RTT per endpoint
+    async fn ping_and_rank_endpoints(
+        endpoints: &[BlockEngineEndpoint],
+    ) -> ahash::HashMap<
+        &str, /* block engine url */
+        (
+            SocketAddr, /* shredstream receiver */
+            u64,        /* latency us */
+        ),
+    > {
+        const PING_COUNT: usize = 3;
+
+        let endpoints_to_ping = endpoints
+            .iter()
+            .flat_map(|endpoint| std::iter::repeat_n(endpoint, PING_COUNT)) // send multiple pings to each destination to get the best time
+            .filter_map(|endpoint| {
+                let uri = endpoint
+                    .block_engine_url
+                    .parse::<Uri>()
+                    .inspect_err(|e| {
+                        warn!(
+                            "Failed to parse URI: {}, Error: {e}",
+                            endpoint.block_engine_url
+                        )
+                    })
+                    .ok()?;
+                let _ = uri.host()?;
+                Some((endpoint, uri))
+            })
+            .collect_vec();
+        let ping_res = futures::future::join_all(
+            endpoints_to_ping
+                .iter()
+                .map(|(_endpoint, uri)| Self::ping(uri.host().unwrap())), // unwrap checked in filter_map above
+        )
+        .await;
+
+        let mut agg_endpoints: ahash::HashMap<
+            &str, /* block engine url */
+            (
+                SocketAddr, /* shredstream receiver */
+                u64,        /* latency us */
+            ),
+        > = ahash::HashMap::default();
+        ping_res.iter().zip(endpoints_to_ping.iter()).for_each(
+            |(maybe_ping_res, (endpoint, _uri))| {
+                let Ok(latency_us) = maybe_ping_res.as_ref() else {
+                    return;
+                };
+
+                datapoint_info!(
+                    "block_engine_stage-ping",
+                    ("endpoint", endpoint.block_engine_url, String),
+                    ("latency_us", *latency_us, i64),
+                );
+                match agg_endpoints.entry(endpoint.block_engine_url.as_str()) {
+                    Entry::Occupied(mut ent) => {
+                        let (_shredstream_socket, best_ping_us) = ent.get_mut();
+                        if latency_us <= best_ping_us {
+                            *best_ping_us = *latency_us;
+                        }
+                    }
+                    Entry::Vacant(entry) => {
+                        let Some(shredstream_socket) = endpoint
+                            .shredstream_receiver_address
+                            .to_socket_addrs()
+                            .inspect_err(|e| {
+                                warn!(
+                                    "Failed to resolve shredstream address {}, error: {e}",
+                                    endpoint.shredstream_receiver_address
+                                )
+                            })
+                            .ok()
+                            .and_then(|mut shredstream_sockets| shredstream_sockets.next())
+                        else {
+                            return;
+                        };
+                        entry.insert((shredstream_socket, *latency_us));
+                    }
+                };
+            },
+        );
+
+        agg_endpoints
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -305,6 +638,7 @@ impl BlockEngineStage {
         connection_timeout: &Duration,
         keypair: Arc<Keypair>,
         cluster_info: &Arc<ClusterInfo>,
+        block_engine_url: &str,
     ) -> crate::proxy::Result<()> {
         let subscribe_packets_stream = timeout(
             *connection_timeout,
@@ -362,6 +696,7 @@ impl BlockEngineStage {
             keypair,
             cluster_info,
             connection_timeout,
+            block_engine_url,
         )
         .await
     }
@@ -386,6 +721,7 @@ impl BlockEngineStage {
         keypair: Arc<Keypair>,
         cluster_info: &Arc<ClusterInfo>,
         connection_timeout: &Duration,
+        block_engine_url: &str,
     ) -> crate::proxy::Result<()> {
         const METRICS_TICK: Duration = Duration::from_secs(1);
         const MAINTENANCE_TICK: Duration = Duration::from_secs(10 * 60);
@@ -416,10 +752,8 @@ impl BlockEngineStage {
                         return Err(ProxyError::AuthenticationConnectionError("validator identity changed".to_string()));
                     }
 
-                    let global_config = global_config.clone();
-                    if *local_config != task::spawn_blocking(move || global_config.lock().unwrap().clone())
-                        .await
-                        .unwrap() {
+                    if !global_config.lock().unwrap().eq(local_config)
+                      {
                         return Err(ProxyError::AuthenticationConnectionError("block engine config changed".to_string()));
                     }
 
@@ -435,20 +769,17 @@ impl BlockEngineStage {
                         num_refresh_access_token += 1;
                         datapoint_info!(
                             "block_engine_stage-refresh_access_token",
-                            ("url", &local_config.block_engine_url, String),
+                            ("url", &block_engine_url, String),
                             ("count", num_refresh_access_token, i64),
                         );
 
-                        let access_token = access_token.clone();
-                        task::spawn_blocking(move || *access_token.lock().unwrap() = new_token)
-                            .await
-                            .unwrap();
+                         *access_token.lock().unwrap() = new_token;
                     }
                     if let Some(new_token) = maybe_new_refresh {
                         num_full_refreshes += 1;
                         datapoint_info!(
                             "block_engine_stage-tokens_generated",
-                            ("url", &local_config.block_engine_url, String),
+                            ("url", &block_engine_url, String),
                             ("count", num_full_refreshes, i64),
                         );
                         refresh_token = new_token;

--- a/core/src/proxy/mod.rs
+++ b/core/src/proxy/mod.rs
@@ -74,8 +74,14 @@ pub enum ProxyError {
     #[error("BlockEngineTimeout")]
     BlockEngineTimeout,
 
+    #[error("BlockEngineEndpointError: {0:?}")]
+    BlockEngineEndpointError(String),
+
     #[error("BlockEngineConnectionError: {0:?}")]
-    BlockEngineConnectionError(String),
+    BlockEngineConnectionError(tonic::transport::Error),
+
+    #[error("BlockEngineRequestError: {0:?}")]
+    BlockEngineRequestError(tonic::Status),
 
     #[error("RelayerConnectionTimeout")]
     RelayerConnectionTimeout,

--- a/core/src/proxy/mod.rs
+++ b/core/src/proxy/mod.rs
@@ -65,6 +65,9 @@ pub enum ProxyError {
     #[error("AuthenticationConnectionError: {0:?}")]
     AuthenticationConnectionError(String),
 
+    #[error("BlockEngineConfigChanged")]
+    BlockEngineConfigChanged,
+
     #[error("BlockEngineConnectionTimeout")]
     BlockEngineConnectionTimeout,
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -20,6 +20,7 @@ use {
         warm_quic_cache_service::WarmQuicCacheService,
         window_service::{WindowService, WindowServiceChannels},
     },
+    arc_swap::ArcSwap,
     bytes::Bytes,
     crossbeam_channel::{unbounded, Receiver, Sender},
     solana_client::connection_cache::ConnectionCache,
@@ -173,7 +174,7 @@ impl Tvu {
         wen_restart_repair_slots: Option<Arc<RwLock<Vec<Slot>>>>,
         slot_status_notifier: Option<SlotStatusNotifier>,
         vote_connection_cache: Arc<ConnectionCache>,
-        shred_receiver_addr: Arc<RwLock<Option<SocketAddr>>>,
+        shred_receiver_addr: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> Result<Self, String> {
         let in_wen_restart = wen_restart_repair_slots.is_some();
 
@@ -608,7 +609,7 @@ pub mod tests {
             wen_restart_repair_slots,
             None,
             Arc::new(connection_cache),
-            Arc::new(RwLock::new(None)),
+            Arc::new(ArcSwap::from_pointee(None)),
         )
         .expect("assume success");
         if enable_wen_restart {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -32,6 +32,7 @@ use {
         tvu::{Tvu, TvuConfig, TvuSockets},
     },
     anyhow::{anyhow, Context, Result},
+    arc_swap::ArcSwap,
     crossbeam_channel::{bounded, unbounded, Receiver},
     quinn::Endpoint,
     solana_accounts_db::{
@@ -310,8 +311,8 @@ pub struct ValidatorConfig {
     // jito configuration
     pub relayer_config: Arc<Mutex<RelayerConfig>>,
     pub block_engine_config: Arc<Mutex<BlockEngineConfig>>,
-    pub shred_receiver_address: Arc<RwLock<Option<SocketAddr>>>,
-    pub shred_retransmit_receiver_address: Arc<RwLock<Option<SocketAddr>>>,
+    pub shred_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
+    pub shred_retransmit_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     pub tip_manager_config: TipManagerConfig,
     pub preallocated_bundle_cost: u64,
 }
@@ -397,8 +398,8 @@ impl ValidatorConfig {
             repair_handler_type: RepairHandlerType::default(),
             relayer_config: Arc::new(Mutex::new(RelayerConfig::default())),
             block_engine_config: Arc::new(Mutex::new(BlockEngineConfig::default())),
-            shred_receiver_address: Arc::new(RwLock::new(None)),
-            shred_retransmit_receiver_address: Arc::new(RwLock::new(None)),
+            shred_receiver_address: Arc::new(ArcSwap::from_pointee(None)),
+            shred_retransmit_receiver_address: Arc::new(ArcSwap::from_pointee(None)),
             tip_manager_config: TipManagerConfig::default(),
             preallocated_bundle_cost: 0,
         }

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -112,6 +112,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --block-engine-url ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --disable-block-engine-autoconfig ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 == --tip-payment-program-pubkey ]]; then
       args+=("$1" "$2")
       shift 2
@@ -122,6 +125,9 @@ while [[ -n $1 ]]; do
       args+=("$1" "$2")
       shift 2
     elif [[ $1 == --shred-receiver-address ]]; then
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 == --shred-retransmit-receiver-address ]]; then
       args+=("$1" "$2")
       shift 2
     elif [[ $1 = --log-messages-bytes-limit ]]; then

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -100,6 +100,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --tip-distribution-program-pubkey ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --disable-block-engine-autoconfig ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 == --commission-bps ]]; then
       args+=("$1" "$2")
       shift 2
@@ -222,6 +225,9 @@ while [[ -n $1 ]]; do
       args+=("$1" "$2")
       shift 2
     elif [[ $1 == --shred-receiver-address ]]; then
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 == --shred-retransmit-receiver-address ]]; then
       args+=("$1" "$2")
       shift 2
     elif [[ $1 == --trust-block-engine-packets ]]; then

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -200,6 +200,7 @@ name = "agave-validator"
 version = "3.1.0"
 dependencies = [
  "agave-geyser-plugin-interface",
+ "arc-swap",
  "chrono",
  "clap",
  "console 0.16.0",
@@ -6834,6 +6835,7 @@ dependencies = [
  "ahash 0.8.11",
  "anchor-lang",
  "anyhow",
+ "arc-swap",
  "arrayvec",
  "assert_matches",
  "async-trait",
@@ -10960,6 +10962,7 @@ version = "3.1.0"
 dependencies = [
  "agave-feature-set",
  "agave-xdp",
+ "arc-swap",
  "bincode",
  "bytes",
  "caps",
@@ -12280,9 +12283,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -12303,9 +12306,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "sharded-slab",
  "thread_local",

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -15,6 +15,7 @@ agave-unstable-api = []
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-xdp = { workspace = true }
+arc-swap = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -94,6 +94,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
             &SocketAddrSpace::Unspecified,
             &quic_endpoint_sender,
             &None,
+            &None,
         )
         .unwrap();
     });

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -298,7 +298,8 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         sock: BroadcastSocket,
         bank_forks: &RwLock<BankForks>,
         _quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
-        _shred_receiver_addr: &Arc<RwLock<Option<SocketAddr>>>,
+        _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        _shred_receiver_addr: &ArcSwap<Option<SocketAddr>>,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         if shreds.is_empty() {

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -156,7 +156,8 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         sock: BroadcastSocket,
         _bank_forks: &RwLock<BankForks>,
         _quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
-        _shred_receiver_addr: &Arc<RwLock<Option<SocketAddr>>>,
+        _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        _shred_receiver_addr: &ArcSwap<Option<SocketAddr>>,
     ) -> Result<()> {
         let sock = match sock {
             BroadcastSocket::Udp(sock) => sock,

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -182,7 +182,8 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         sock: BroadcastSocket,
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
-        shred_receiver_address: &Arc<RwLock<Option<SocketAddr>>>,
+        shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        shred_receiver_address: &ArcSwap<Option<SocketAddr>>,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         broadcast_shreds(
@@ -195,7 +196,8 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             bank_forks,
             cluster_info.socket_addr_space(),
             quic_endpoint_sender,
-            &shred_receiver_address.read().unwrap(),
+            &shredstream_receiver_address.load(),
+            &shred_receiver_address.load(),
         )
     }
     fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()> {

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -181,7 +181,8 @@ impl StandardBroadcastRun {
             BroadcastSocket::Udp(sock),
             bank_forks,
             quic_endpoint_sender,
-            &Arc::new(RwLock::new(None)),
+            &ArcSwap::default(),
+            &ArcSwap::default(),
         );
         let _ = self.record(&brecv, blockstore);
         Ok(())
@@ -383,6 +384,7 @@ impl StandardBroadcastRun {
         broadcast_shred_batch_info: Option<BroadcastShredBatchInfo>,
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
+        shredstream_receiver_address: &Option<SocketAddr>,
         shred_receiver_addr: &Option<SocketAddr>,
     ) -> Result<()> {
         trace!("Broadcasting {:?} shreds", shreds.len());
@@ -402,6 +404,7 @@ impl StandardBroadcastRun {
             bank_forks,
             cluster_info.socket_addr_space(),
             quic_endpoint_sender,
+            shredstream_receiver_address,
             shred_receiver_addr,
         )?;
         transmit_time.stop();
@@ -475,7 +478,8 @@ impl BroadcastRun for StandardBroadcastRun {
         sock: BroadcastSocket,
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
-        shred_receiver_address: &Arc<RwLock<Option<SocketAddr>>>,
+        shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        shred_receiver_address: &ArcSwap<Option<SocketAddr>>,
     ) -> Result<()> {
         let (shreds, batch_info) = receiver.recv()?;
         self.broadcast(
@@ -485,7 +489,8 @@ impl BroadcastRun for StandardBroadcastRun {
             batch_info,
             bank_forks,
             quic_endpoint_sender,
-            &shred_receiver_address.read().unwrap(),
+            &shredstream_receiver_address.load(),
+            &shred_receiver_address.load(),
         )
     }
     fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()> {

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -6,6 +6,7 @@ use {
         cluster_nodes::{self, ClusterNodes, ClusterNodesCache, Error, MAX_NUM_TURBINE_HOPS},
         xdp::XdpSender,
     },
+    arc_swap::ArcSwap,
     bytes::Bytes,
     crossbeam_channel::{Receiver, RecvError, TryRecvError},
     lru::LruCache,
@@ -242,7 +243,7 @@ fn retransmit(
     rpc_subscriptions: Option<&RpcSubscriptions>,
     slot_status_notifier: Option<&SlotStatusNotifier>,
     shred_buf: &mut Vec<Vec<shred::Payload>>,
-    shred_receiver_address: &Option<SocketAddr>,
+    shred_receiver_address: &ArcSwap<Option<SocketAddr>>,
 ) -> Result<(), RecvError> {
     // Try to receive shreds from the channel without blocking. If the channel
     // is empty precompute turbine trees speculatively. If no cache updates are
@@ -329,6 +330,7 @@ fn retransmit(
         entry.record(now, out);
         stats
     };
+    let shred_receiver_address_local = shred_receiver_address.load();
     let retransmit_shred = |shred, socket, stats| {
         retransmit_shred(
             shred,
@@ -340,7 +342,7 @@ fn retransmit(
             socket,
             quic_endpoint_sender,
             stats,
-            shred_receiver_address,
+            &shred_receiver_address_local,
         )
     };
 
@@ -607,7 +609,7 @@ impl RetransmitStage {
         rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
         slot_status_notifier: Option<SlotStatusNotifier>,
         xdp_sender: Option<XdpSender>,
-        shred_receiver_addr: Arc<RwLock<Option<SocketAddr>>>,
+        shred_receiver_addr: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> Self {
         let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
             CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
@@ -649,7 +651,7 @@ impl RetransmitStage {
                         rpc_subscriptions.as_deref(),
                         slot_status_notifier.as_ref(),
                         &mut shred_buf,
-                        &shred_receiver_addr.read().unwrap(),
+                        &shred_receiver_addr,
                     )
                     .is_ok()
                     {}

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 agave-geyser-plugin-interface = { workspace = true }
+arc-swap = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 clap = { workspace = true }
 console = { workspace = true }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -270,6 +270,7 @@ pub trait AdminRpc {
         &self,
         meta: Self::Metadata,
         block_engine_url: String,
+        disable_block_engine_autoconfig: bool,
         trust_packets: bool,
     ) -> Result<()>;
 
@@ -527,11 +528,13 @@ impl AdminRpc for AdminRpcImpl {
         &self,
         meta: Self::Metadata,
         block_engine_url: String,
+        disable_block_engine_autoconfig: bool,
         trust_packets: bool,
     ) -> Result<()> {
         debug!("set_block_engine_config request received");
         let config = BlockEngineConfig {
             block_engine_url,
+            disable_block_engine_autoconfig,
             trust_packets,
         };
         // Detailed log messages are printed inside validate function
@@ -623,7 +626,9 @@ impl AdminRpc for AdminRpcImpl {
         };
 
         meta.with_post_init(|post_init| {
-            *post_init.shred_receiver_address.write().unwrap() = shred_receiver_address;
+            post_init
+                .shred_receiver_address
+                .store(Arc::new(shred_receiver_address));
             Ok(())
         })
     }
@@ -645,7 +650,9 @@ impl AdminRpc for AdminRpcImpl {
         };
 
         meta.with_post_init(|post_init| {
-            *post_init.shred_retransmit_receiver_address.write().unwrap() = shred_receiver_address;
+            post_init
+                .shred_retransmit_receiver_address
+                .store(Arc::new(shred_receiver_address));
             Ok(())
         })
     }
@@ -1053,6 +1060,7 @@ pub fn load_staked_nodes_overrides(
 mod tests {
     use {
         super::*,
+        arc_swap::ArcSwap,
         serde_json::Value,
         solana_account::{Account, AccountSharedData},
         solana_accounts_db::{
@@ -1134,8 +1142,8 @@ mod tests {
             let repair_whitelist = Arc::new(RwLock::new(HashSet::new()));
             let block_engine_config = Arc::new(Mutex::new(BlockEngineConfig::default()));
             let relayer_config = Arc::new(Mutex::new(RelayerConfig::default()));
-            let shred_receiver_address = Arc::new(RwLock::new(None));
-            let shred_retransmit_receiver_address = Arc::new(RwLock::new(None));
+            let shred_receiver_address = Arc::new(ArcSwap::default());
+            let shred_retransmit_receiver_address = Arc::new(ArcSwap::default());
             let meta = AdminRpcRequestMetadata {
                 rpc_addr: None,
                 start_time: SystemTime::now(),

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1652,7 +1652,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
     ).arg(
         Arg::with_name("block_engine_url")
             .long("block-engine-url")
-            .help("Block engine url.  Set to empty string to disable block engine connection.")
+            .help("URL entrypoint to the Block Engine. Connected Block Engine will be autoconfigured unless `--disable-block-engine-autoconfig` is used. Set to empty string to disable block engine connection.")
             .takes_value(true)
     )
     .arg(
@@ -1716,6 +1716,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .default_value(&default_args.preallocated_bundle_cost)
             .help("Number of CUs to allocate for bundles at beginning of slot.")
+    )
+    .arg(
+        Arg::with_name("disable_block_engine_autoconfig")
+            .long("disable-block-engine-autoconfig")
+            .value_name("DISABLE_BLOCK_ENGINE_AUTOCONFIG")
+            .takes_value(false)
+            .help("Disables Block Engine auto-configuration. This stops the validator client from using the most performant Block Engine region. Values provided to `--block-engine-url` will be used as-is."),
     )
     .arg(
         Arg::with_name("shred_receiver_address")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -6,6 +6,7 @@ use {
         commands::{run::args::RunArgs, FromClapArgMatches},
         ledger_lockfile, lock_ledger,
     },
+    arc_swap::ArcSwap,
     clap::{crate_name, value_t, value_t_or_exit, values_t, values_t_or_exit, ArgMatches},
     crossbeam_channel::unbounded,
     log::*,
@@ -569,8 +570,9 @@ pub fn execute(
         block_engine_url: if matches.is_present("block_engine_url") {
             value_of(matches, "block_engine_url").expect("couldn't parse block_engine_url")
         } else {
-            "".to_string()
+            String::default()
         },
+        disable_block_engine_autoconfig: matches.is_present("disable_block_engine_autoconfig"),
         trust_packets: matches.is_present("trust_block_engine_packets"),
     }));
 
@@ -599,11 +601,12 @@ pub fn execute(
         ),
     }));
 
-    let shred_receiver_address =
-        Arc::new(RwLock::new(matches.value_of("shred_receiver_address").map(
-            |addr| SocketAddr::from_str(addr).expect("shred_receiver_address invalid"),
-        )));
-    let shred_retransmit_receiver_address = Arc::new(RwLock::new(
+    let shred_receiver_address = Arc::new(ArcSwap::from_pointee(
+        matches
+            .value_of("shred_receiver_address")
+            .map(|addr| SocketAddr::from_str(addr).expect("shred_receiver_address invalid")),
+    ));
+    let shred_retransmit_receiver_address = Arc::new(ArcSwap::from_pointee(
         matches
             .value_of("shred_retransmit_receiver_address")
             .map(|addr| {

--- a/validator/src/commands/shred/mod.rs
+++ b/validator/src/commands/shred/mod.rs
@@ -6,24 +6,24 @@ use {
 
 pub fn shred_receiver_command(_default_args: &DefaultArgs) -> App<'_, '_> {
     SubCommand::with_name("set-shred-receiver-address")
-        .about("Changes shred receiver address")
+        .about("Set shred receiver address")
         .arg(
             Arg::with_name("shred_receiver_address")
                 .long("shred-receiver-address")
                 .value_name("SHRED_RECEIVER_ADDRESS")
                 .takes_value(true)
-                .help("Validator will forward all shreds to this address in addition to normal turbine operation. Set to empty string to disable.")
+                .help("Validator will forward all leader shreds to this address in addition to normal turbine operation. Set to empty string to disable.")
                 .required(true)
         )
 }
 
 pub fn shred_retransmit_receiver_command(_default_args: &DefaultArgs) -> App<'_, '_> {
     SubCommand::with_name("set-shred-retransmit-receiver-address")
-        .about("Changes shred retransmit receiver address")
+        .about("Set shred retransmit receiver address")
         .arg(
-            Arg::with_name("shred_receiver_address")
-                .long("shred-receiver-address")
-                .value_name("SHRED_RECEIVER_ADDRESS")
+            Arg::with_name("shred_retransmit_receiver_address")
+                .long("shred-retransmit-receiver-address")
+                .value_name("SHRED_RETRANSMIT_RECEIVER_ADDRESS")
                 .takes_value(true)
                 .help("Validator will forward all retransmit shreds to this address in addition to normal turbine operation. Set to empty string to disable.")
                 .required(true)
@@ -45,7 +45,11 @@ pub fn set_shred_retransmit_receiver_execute(
     subcommand_matches: &ArgMatches,
     ledger_path: &Path,
 ) -> Result<()> {
-    let addr = value_t_or_exit!(subcommand_matches, "shred_receiver_address", String);
+    let addr = value_t_or_exit!(
+        subcommand_matches,
+        "shred_retransmit_receiver_address",
+        String
+    );
     let admin_client = admin_rpc_service::connect(ledger_path);
     admin_rpc_service::runtime().block_on(async move {
         admin_client


### PR DESCRIPTION
This pull request introduces several changes aimed at improving the handling of configuration by adding support for dynamic Block Engine endpoint discovery. Whenever the connection with the block engine is broken, we automatically try to connect to the best available region.

Changes:

* Implemented dynamic Block Engine endpoint discovery using latency-based selection via a new `ping` utility
* Introduced a `disable_block_engine_autoconfig` flag in `BlockEngineConfig` to allow users to bypass automatic endpoint discovery
* Replaced `RwLock` with `ArcSwap` for `shred_receiver_address` to avoid acquiring a lock per sent shred batch

Port of #923, without the autoconfig default change