### PR TITLE
[v3.1] Reduce BAM Scheduler allocs, remove lock contention in consume_work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,7 @@ version = "3.1.8"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-logger",
+ "arc-swap",
  "assert_matches",
  "clap 3.2.23",
  "crossbeam-channel",
@@ -8446,6 +8447,7 @@ dependencies = [
  "solana-metrics",
  "solana-native-token",
  "solana-net-utils",
+ "solana-nohash-hasher",
  "solana-nonce",
  "solana-nonce-account",
  "solana-packet",

--- a/bam-banking-bench/Cargo.toml
+++ b/bam-banking-bench/Cargo.toml
@@ -17,6 +17,7 @@ agave-unstable-api = []
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
 agave-logger = { workspace = true }
+arc-swap = { workspace = true }
 assert_matches = { workspace = true }
 clap = { version = "3.1.8", features = ["derive", "cargo"] }
 crossbeam-channel = { workspace = true }

--- a/bam-banking-bench/src/main.rs
+++ b/bam-banking-bench/src/main.rs
@@ -3,6 +3,7 @@ mod mock_bam_server;
 
 use {
     crate::mock_bam_server::MockBamServer,
+    arc_swap::ArcSwap,
     assert_matches::assert_matches,
     clap::{crate_description, crate_name, Arg, Command},
     crossbeam_channel::{unbounded, Receiver},
@@ -42,7 +43,7 @@ use {
         collections::HashSet,
         sync::{
             atomic::{AtomicBool, AtomicU8, Ordering},
-            Arc, Mutex, RwLock,
+            Arc, RwLock,
         },
         thread::{sleep, spawn},
         time::{Duration, Instant},
@@ -120,9 +121,9 @@ fn main() {
             Arc::new(keypair),
             SocketAddrSpace::new(true),
         )),
-        block_builder_fee_info: Arc::new(Mutex::new(BlockBuilderFeeInfo::default())),
+        block_builder_fee_info: Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo::default())),
         bank_forks: bank_forks.clone(),
-        bam_node_pubkey: Arc::new(Mutex::new(Pubkey::new_unique())),
+        bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::new_unique())),
     };
 
     let keypairs = (0..matches.value_of_t::<usize>("num_keypairs").unwrap())

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -133,6 +133,7 @@ solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-native-token = { workspace = true }
 solana-net-utils = { workspace = true, features = ["agave-unstable-api"] }
+solana-nohash-hasher = { workspace = true }
 solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-packet = { workspace = true }

--- a/core/src/bam_dependencies.rs
+++ b/core/src/bam_dependencies.rs
@@ -1,8 +1,9 @@
 /// Dependencies that are needed for the BAM (Jito Scheduler Service) to function.
 /// All-in-one for convenience.
