### PR TITLE
feat: add support for multiple shred receivers

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -88,6 +88,6 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub banking_control_sender: mpsc::Sender<BankingControlMsg>,
     pub block_engine_config: Arc<Mutex<BlockEngineConfig>>,
     pub relayer_config: Arc<Mutex<RelayerConfig>>,
-    pub shred_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
-    pub shred_retransmit_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
+    pub shred_receiver_addresses: Arc<ArcSwap<Vec<SocketAddr>>>,
+    pub shred_retransmit_receiver_addresses: Arc<ArcSwap<Vec<SocketAddr>>>,
 }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -199,7 +199,7 @@ impl Tpu {
         block_engine_config: Arc<Mutex<BlockEngineConfig>>,
         relayer_config: Arc<Mutex<RelayerConfig>>,
         tip_manager_config: TipManagerConfig,
-        shred_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
+        shred_receiver_addresses: Arc<ArcSwap<Vec<SocketAddr>>>,
         bam_url: Arc<Mutex<Option<String>>>,
     ) -> Self {
         let TpuSockets {
@@ -543,7 +543,7 @@ impl Tpu {
             turbine_quic_endpoint_sender,
             xdp_sender,
             shredstream_receiver_address,
-            shred_receiver_address,
+            shred_receiver_addresses,
         );
 
         let mut key_notifiers = key_notifiers.write().unwrap();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -174,7 +174,7 @@ impl Tvu {
         wen_restart_repair_slots: Option<Arc<RwLock<Vec<Slot>>>>,
         slot_status_notifier: Option<SlotStatusNotifier>,
         vote_connection_cache: Arc<ConnectionCache>,
-        shred_receiver_addr: Arc<ArcSwap<Option<SocketAddr>>>,
+        shred_receiver_addrs: Arc<ArcSwap<Vec<SocketAddr>>>,
     ) -> Result<Self, String> {
         let in_wen_restart = wen_restart_repair_slots.is_some();
 
@@ -233,7 +233,7 @@ impl Tvu {
             tvu_config.xdp_sender,
             // votor_event_sender is Alpenglow specific sender, it is None if Alpenglow is not enabled.
             None,
-            shred_receiver_addr,
+            shred_receiver_addrs,
         );
 
         let (ancestor_duplicate_slots_sender, ancestor_duplicate_slots_receiver) = unbounded();
@@ -618,7 +618,7 @@ pub mod tests {
             wen_restart_repair_slots,
             None,
             Arc::new(connection_cache),
-            Arc::new(ArcSwap::from_pointee(None)),
+            Arc::new(ArcSwap::from_pointee(vec![])),
         )
         .expect("assume success");
         if enable_wen_restart {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -387,8 +387,8 @@ pub struct ValidatorConfig {
     // jito configuration
     pub relayer_config: Arc<Mutex<RelayerConfig>>,
     pub block_engine_config: Arc<Mutex<BlockEngineConfig>>,
-    pub shred_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
-    pub shred_retransmit_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
+    pub shred_receiver_addresses: Arc<ArcSwap<Vec<SocketAddr>>>,
+    pub shred_retransmit_receiver_addresses: Arc<ArcSwap<Vec<SocketAddr>>>,
     pub tip_manager_config: TipManagerConfig,
     pub bam_url: Arc<Mutex<Option<String>>>,
 }
@@ -476,8 +476,8 @@ impl ValidatorConfig {
             repair_handler_type: RepairHandlerType::default(),
             relayer_config: Arc::new(Mutex::new(RelayerConfig::default())),
             block_engine_config: Arc::new(Mutex::new(BlockEngineConfig::default())),
-            shred_receiver_address: Arc::new(ArcSwap::from_pointee(None)),
-            shred_retransmit_receiver_address: Arc::new(ArcSwap::from_pointee(None)),
+            shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(vec![])),
+            shred_retransmit_receiver_addresses: Arc::new(ArcSwap::from_pointee(vec![])),
             tip_manager_config: TipManagerConfig::default(),
             bam_url: Arc::new(Mutex::new(None)),
         }
@@ -1628,7 +1628,7 @@ impl Validator {
             wen_restart_repair_slots.clone(),
             slot_status_notifier,
             vote_connection_cache,
-            config.shred_retransmit_receiver_address.clone(),
+            config.shred_retransmit_receiver_addresses.clone(),
         )
         .map_err(ValidatorError::Other)?;
 
@@ -1730,7 +1730,7 @@ impl Validator {
             config.block_engine_config.clone(),
             config.relayer_config.clone(),
             config.tip_manager_config.clone(),
-            config.shred_receiver_address.clone(),
+            config.shred_receiver_addresses.clone(),
             config.bam_url.clone(),
         );
 
@@ -1765,8 +1765,8 @@ impl Validator {
             banking_control_sender,
             block_engine_config: config.block_engine_config.clone(),
             relayer_config: config.relayer_config.clone(),
-            shred_receiver_address: config.shred_receiver_address.clone(),
-            shred_retransmit_receiver_address: config.shred_retransmit_receiver_address.clone(),
+            shred_receiver_addresses: config.shred_receiver_addresses.clone(),
+            shred_retransmit_receiver_addresses: config.shred_retransmit_receiver_addresses.clone(),
         });
 
         Ok(Self {

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -84,8 +84,8 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         repair_handler_type: config.repair_handler_type.clone(),
         relayer_config: config.relayer_config.clone(),
         block_engine_config: config.block_engine_config.clone(),
-        shred_receiver_address: config.shred_receiver_address.clone(),
-        shred_retransmit_receiver_address: config.shred_retransmit_receiver_address.clone(),
+        shred_receiver_addresses: config.shred_receiver_addresses.clone(),
+        shred_retransmit_receiver_addresses: config.shred_retransmit_receiver_addresses.clone(),
         tip_manager_config: config.tip_manager_config.clone(),
         bam_url: config.bam_url.clone(),
     }

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -93,7 +93,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
             &SocketAddrSpace::Unspecified,
             &quic_endpoint_sender,
             &None,
-            &None,
+            &[],
         )
         .unwrap();
     });

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -299,7 +299,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         bank_forks: &RwLock<BankForks>,
         _quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        _shred_receiver_addr: &ArcSwap<Option<SocketAddr>>,
