### PR TITLE
Fix priority graph TOCTOU

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -431,7 +431,6 @@ fn try_schedule_transaction<Tx: TransactionWithMeta>(
             return Err(TransactionSchedulingError::UnschedulableConflicts);
         }
     }
-    drop(l_account_locks);
 
     let thread_id = match account_locks.try_lock_accounts(
         write_account_locks,
@@ -449,6 +448,9 @@ fn try_schedule_transaction<Tx: TransactionWithMeta>(
             return Err(TransactionSchedulingError::UnschedulableThread);
         }
     };
+
+    // Avoid time of check time of use race condition between bundle account locker and account locks
+    drop(l_account_locks);
 
     let (transaction, max_age) = transaction_state.take_transaction_for_scheduling();
     let cost = transaction_state.cost();


### PR DESCRIPTION
#### Problem
Time of check time of use bug in jito-solana

#### Summary of Changes
Move dropping the bundle account locks until after the main account lock grabbing

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