-use std::sync::{atomic::AtomicU8, Arc, Mutex};
+use std::sync::{atomic::AtomicU8, Arc};
 use {
     crate::proxy::block_engine_stage::BlockBuilderFeeInfo,
+    arc_swap::ArcSwap,
     jito_protos::proto::{
         bam_api::{scheduler_message::VersionedMsg, SchedulerMessage, SchedulerMessageV0},
         bam_types,
@@ -50,9 +51,9 @@ pub struct BamDependencies {
     pub outbound_receiver: crossbeam_channel::Receiver<BamOutboundMessage>,
 
     pub cluster_info: Arc<ClusterInfo>,
-    pub block_builder_fee_info: Arc<Mutex<BlockBuilderFeeInfo>>,
+    pub block_builder_fee_info: Arc<ArcSwap<BlockBuilderFeeInfo>>,
     pub bank_forks: Arc<RwLock<BankForks>>,
-    pub bam_node_pubkey: Arc<Mutex<Pubkey>>,
+    pub bam_node_pubkey: Arc<ArcSwap<Pubkey>>,
 }
 
 pub fn v0_to_versioned_proto(v0: SchedulerMessageV0) -> SchedulerMessage {

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -10,6 +10,7 @@ use {
         proxy::block_engine_stage::BlockBuilderFeeInfo, tip_manager::TipManager,
     },
     ahash::AHashSet,
+    arc_swap::ArcSwap,
     itertools::Itertools,
     solana_accounts_db::accounts::TransactionAccountLocksIterator,
     solana_clock::MAX_PROCESSING_AGE,
@@ -103,7 +104,7 @@ pub struct LeaderProcessedTransactionCounts {
 pub struct TipProcessingDependencies {
     pub tip_manager: TipManager,
     pub last_tip_updated_slot: Arc<Mutex<u64>>,
-    pub block_builder_fee_info: Arc<Mutex<BlockBuilderFeeInfo>>,
+    pub block_builder_fee_info: Arc<ArcSwap<BlockBuilderFeeInfo>>,
     pub cluster_info: Arc<ClusterInfo>,
     pub bundle_account_locker: BundleAccountLocker,
 }
@@ -162,18 +163,10 @@ impl Consumer {
         let check_results =
             bank.check_transactions(txs, &pre_results, MAX_PROCESSING_AGE, &mut error_counters);
 
-        let check_results: Vec<_> = check_results
-            .into_iter()
-            .map(|result| match result {
-                Ok(_) => Ok(()),
-                Err(err) => Err(err),
-            })
-            .collect();
-
         let mut output = self.process_and_record_transactions_with_pre_results(
             bank,
             txs,
-            check_results.into_iter(),
+            check_results.into_iter().map(|result| result.map(|_| ())),
             reservation_cb,
             Some(bundle_account_locker),
             revert_on_error,
@@ -263,25 +256,23 @@ impl Consumer {
                 .zip(txs.iter())
                 .map(|(r, tx)| match r {
                     Ok(_cost) => {
-                        if let Some(l_bundle_account_locker) = &l_bundle_account_locker {
-                            let transactions_account_locks =
-                                TransactionAccountLocksIterator::new(tx)
-                                    .accounts_with_is_writable();
-                            for (acc, writable) in transactions_account_locks {
-                                let is_writable_conflict = writable
-                                    && (l_bundle_account_locker.write_locks().contains_key(acc)
-                                        || l_bundle_account_locker.read_locks().contains_key(acc));
-                                let is_read_conflict = !writable
-                                    && l_bundle_account_locker.write_locks().contains_key(acc);
+                        let Some(l_bundle_account_locker) = &l_bundle_account_locker else {
+                            return Ok(());
+                        };
+                        let transactions_account_locks =
+                            TransactionAccountLocksIterator::new(tx).accounts_with_is_writable();
+                        for (acc, writable) in transactions_account_locks {
+                            let is_writable_conflict = writable
+                                && (l_bundle_account_locker.write_locks().contains_key(acc)
+                                    || l_bundle_account_locker.read_locks().contains_key(acc));
+                            let is_read_conflict = !writable
+                                && l_bundle_account_locker.write_locks().contains_key(acc);
 
-                                if is_writable_conflict || is_read_conflict {
-                                    return Err(TransactionError::AccountInUse);
-                                }
+                            if is_writable_conflict || is_read_conflict {
+                                return Err(TransactionError::AccountInUse);
                             }
-                            Ok(())
-                        } else {
-                            Ok(())
                         }
+                        Ok(())
                     }
                     Err(err) => Err(err.clone()),
                 }),
@@ -451,11 +442,6 @@ impl Consumer {
         let successful_count = load_and_execute_transactions_output
             .processed_counts
             .processed_with_successful_result_count as usize;
-        let transaction_errors = load_and_execute_transactions_output
-            .processing_results
-            .iter()
-            .map(|result| result.flattened_result().err())
-            .collect_vec();
 
         if revert_on_error && successful_count != batch.sanitized_transactions().len() {
             return ExecuteAndCommitTransactionsOutput {
@@ -464,14 +450,14 @@ impl Consumer {
                     ..Default::default()
                 },
                 retryable_transaction_indexes,
-                commit_transactions_result: Ok((0..batch.sanitized_transactions().len())
-                    .map(|index| {
+                commit_transactions_result: Ok(load_and_execute_transactions_output
+                    .processing_results
+                    .iter()
+                    .map(|result| {
                         CommitTransactionDetails::NotCommitted(
-                            transaction_errors
-                                .get(index)
-                                .map(|error| {
-                                    error.clone().unwrap_or(TransactionError::CommitCancelled)
-                                })
+                            result
+                                .flattened_result()
+                                .err()
                                 .unwrap_or(TransactionError::CommitCancelled),
                         )
                     })
@@ -515,18 +501,16 @@ impl Consumer {
             attempted_processing_count: processing_results.len() as u64,
         };
 
-        let (processed_transactions, processing_results_to_transactions_us) =
-            measure_us!(processing_results
-                .iter()
-                .zip(batch.sanitized_transactions())
-                .filter_map(|(processing_result, tx)| {
-                    if processing_result.was_processed() {
-                        Some((tx.to_versioned_transaction(), tx))
-                    } else {
-                        None
-                    }
-                })
-                .collect_vec());
+        let processed_transactions = processing_results
+            .iter()
+            .zip(batch.sanitized_transactions())
+            .filter_map(|(processing_result, tx)| {
+                if processing_result.was_processed() {
+                    Some((tx.to_versioned_transaction(), tx))
+                } else {
+                    None
+                }
+            });
 
         let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
         execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
@@ -536,9 +520,8 @@ impl Consumer {
         // Entries do **not** yet support conflicting transactions. To get around this we create
         // lists of transactions that are non-conflicting to shred out into entries. If we don't do
         // this, then blocks are rejected by consensus/replay.
-        let batches = Self::create_sequential_non_conflicting_batches(
-            &mut reusables,
-            processed_transactions.into_iter(),
+        let (batches, prepare_record_transactions_us) = measure_us!(
+            Self::create_sequential_non_conflicting_batches(&mut reusables, processed_transactions)
         );
         self.seq_not_conflict_batch_reusables.set(reusables);
         let hashes = batches
@@ -557,9 +540,7 @@ impl Consumer {
             starting_transaction_index,
         } = record_transactions_summary;
         execute_and_commit_timings.record_transactions_timings = RecordTransactionsTimings {
-            processing_results_to_transactions_us: Saturating(
-                processing_results_to_transactions_us,
-            ),
+            prepare_record_transactions_us: Saturating(prepare_record_transactions_us),
             ..record_transactions_timings
         };
 
@@ -680,7 +661,9 @@ impl Consumer {
             }
 
             if has_contention {
-                result.push(std::mem::take(&mut current_batch));
+                let mut finished_batch = Vec::with_capacity(current_batch.len());
+                finished_batch.append(&mut current_batch);
+                result.push(finished_batch);
                 aggregate_write_locks.clear();
                 aggregate_read_locks.clear();
             }

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -45,9 +45,9 @@ impl LeaderExecuteAndCommitTimings {
             "banking_stage-leader_slot_vote_record_timings",
             ("slot", slot as i64, i64),
             (
-                "processing_results_to_transactions_us",
+                "prepare_record_transactions_us",
                 self.record_transactions_timings
-                    .processing_results_to_transactions_us
+                    .prepare_record_transactions_us
                     .0 as i64,
                 i64
             ),

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -7,7 +7,7 @@ use {
 };
 
 /// A unique identifier for a transaction batch.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TransactionBatchId(pub u64);
 
 impl TransactionBatchId {
@@ -15,6 +15,14 @@ impl TransactionBatchId {
         Self(index)
     }
 }
+
+impl std::hash::Hash for TransactionBatchId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write_u64(self.0)
+    }
+}
+
+impl solana_nohash_hasher::IsEnabled for TransactionBatchId {}
 
 impl Display for TransactionBatchId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -14,6 +14,7 @@ use {
             decision_maker::BufferedPacketsDecision,
             scheduler_messages::MaxAge,
             transaction_scheduler::{
+                bam_scheduler::MAX_PACKETS_PER_BUNDLE,
                 bam_utils::convert_txn_error_to_proto,
                 receive_and_buffer::{
                     calculate_max_age, calculate_priority_and_cost, DisconnectedError,
@@ -35,6 +36,7 @@ use {
         atomic_txn_batch_result, not_committed::Reason, AtomicTxnBatch, DeserializationErrorReason,
         Packet, SchedulingError, TransactionErrorReason,
     },
+    smallvec::SmallVec,
     solana_accounts_db::account_locks::validate_account_locks,
     solana_clock::{Slot, MAX_PROCESSING_AGE},
     solana_measure::{measure::Measure, measure_us},
@@ -71,10 +73,12 @@ pub struct BamReceiveAndBuffer {
 }
 
 struct ParsedBatch {
-    pub txns_max_age: Vec<(
-        RuntimeTransaction<ResolvedTransactionView<SharedBytes>>,
-        MaxAge,
-    )>,
+    pub txns_max_age: SmallVec<
+        [(
+            RuntimeTransaction<ResolvedTransactionView<SharedBytes>>,
+            MaxAge,
+        ); MAX_PACKETS_PER_BUNDLE],
+    >,
     pub cost: u64,
     priority: u64,
     pub revert_on_error: bool,
@@ -133,16 +137,17 @@ impl BamReceiveAndBuffer {
         let mut last_metrics_report = Instant::now();
         let mut metrics = BamReceiveAndBufferMetrics::default();
         let mut stats = ReceivingStats::default();
-        let mut prevalidated = Vec::new();
-        let mut packet_batches = Vec::new();
-        let mut verify_results = Vec::new();
+        let mut prevalidated = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
+        let mut packet_batches = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
+        let mut verify_results = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
         const METRICS_REPORT_INTERVAL: Duration = Duration::from_millis(20);
         let mut recv_buffer = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST * 2);
 
         while !exit.load(Ordering::Relaxed) {
-            if last_metrics_report.elapsed() > METRICS_REPORT_INTERVAL {
+            let loop_start = Instant::now();
+            if loop_start.duration_since(last_metrics_report) > METRICS_REPORT_INTERVAL {
                 metrics.report();
-                last_metrics_report = Instant::now();
+                last_metrics_report = loop_start;
                 let _ = recv_stats_sender.try_send(stats);
                 stats = ReceivingStats::default();
             }
@@ -304,25 +309,24 @@ impl BamReceiveAndBuffer {
         let enable_static_instruction_limit = root_bank
             .feature_set
             .is_active(&agave_feature_set::static_instruction_limit::ID);
-
         let mut cost: u64 = 0;
-        let mut txns_max_age = Vec::with_capacity(verified_batch.len());
+        let mut txns_max_age = SmallVec::with_capacity(verified_batch.len());
+
+        if vote_only {
+            return (
+                Err(Reason::DeserializationError(
+                    jito_protos::proto::bam_types::DeserializationError {
+                        index: 0,
+                        reason: DeserializationErrorReason::SanitizeError as i32,
+                    },
+                )),
+                stats,
+            );
+        }
 
         // Checks are taken from receive_and_buffer.rs:
         // SanitizedTransactionReceiveAndBuffer::buffer_packets
         for (index, verified_packet) in verified_batch.into_iter().enumerate() {
-            if vote_only {
-                return (
-                    Err(Reason::DeserializationError(
-                        jito_protos::proto::bam_types::DeserializationError {
-                            index: index as u32,
-                            reason: DeserializationErrorReason::SanitizeError as i32,
-                        },
-                    )),
-                    stats,
-                );
-            }
-
             // Parsing and basic sanitization checks
             let sanitization_start = Instant::now();
             let Ok(view) = SanitizedTransactionView::try_new_sanitized(
@@ -602,7 +606,7 @@ impl BamReceiveAndBuffer {
                     ));
                 }
 
-                if atomic_txn_batch.packets.len() > 5 {
+                if atomic_txn_batch.packets.len() > MAX_PACKETS_PER_BUNDLE {
                     stats.num_dropped_without_parsing += 1;
                     return Err((
                         Reason::DeserializationError(

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -25,7 +25,6 @@ use {
             },
         },
     },
-    ahash::HashMap,
     crossbeam_channel::{Receiver, Sender},
     histogram::Histogram,
     itertools::Itertools,
@@ -33,7 +32,9 @@ use {
         atomic_txn_batch_result, not_committed::Reason, SchedulingError,
     },
     prio_graph::{AccessKind, GraphNode, PrioGraph},
+    smallvec::SmallVec,
     solana_clock::{Slot, MAX_PROCESSING_AGE},
+    solana_nohash_hasher::IntMap,
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -62,15 +63,18 @@ fn passthrough_priority(
     *id
 }
 
+pub const MAX_PACKETS_PER_BUNDLE: usize = 5; // copied from BundleStorage::MAX_PACKETS_PER_BUNDLE
+
 pub struct BamScheduler<Tx: TransactionWithMeta> {
     consume_work_sender: Sender<ConsumeWork<Tx>>,
     finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
     response_sender: Sender<BamOutboundMessage>,
 
     next_batch_id: u64,
-    inflight_batch_info: HashMap<TransactionBatchId, InflightBatchInfo>,
+    inflight_batch_info: IntMap<TransactionBatchId, InflightBatchInfo>,
     prio_graph: SchedulerPrioGraph,
-    insertion_to_prio_graph_time: HashMap<u32, Instant>,
+    /// seq_id is the key
+    insertion_to_prio_graph_time: IntMap<u32, Instant>,
     time_in_priograph_us: Histogram,
     time_in_worker_us: Histogram,
     time_between_schedule_us: Histogram,
@@ -79,7 +83,7 @@ pub struct BamScheduler<Tx: TransactionWithMeta> {
 
     // Reusable objects to avoid allocations
     reusable_consume_work: Vec<ConsumeWork<Tx>>,
-    reusable_priority_ids: Vec<Vec<TransactionPriorityId>>,
+    reusable_priority_ids: Vec<SmallVec<[TransactionPriorityId; 1]>>,
 
     extra_checks_enabled: bool,
     bank_forks: Arc<RwLock<BankForks>>,
@@ -90,7 +94,7 @@ pub struct BamScheduler<Tx: TransactionWithMeta> {
 // 'non-revert_on_error' batches that are scheduled together.
 struct InflightBatchInfo {
     pub schedule_time: Instant,
-    pub batch_priority_ids: Vec<TransactionPriorityId>,
+    pub batch_priority_ids: SmallVec<[TransactionPriorityId; 1]>,
     pub slot: Slot,
 }
 
@@ -106,9 +110,9 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             finished_consume_work_receiver,
             response_sender,
             next_batch_id: 0,
-            inflight_batch_info: HashMap::default(),
+            inflight_batch_info: IntMap::default(),
             prio_graph: PrioGraph::new(passthrough_priority),
-            insertion_to_prio_graph_time: HashMap::default(),
+            insertion_to_prio_graph_time: IntMap::default(),
             time_in_priograph_us: Histogram::new(),
             time_in_worker_us: Histogram::new(),
             time_between_schedule_us: Histogram::new(),
@@ -163,15 +167,15 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             let txns = batch_ids
                 .iter()
                 .filter_map(|txn_id| container.get_transaction(*txn_id))
-                .collect_vec();
+                .collect::<SmallVec<[&Tx; MAX_PACKETS_PER_BUNDLE]>>();
 
             if self.extra_checks_enabled {
-                let lock_results = (0..txns.len())
-                    .map(|_| Ok(()))
-                    .collect::<Vec<solana_transaction_error::TransactionResult<()>>>();
+                let lock_results: SmallVec<
+                    [solana_transaction_error::TransactionResult<()>; MAX_PACKETS_PER_BUNDLE],
+                > = SmallVec::from_elem(Ok(()), txns.len());
                 let check_result = working_bank.check_transactions::<Tx>(
                     &txns,
-                    lock_results.as_slice(),
+                    &lock_results,
                     MAX_PROCESSING_AGE,
                     &mut TransactionErrorMetrics::default(),
                 );
@@ -180,6 +184,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                     .find_position(|res| res.is_err())
                     .map(|(i, res)| (i, res.as_ref().err().unwrap().clone()))
                 {
+                    drop(txns);
                     container.remove_by_id(next_batch_id.id);
 
                     let seq_id = priority_to_seq_id(next_batch_id.priority);
@@ -242,17 +247,19 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
 
             // Filter on check_transactions
             if self.extra_checks_enabled {
-                let sanitized_txs = batch_ids
-                    .iter()
-                    .filter_map(|txn_id| container.get_transaction(*txn_id))
-                    .map(|txn| txn.borrow())
-                    .collect::<Vec<_>>();
-                let lock_results = (0..sanitized_txs.len())
-                    .map(|_| Ok(()))
-                    .collect::<Vec<solana_transaction_error::TransactionResult<()>>>();
+                let mut sanitized_txs: SmallVec<[&Tx; MAX_PACKETS_PER_BUNDLE]> = SmallVec::new();
+                let mut lock_results: SmallVec<
+                    [solana_transaction_error::TransactionResult<()>; MAX_PACKETS_PER_BUNDLE],
+                > = SmallVec::new();
+                for txn_id in batch_ids.iter() {
+                    if let Some(txn) = container.get_transaction(*txn_id) {
+                        sanitized_txs.push(txn.borrow());
+                        lock_results.push(Ok(()));
+                    }
+                }
                 let check_result = working_bank.check_transactions::<Tx>(
                     &sanitized_txs,
-                    lock_results.as_slice(),
+                    &lock_results,
                     MAX_PROCESSING_AGE,
                     &mut TransactionErrorMetrics::default(),
                 );
@@ -261,6 +268,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                     .find_position(|res| res.is_err())
                     .map(|(i, res)| (i, res.as_ref().err().unwrap().clone()))
                 {
+                    drop(sanitized_txs);
                     container.remove_by_id(id.id);
                     self.prio_graph.unblock(&id);
 
@@ -283,13 +291,13 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             let batch_id = self.get_next_schedule_id();
             *num_scheduled += batch_ids.len();
             Self::generate_work(&mut work, batch_id, &[id], revert_on_error, container, slot);
-            self.send_to_worker(vec![id], work, slot);
+            self.send_to_worker(SmallVec::from([id]), work, slot);
         }
     }
 
     fn send_to_worker(
         &mut self,
-        priority_ids: Vec<TransactionPriorityId>,
+        priority_ids: SmallVec<[TransactionPriorityId; 1]>,
         work: ConsumeWork<Tx>,
         slot: Slot,
     ) {
@@ -319,8 +327,8 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             ConsumeWork {
                 batch_id: TransactionBatchId::new(0),
                 ids: Vec::with_capacity(1),
-                transactions: Vec::with_capacity(5),
-                max_ages: Vec::with_capacity(5),
+                transactions: Vec::with_capacity(MAX_PACKETS_PER_BUNDLE),
+                max_ages: Vec::with_capacity(MAX_PACKETS_PER_BUNDLE),
                 revert_on_error: false,
                 respond_with_extra_info: false,
                 max_schedule_slot: None,
@@ -336,7 +344,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         self.reusable_consume_work.push(work);
     }
 
-    fn recycle_priority_ids(&mut self, mut priority_ids: Vec<TransactionPriorityId>) {
+    fn recycle_priority_ids(&mut self, mut priority_ids: SmallVec<[TransactionPriorityId; 1]>) {
         priority_ids.clear();
         self.reusable_priority_ids.push(priority_ids);
     }
@@ -800,7 +808,7 @@ mod tests {
                 tests::create_slow_genesis_config,
                 transaction_scheduler::{
                     bam_receive_and_buffer::seq_id_to_priority,
-                    bam_scheduler::BamScheduler,
+                    bam_scheduler::{BamScheduler, MAX_PACKETS_PER_BUNDLE},
                     scheduler::{PreLockFilterAction, Scheduler},
                     transaction_state_container::{StateContainer, TransactionStateContainer},
                 },
@@ -812,6 +820,7 @@ mod tests {
             atomic_txn_batch_result::Result::{Committed, NotCommitted},
             TransactionCommittedResult,
         },
+        smallvec::SmallVec,
         solana_compute_budget_interface::ComputeBudgetInstruction,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -904,8 +913,12 @@ mod tests {
                 compute_unit_price,
             );
             const TEST_TRANSACTION_COST: u64 = 5000;
+            let mut txns_max_age: SmallVec<
+                [(RuntimeTransaction<SanitizedTransaction>, MaxAge); MAX_PACKETS_PER_BUNDLE],
+            > = SmallVec::new();
+            txns_max_age.push((transaction, MaxAge::MAX));
             container.insert_new_batch(
-                vec![(transaction, MaxAge::MAX)],
+                txns_max_age,
                 compute_unit_price,
                 TEST_TRANSACTION_COST,
                 false,

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -21,7 +21,9 @@ use {
         tip_manager::TipManager,
     },
     ahash::HashSet,
+    arc_swap::ArcSwap,
     crossbeam_channel::{Receiver, RecvTimeoutError},
+    smallvec::SmallVec,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
@@ -40,7 +42,7 @@ use {
         ops::Deref,
         sync::{
             atomic::{AtomicBool, Ordering},
-            Arc, Mutex, RwLock,
+            Arc, RwLock,
         },
         thread::{self, Builder, JoinHandle},
         time::{Duration, Instant},
@@ -344,7 +346,7 @@ impl BundleStage {
         exit: Arc<AtomicBool>,
         tip_manager: TipManager,
         bundle_account_locker: BundleAccountLocker,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         blacklisted_accounts: HashSet<Pubkey>,
     ) -> Self {
@@ -383,7 +385,7 @@ impl BundleStage {
         exit: Arc<AtomicBool>,
         tip_manager: TipManager,
         bundle_account_locker: BundleAccountLocker,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         blacklisted_accounts: HashSet<Pubkey>,
     ) -> Self {
@@ -434,7 +436,7 @@ impl BundleStage {
         blacklisted_accounts: HashSet<Pubkey>,
         bundle_account_locker: BundleAccountLocker,
         tip_manager: TipManager,
-        block_builder_fee_info: Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: Arc<ArcSwap<BlockBuilderFeeInfo>>,
         cluster_info: Arc<ClusterInfo>,
     ) {
         let mut last_metrics_update = Instant::now();
@@ -571,7 +573,7 @@ impl BundleStage {
         bundle_account_locker: &BundleAccountLocker,
         bundle_stage_metrics: &mut BundleStageLoopMetrics,
         last_tip_update_slot: &mut Slot,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         tip_manager: &TipManager,
         cluster_info: &Arc<ClusterInfo>,
         consume_worker_metrics: &ConsumeWorkerMetrics,
@@ -613,7 +615,7 @@ impl BundleStage {
         consumer: &mut BundleConsumer,
         bundle_stage_metrics: &mut BundleStageLoopMetrics,
         last_tip_update_slot: &mut Slot,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         tip_manager: &TipManager,
         cluster_info: &Arc<ClusterInfo>,
         consume_worker_metrics: &ConsumeWorkerMetrics,
@@ -727,7 +729,7 @@ impl BundleStage {
         consumer: &mut BundleConsumer,
         tip_manager: &TipManager,
         cluster_info: &Arc<ClusterInfo>,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         consume_worker_metrics: &ConsumeWorkerMetrics,
     ) -> BundleExecutionResult<()> {
         let keypair = cluster_info.keypair();
@@ -772,13 +774,12 @@ impl BundleStage {
             return Ok(());
         }
 
-        let max_ages = vec![
-            MaxAge {
-                sanitized_epoch: bank.epoch(),
-                alt_invalidation_slot: bank.slot(),
-            };
-            initialize_tip_program_transactions.len()
-        ];
+        let max_age = MaxAge {
+            sanitized_epoch: bank.epoch(),
+            alt_invalidation_slot: bank.slot(),
+        };
+        let max_ages: SmallVec<[MaxAge; 2]> =
+            SmallVec::from_elem(max_age, initialize_tip_program_transactions.len());
         let _ = bundle_account_locker.lock_bundle(&initialize_tip_program_transactions, bank);
         let output = consumer.process_and_record_aged_transactions(
             bank,
@@ -809,12 +810,13 @@ impl BundleStage {
         bundle_account_locker: &BundleAccountLocker,
         consumer: &mut BundleConsumer,
         tip_manager: &TipManager,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         consume_worker_metrics: &ConsumeWorkerMetrics,
         keypair: &Keypair,
     ) -> BundleExecutionResult<()> {
+        let block_builder_fee_info = block_builder_fee_info.load();
         let crank_tip_program_transactions = tip_manager
-            .get_tip_programs_crank_bundle(bank, keypair, &block_builder_fee_info.lock().unwrap())
+            .get_tip_programs_crank_bundle(bank, keypair, &block_builder_fee_info)
             .map_err(|e| {
                 warn!("tip programs crank error: {e:?}");
                 BundleExecutionError::TipError
@@ -824,13 +826,12 @@ impl BundleStage {
             return Ok(());
         }
 
-        let max_ages = vec![
-            MaxAge {
-                sanitized_epoch: bank.epoch(),
-                alt_invalidation_slot: bank.slot(),
-            };
-            crank_tip_program_transactions.len()
-        ];
+        let max_age = MaxAge {
+            sanitized_epoch: bank.epoch(),
+            alt_invalidation_slot: bank.slot(),
+        };
+        let max_ages: SmallVec<[MaxAge; 2]> =
+            SmallVec::from_elem(max_age, crank_tip_program_transactions.len());
         let _ = bundle_account_locker.lock_bundle(&crank_tip_program_transactions, bank);
         let output = consumer.process_and_record_aged_transactions(
             bank,
@@ -1093,7 +1094,7 @@ mod tests {
                 },
             }),
             BundleAccountLocker::default(),
-            &Arc::new(Mutex::new(BlockBuilderFeeInfo {
+            &Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
                 block_builder: genesis_config_info.validator_pubkey,
                 block_builder_commission: 10,
             })),
@@ -1231,7 +1232,7 @@ mod tests {
                 },
             }),
             BundleAccountLocker::default(),
-            &Arc::new(Mutex::new(BlockBuilderFeeInfo {
+            &Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
                 block_builder: genesis_config_info.validator_pubkey,
                 block_builder_commission: 10,
             })),
@@ -1324,7 +1325,7 @@ mod tests {
                 },
             }),
             BundleAccountLocker::default(),
-            &Arc::new(Mutex::new(BlockBuilderFeeInfo {
+            &Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
                 block_builder: genesis_config_info.validator_pubkey,
                 block_builder_commission: 10,
             })),
@@ -1448,7 +1449,7 @@ mod tests {
                 },
             }),
             BundleAccountLocker::default(),
-            &Arc::new(Mutex::new(BlockBuilderFeeInfo {
+            &Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
                 block_builder: genesis_config_info.validator_pubkey,
                 block_builder_commission: 10,
             })),
@@ -1572,7 +1573,7 @@ mod tests {
                 },
             }),
             BundleAccountLocker::default(),
-            &Arc::new(Mutex::new(BlockBuilderFeeInfo {
+            &Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
                 block_builder: genesis_config_info.validator_pubkey,
                 block_builder_commission: 10,
             })),

--- a/core/src/bundle_stage/bundle_consumer.rs
+++ b/core/src/bundle_stage/bundle_consumer.rs
@@ -409,7 +409,7 @@ impl BundleConsumer {
             attempted_processing_count: processing_results.len() as u64,
         };
 
-        let (processed_transactions, processing_results_to_transactions_us) =
+        let (processed_transactions, prepare_record_transactions_us) =
             measure_us!(processing_results
                 .iter()
                 .zip(batch.sanitized_transactions())
@@ -438,9 +438,7 @@ impl BundleConsumer {
             starting_transaction_index,
         } = record_transactions_summary;
         execute_and_commit_timings.record_transactions_timings = RecordTransactionsTimings {
-            processing_results_to_transactions_us: Saturating(
-                processing_results_to_transactions_us,
-            ),
+            prepare_record_transactions_us: Saturating(prepare_record_transactions_us),
             ..record_transactions_timings
         };
 

--- a/core/src/bundle_stage/bundle_storage.rs
+++ b/core/src/bundle_stage/bundle_storage.rs
@@ -182,6 +182,10 @@ impl BundleStorage {
 
         let mut container_ids: Vec<usize> = Vec::with_capacity(batch.len());
         let mut maybe_error = Ok(());
+        let enable_static_instruction_limit = working_bank
+            .feature_set
+            .is_active(&agave_feature_set::static_instruction_limit::id());
+        let transaction_account_lock_limit = working_bank.get_transaction_account_lock_limit();
 
         for (idx, packet) in batch.iter().enumerate() {
             // bundles shall contain all valid packets; checked above
@@ -195,10 +199,8 @@ impl BundleStorage {
                         bytes,
                         root_bank,
                         working_bank,
-                        working_bank
-                            .feature_set
-                            .is_active(&agave_feature_set::static_instruction_limit::id()),
-                        working_bank.get_transaction_account_lock_limit(),
+                        enable_static_instruction_limit,
+                        transaction_account_lock_limit,
                         blacklisted_accounts,
                     ) {
                         Ok(state) => Ok(state),

--- a/core/src/proxy/block_engine_stage.rs
+++ b/core/src/proxy/block_engine_stage.rs
@@ -128,7 +128,7 @@ impl BlockEngineStage {
         // Channel that trusted packets get piped through.
         banking_packet_sender: BankingPacketSender,
         exit: Arc<AtomicBool>,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         bam_enabled: Arc<AtomicU8>,
     ) -> Self {
@@ -175,7 +175,7 @@ impl BlockEngineStage {
         packet_tx: Sender<PacketBatch>,
         banking_packet_sender: BankingPacketSender,
         exit: Arc<AtomicBool>,
-        block_builder_fee_info: Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: Arc<ArcSwap<BlockBuilderFeeInfo>>,
         shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         bam_enabled: Arc<AtomicU8>,
     ) {
@@ -236,7 +236,7 @@ impl BlockEngineStage {
         packet_tx: &Sender<PacketBatch>,
         banking_packet_sender: &BankingPacketSender,
         exit: &Arc<AtomicBool>,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         shredstream_receiver_address: &Arc<ArcSwap<Option<SocketAddr>>>,
         local_block_engine_config: &BlockEngineConfig,
         bam_enabled: &Arc<AtomicU8>,
@@ -325,7 +325,7 @@ impl BlockEngineStage {
         packet_tx: &Sender<PacketBatch>,
         banking_packet_sender: &BankingPacketSender,
         exit: &Arc<AtomicBool>,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         shredstream_receiver_address: &Arc<ArcSwap<Option<SocketAddr>>>,
         bam_enabled: &Arc<AtomicU8>,
     ) -> crate::proxy::Result<()> {
@@ -493,7 +493,7 @@ impl BlockEngineStage {
         packet_tx: &Sender<PacketBatch>,
         banking_packet_sender: &BankingPacketSender,
         exit: &Arc<AtomicBool>,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         connection_timeout: &Duration,
         bam_enabled: &Arc<AtomicU8>,
     ) -> crate::proxy::Result<()> {
@@ -735,7 +735,7 @@ impl BlockEngineStage {
         global_config: &Arc<Mutex<BlockEngineConfig>>, // guarded reference for detecting run-time updates
         banking_packet_sender: &BankingPacketSender,
         exit: &Arc<AtomicBool>,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         auth_client: AuthServiceClient<Channel>,
         access_token: Arc<Mutex<Token>>,
         refresh_token: Token,
@@ -775,11 +775,20 @@ impl BlockEngineStage {
         .map_err(|err| Self::map_bam_enabled(bam_enabled, err))?
         .into_inner();
         {
-            let mut bb_fee = block_builder_fee_info.lock().unwrap();
-            bb_fee.block_builder_commission = block_builder_info.commission;
-            if let Ok(pk) = Pubkey::from_str(&block_builder_info.pubkey) {
-                bb_fee.block_builder = pk
-            }
+            let block_builder_pubkey =
+                Pubkey::from_str(&block_builder_info.pubkey).unwrap_or_else(|_| {
+                    datapoint_warn!(
+                        "block_engine_stage-block_builder_pubkey_parse_error",
+                        ("url", &block_engine_url, String),
+                        ("pubkey", &block_builder_info.pubkey, String),
+                        ("count", 1, i64),
+                    );
+                    block_builder_fee_info.load().block_builder
+                });
+            block_builder_fee_info.store(Arc::new(BlockBuilderFeeInfo {
+                block_builder: block_builder_pubkey,
+                block_builder_commission: block_builder_info.commission,
+            }));
         }
 
         Self::consume_bundle_and_packet_stream(
@@ -817,7 +826,7 @@ impl BlockEngineStage {
         global_config: &Arc<Mutex<BlockEngineConfig>>, // guarded reference for detecting run-time updates
         banking_packet_sender: &BankingPacketSender,
         exit: &Arc<AtomicBool>,
-        block_builder_fee_info: &Arc<Mutex<BlockBuilderFeeInfo>>,
+        block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         mut auth_client: AuthServiceClient<Channel>,
         access_token: Arc<Mutex<Token>>,
         mut refresh_token: Token,
@@ -913,13 +922,20 @@ impl BlockEngineStage {
                     .map_err(|e| ProxyError::MethodError(e.to_string()))
                     .map_err(|err| Self::map_bam_enabled(bam_enabled, err))?
                     .into_inner();
-                    {
-                        let mut bb_fee = block_builder_fee_info.lock().unwrap();
-                        bb_fee.block_builder_commission = block_builder_info.commission;
-                        if let Ok(pk) = Pubkey::from_str(&block_builder_info.pubkey) {
-                            bb_fee.block_builder = pk
-                        }
-                    }
+                    let block_builder_pubkey =
+                        Pubkey::from_str(&block_builder_info.pubkey).unwrap_or_else(|_| {
+                            datapoint_warn!(
+                                "block_engine_stage-block_builder_pubkey_parse_error",
+                                ("url", &block_engine_url, String),
+                                ("pubkey", &block_builder_info.pubkey, String),
+                                ("count", 1, i64),
+                            );
+                            block_builder_fee_info.load().block_builder
+                        });
+                    block_builder_fee_info.store(Arc::new(BlockBuilderFeeInfo {
+                        block_builder: block_builder_pubkey,
+                        block_builder_commission: block_builder_info.commission,
+                    }));
                 }
             }
         }
@@ -932,32 +948,29 @@ impl BlockEngineStage {
         bundle_sender: &Sender<Vec<PacketBundle>>,
         block_engine_stats: &mut BlockEngineStageStats,
     ) -> crate::proxy::Result<()> {
+        let mut bundle_packets = 0u64;
         let bundles: Vec<PacketBundle> = bundles_response
             .bundles
             .into_iter()
             .filter_map(|bundle| {
-                Some(PacketBundle::new(
-                    PacketBatch::from(
-                        bundle
-                            .bundle?
-                            .packets
-                            .into_iter()
-                            .map(proto_packet_to_packet)
-                            .collect::<Vec<BytesPacket>>(),
-                    ),
-                    bundle.uuid,
-                ))
+                let packet_batch = PacketBatch::from(
+                    bundle
+                        .bundle?
+                        .packets
+                        .into_iter()
+                        .map(proto_packet_to_packet)
+                        .collect::<Vec<BytesPacket>>(),
+                );
+                bundle_packets += packet_batch.len() as u64;
+                Some(PacketBundle::new(packet_batch, bundle.uuid))
             })
             .collect();
         block_engine_stats
             .num_bundles
             .add_assign(bundles.len() as u64);
-        block_engine_stats.num_bundle_packets.add_assign(
-            bundles
-                .iter()
-                .map(|bundle| bundle.batch().len() as u64)
-                .sum::<u64>(),
-        );
+        block_engine_stats
+            .num_bundle_packets
+            .add_assign(bundle_packets);
 
         // NOTE: bundles are sanitized in bundle_sanitizer module
         bundle_sender

--- a/core/src/tip_manager.rs
+++ b/core/src/tip_manager.rs
@@ -13,6 +13,7 @@ use {
             },
         },
     },
+    smallvec::SmallVec,
     solana_account::ReadableAccount,
     solana_clock::Epoch,
     solana_instruction::{AccountMeta, Instruction},
@@ -468,8 +469,8 @@ impl TipManager {
         &self,
         bank: &Bank,
         keypair: &Keypair,
-    ) -> Result<Vec<RuntimeTransaction<SanitizedTransaction>>> {
-        let mut transactions = Vec::new();
+    ) -> Result<SmallVec<[RuntimeTransaction<SanitizedTransaction>; 2]>> {
+        let mut transactions = SmallVec::with_capacity(2);
         if self.should_initialize_tip_payment_program(bank) {
             info!("should_initialize_tip_payment_program=true");
             transactions.push(self.initialize_tip_payment_program_tx(bank, keypair)?);
@@ -488,8 +489,8 @@ impl TipManager {
         bank: &Bank,
         keypair: &Keypair,
         block_builder_fee_info: &BlockBuilderFeeInfo,
-    ) -> Result<Vec<RuntimeTransaction<SanitizedTransaction>>> {
-        let mut transactions = Vec::new();
+    ) -> Result<SmallVec<[RuntimeTransaction<SanitizedTransaction>; 2]>> {
+        let mut transactions = SmallVec::with_capacity(2);
         if self.should_init_tip_distribution_account(bank) {
             info!("should_init_tip_distribution_account=true");
             transactions.push(self.initialize_tip_distribution_account_tx(bank, keypair)?);

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -361,7 +361,7 @@ impl Tpu {
             )
         };
 
-        let block_builder_fee_info = Arc::new(Mutex::new(BlockBuilderFeeInfo {
+        let block_builder_fee_info = Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
             block_builder: cluster_info.keypair().pubkey(),
             block_builder_commission: 0,
         }));
@@ -434,8 +434,8 @@ impl Tpu {
             outbound_sender: bam_outbound_sender,
             outbound_receiver: bam_outbound_receiver,
             cluster_info: cluster_info.clone(),
-            block_builder_fee_info: Arc::new(Mutex::new(BlockBuilderFeeInfo::default())),
-            bam_node_pubkey: Arc::new(Mutex::new(Pubkey::default())),
+            block_builder_fee_info: Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo::default())),
+            bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bank_forks: bank_forks.clone(),
         };
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7011,6 +7011,7 @@ dependencies = [
  "solana-metrics",
  "solana-native-token",
  "solana-net-utils",
+ "solana-nohash-hasher",
  "solana-nonce",
  "solana-nonce-account",
  "solana-packet",

--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -13,14 +13,14 @@ use {
 
 #[derive(Default, Debug)]
 pub struct RecordTransactionsTimings {
-    pub processing_results_to_transactions_us: Saturating<u64>,
+    pub prepare_record_transactions_us: Saturating<u64>,
     pub hash_us: Saturating<u64>,
     pub poh_record_us: Saturating<u64>,
 }
 
 impl RecordTransactionsTimings {
     pub fn accumulate(&mut self, other: &RecordTransactionsTimings) {
-        self.processing_results_to_transactions_us += other.processing_results_to_transactions_us;
+        self.prepare_record_transactions_us += other.prepare_record_transactions_us;
         self.hash_us += other.hash_us;
         self.poh_record_us += other.poh_record_us;
     }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6894,6 +6894,7 @@ dependencies = [
  "solana-metrics",
  "solana-native-token",
  "solana-net-utils",
+ "solana-nohash-hasher",
  "solana-nonce",
  "solana-nonce-account",
  "solana-packet",

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4218,21 +4218,18 @@ pub mod rpc_full {
                      base64",
                 ))
             })?;
-            let mut unsanitized_txs = rpc_bundle_request
-                .encoded_transactions
-                .into_iter()
-                .map(|encoded_tx| {
+            let mut packet_hashes =
+                HashSet::with_capacity(rpc_bundle_request.encoded_transactions.len());
+            let mut unsanitized_txs =
+                Vec::with_capacity(rpc_bundle_request.encoded_transactions.len());
+            for encoded_tx in rpc_bundle_request.encoded_transactions {
+                let tx =
                     decode_and_deserialize::<VersionedTransaction>(encoded_tx, binary_encoding)
-                        .map(|de| de.1)
-                })
-                .collect::<Result<Vec<VersionedTransaction>>>()?;
-
-            // check for duplicate transactions
-            let mut packet_hashes = HashSet::new();
-            for tx in unsanitized_txs.iter() {
+                        .map(|(_bytes, txn)| txn)?;
                 if !packet_hashes.insert(tx.message.hash()) {
                     return Err(Error::invalid_params("duplicate transactions"));
                 }
+                unsanitized_txs.push(tx);
             }
 
             let bank = match simulation_bank.unwrap_or_default() {
@@ -4692,18 +4689,22 @@ fn sanitize_transaction(
 pub fn account_configs_to_accounts(
     accounts_config: &[Option<RpcSimulateTransactionAccountsConfig>],
 ) -> Result<Vec<Vec<Pubkey>>> {
-    let mut execution_accounts = Vec::new();
+    let mut execution_accounts = Vec::with_capacity(accounts_config.len());
     for account_config in accounts_config {
-        let mut accounts = Vec::new();
-        if let Some(account_config) = account_config {
-            for address in &account_config.addresses {
-                accounts.push(Pubkey::from_str(address).map_err(|_| {
-                    Error::invalid_params(format!(
-                        "invalid pubkey for pre/post accounts provided: {address}"
-                    ))
-                })?);
+        let accounts = match account_config {
+            Some(account_config) => {
+                let mut accounts = Vec::with_capacity(account_config.addresses.len());
+                for address in &account_config.addresses {
+                    accounts.push(Pubkey::from_str(address).map_err(|_| {
+                        Error::invalid_params(format!(
+                            "invalid pubkey for pre/post accounts provided: {address}"
+                        ))
+                    })?);
+                }
+                accounts
             }
-        }
+            _ => Vec::new(),
+        };
         execution_accounts.push(accounts);
     }
     Ok(execution_accounts)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3272,7 +3272,7 @@ impl Bank {
         if transactions.is_empty() {
             return vec![];
         }
-        let mut simulation_results = Vec::new();
+        let mut simulation_results = Vec::with_capacity(transactions.len());
 
         let mut account_overrides = AccountOverrides::default();
 
@@ -3280,7 +3280,7 @@ impl Bank {
         for transaction in transactions {
             let account_keys = transaction.account_keys();
             account_overrides.merge(self.get_account_overrides_for_simulation(&account_keys));
-            for account in transaction.account_keys().iter() {
+            for account in account_keys.iter() {
                 if !account_overrides.accounts().contains_key(account) {
                     if let Some((account_shared_data, _slot)) =
                         self.get_account_shared_data(account)
@@ -3295,7 +3295,7 @@ impl Bank {
         for (transaction, pre_accounts, post_accounts) in
             izip!(transactions, pre_accounts, post_accounts)
         {
-            let mut accounts_pre_loaded: Vec<KeyedAccountSharedData> = Vec::new();
+            let mut accounts_pre_loaded = Vec::with_capacity(pre_accounts.len());
 
             // fill out the pre-accounts from the account overrides or bank
             // shouldn't need to hit the bank unless pre_account isn't in transaction keys
@@ -3431,9 +3431,7 @@ impl Bank {
                     None => (None, None, None, None),
                 };
 
-            let execution_result = result.clone();
-
-            let mut accounts_post_loaded: Vec<KeyedAccountSharedData> = Vec::new();
+            let mut accounts_post_loaded = Vec::with_capacity(post_accounts.len());
             for pubkey in post_accounts {
                 if let Some(account) = account_overrides.get(pubkey) {
                     accounts_post_loaded.push((*pubkey, account.clone()));
@@ -3446,6 +3444,7 @@ impl Bank {
                 }
             }
 
+            let is_execution_result_err = result.is_err();
             simulation_results.push((
                 accounts_pre_loaded,
                 TransactionSimulationResult {
@@ -3466,7 +3465,7 @@ impl Bank {
             ));
 
             // bail out early if the execution result is an error
-            if execution_result.is_err() {
+            if is_execution_result_err {
                 break;
             }
         }


### PR DESCRIPTION
Tldr: should reduce heap allocs from 19 -> 13 per bundle (post prost decode)
Changes:
  - Switch shared block builder fee info to ArcSwap across BAM/proxy/bundle/TPU/bench, with atomic load/store updates and tighter validation (commission bounds, fallback to previous pubkey on parse errors).
  - Reduce allocation/CPU overhead across schedulers, bundle handling, RPC, and simulation paths (SmallVec/preallocations, buffer reuse, avoid temp lock vectors, single‑pass bundle decode/dup checks, precomputed limits, single‑pass bundle packet counts).

