### PR TITLE
[v3.1] fix unstaked xdp retransmit to block engine

### DIFF
--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -500,7 +500,7 @@ fn retransmit_shred(
         Protocol::UDP => match socket {
             RetransmitSocket::Xdp(sender) => {
                 let mut sent = num_addrs;
-                if num_addrs > 0 {
+                if (num_addrs > 0) || shred_receiver_addr.is_some() {
                     // shred receiver not included in the stats
                     let mut send_addrs = Vec::with_capacity(num_addrs + 1);
                     send_addrs.extend(addrs.iter());


### PR DESCRIPTION
Reapplication with commit signing of https://github.com/jito-foundation/jito-solana/pull/1090 for v3.1
Credit to @alexpyattaev
