### PR TITLE
refactor: remove redundant iterator clones in transaction schedulers

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -408,33 +408,38 @@ fn try_schedule_transaction<Tx: TransactionWithMeta>(
 
     // Schedule the transaction if it can be.
     let account_keys = transaction.account_keys();
-    let write_account_locks = account_keys
+    // Collect account locks into Vecs to avoid redundant iterator cloning.
+    // This is more efficient than cloning filter_map iterators which would
+    // re-evaluate the filter for each clone.
+    let write_account_locks: Vec<_> = account_keys
         .iter()
         .enumerate()
-        .filter_map(|(index, key)| transaction.is_writable(index).then_some(key));
-    let read_account_locks = account_keys
+        .filter_map(|(index, key)| transaction.is_writable(index).then_some(key))
+        .collect();
+    let read_account_locks: Vec<_> = account_keys
         .iter()
         .enumerate()
-        .filter_map(|(index, key)| (!transaction.is_writable(index)).then_some(key));
+        .filter_map(|(index, key)| (!transaction.is_writable(index)).then_some(key))
+        .collect();
 
     // Check bundle account locks doesn't have it yet
     let l_account_locks = bundle_account_locker.account_locks();
-    for lock in read_account_locks.clone() {
-        if l_account_locks.write_locks().contains_key(lock) {
+    for lock in &read_account_locks {
+        if l_account_locks.write_locks().contains_key(*lock) {
             return Err(TransactionSchedulingError::UnschedulableConflicts);
         }
     }
-    for lock in write_account_locks.clone() {
-        if l_account_locks.write_locks().contains_key(lock)
-            || l_account_locks.read_locks().contains_key(lock)
+    for lock in &write_account_locks {
+        if l_account_locks.write_locks().contains_key(*lock)
+            || l_account_locks.read_locks().contains_key(*lock)
         {
             return Err(TransactionSchedulingError::UnschedulableConflicts);
         }
     }
 
     let thread_id = match account_locks.try_lock_accounts(
-        write_account_locks,
-        read_account_locks,
+        write_account_locks.iter().copied(),
+        read_account_locks.iter().copied(),
         ThreadSet::any(num_threads),
         thread_selector,
     ) {


### PR DESCRIPTION
### Summary
Removes unnecessary iterator cloning in `greedy_scheduler::try_schedule_transaction` and `prio_graph_scheduler::try_schedule_transaction`. Instead of cloning the `filter_map` iterator (which causes re-evaluation of the filter predicate and reconstruction of the iterator chain), we now collect the filtered account keys into a `Vec` once and iterate over slices.

### Motivation
In the [try_schedule_transaction] hot path, the code previously defined `read_account_locks` and `write_account_locks` as lazy iterators. These were then `.clone()`'d to:
1. Check for conflicts in [bundle_account_locker]
2. Pass to `account_locks.try_lock_accounts`

Cloning a `filter_map` iterator is not free—it duplicates the iterator state and, more importantly, requires re-executing the `is_writable` check and `filter_map` logic for every element during the second iteration.

### Technical Details
- Changed `read_account_locks` and `write_account_locks` from `impl Iterator` to `Vec<&Pubkey>`.
- Replaced `.clone()` calls with cheap slice iteration (`&read_account_locks` or `.iter().copied()`).
- This trades a small stack allocation (the vector of references) for reduced CPU cycles spent re-evaluating transaction account properties in a high-frequency loop.

### Verification
- ran `cargo test --package solana-core greedy_scheduler`
- ran `cargo test --package solana-core prio_graph_scheduler`
- Verified logic remains equivalent (just optimizing the access pattern).