+        _shred_receiver_addr: &ArcSwap<Vec<SocketAddr>>,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         if shreds.is_empty() {

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -157,7 +157,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         _bank_forks: &RwLock<BankForks>,
         _quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        _shred_receiver_addr: &ArcSwap<Option<SocketAddr>>,
+        _shred_receiver_addrs: &ArcSwap<Vec<SocketAddr>>,
     ) -> Result<()> {
         let sock = match sock {
             BroadcastSocket::Udp(sock) => sock,

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -183,7 +183,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        shred_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        shred_receiver_addresses: &ArcSwap<Vec<SocketAddr>>,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         broadcast_shreds(
@@ -197,7 +197,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             cluster_info.socket_addr_space(),
             quic_endpoint_sender,
             &shredstream_receiver_address.load(),
-            &shred_receiver_address.load(),
+            &shred_receiver_addresses.load(),
         )
     }
     fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()> {

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -385,7 +385,7 @@ impl StandardBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         shredstream_receiver_address: &Option<SocketAddr>,
-        shred_receiver_addr: &Option<SocketAddr>,
+        shred_receiver_addrs: &[SocketAddr],
     ) -> Result<()> {
         trace!("Broadcasting {:?} shreds", shreds.len());
         let mut transmit_stats = TransmitShredsStats {
@@ -408,7 +408,7 @@ impl StandardBroadcastRun {
             cluster_info.socket_addr_space(),
             quic_endpoint_sender,
             shredstream_receiver_address,
-            shred_receiver_addr,
+            shred_receiver_addrs,
         )?;
         transmit_time.stop();
 
@@ -482,7 +482,7 @@ impl BroadcastRun for StandardBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        shred_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        shred_receiver_addresses: &ArcSwap<Vec<SocketAddr>>,
     ) -> Result<()> {
         let (shreds, batch_info) = receiver.recv()?;
         self.broadcast(
@@ -493,7 +493,7 @@ impl BroadcastRun for StandardBroadcastRun {
             bank_forks,
             quic_endpoint_sender,
             &shredstream_receiver_address.load(),
-            &shred_receiver_address.load(),
+            &shred_receiver_addresses.load(),
         )
     }
     fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()> {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1350,6 +1350,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("shred-receiver-address")
             .value_name("SHRED_RECEIVER_ADDRESS")
             .takes_value(true)
+            .multiple(true)
             .help(
                 "Validator will forward all leader shreds to this address in addition to normal \
                  turbine operation. Set to empty string to disable.",
@@ -1360,6 +1361,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("shred-retransmit-receiver-address")
             .value_name("SHRED_RETRANSMIT_RECEIVER_ADDRESS")
             .takes_value(true)
+            .multiple(true)
             .help(
                 "Validator will forward all retransmit shreds to this address in addition to \
                  normal turbine operation. Set to empty string to disable.",

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -545,17 +545,28 @@ pub fn execute(
         ),
     }));
 
-    let shred_receiver_address = Arc::new(ArcSwap::from_pointee(
+    let shred_receiver_addresses = Arc::new(ArcSwap::from_pointee(
         matches
-            .value_of("shred_receiver_address")
-            .map(|addr| SocketAddr::from_str(addr).expect("shred_receiver_address invalid")),
-    ));
-    let shred_retransmit_receiver_address = Arc::new(ArcSwap::from_pointee(
-        matches
-            .value_of("shred_retransmit_receiver_address")
+            .values_of("shred_receiver_address")
+            .into_iter()
+            .flatten()
             .map(|addr| {
-                SocketAddr::from_str(addr).expect("shred_retransmit_receiver_address invalid")
-            }),
+                SocketAddr::from_str(addr)
+                    .unwrap_or_else(|_| panic!("shred_receiver_address {addr} invalid"))
+            })
+            .collect::<Vec<_>>(),
+    ));
+
+    let shred_retransmit_receiver_addresses = Arc::new(ArcSwap::from_pointee(
+        matches
+            .values_of("shred_retransmit_receiver_address")
+            .into_iter()
+            .flatten()
+            .map(|addr| {
+                SocketAddr::from_str(addr)
+                    .unwrap_or_else(|_| panic!("shred_receiver_address {addr} invalid"))
+            })
+            .collect::<Vec<_>>(),
     ));
 
     let mut validator_config = ValidatorConfig {
@@ -677,8 +688,8 @@ pub fn execute(
         // jito config
         relayer_config,
         block_engine_config,
-        shred_receiver_address,
-        shred_retransmit_receiver_address,
+        shred_receiver_addresses,
+        shred_retransmit_receiver_addresses,
         tip_manager_config,
         bam_url,
     };


### PR DESCRIPTION
#### Problem

The jito client by default only allows a single address for shred receivers right now

#### Summary of Changes

This change allows specifying multiple addresses in the shred receiver related arguments, while preserving complete backwards compatibility. This can also be backported to v3.0 easily, our fork has another branch (https://github.com/Overclock-Validator/jito-solana/tree/v3.0.14-jito-multirecv) for v3.
