### PR TITLE
Fix dockerfile warnings

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:1.64-slim-bullseye as builder
+FROM rust:1.90-slim-bullseye AS builder
 
 # Add Google Protocol Buffers for Libra's metrics library.
-ENV PROTOC_VERSION 3.8.0
-ENV PROTOC_ZIP protoc-$PROTOC_VERSION-linux-x86_64.zip
+ENV PROTOC_VERSION=3.8.0
+ENV PROTOC_ZIP=protoc-$PROTOC_VERSION-linux-x86_64.zip
 
 RUN set -x \
  && apt update \
@@ -17,8 +17,6 @@ RUN set -x \
       pkg-config \
       zlib1g-dev \
       curl \
- && rustup component add rustfmt \
- && rustup component add clippy \
  && rustc --version \
  && cargo --version \
  && curl -OL https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP \


### PR DESCRIPTION
Sync rust version with master
Fixes errors when running ./f
```
#13 exporting to image
#13 exporting layers
#13 exporting layers 3.1s done
#13 writing image sha256:a0864289d2e8f76423137fadb0b791e8830e45a57264c22a35d264b8b9ff8535 done
#13 naming to docker.io/jitolabs/build-solana done
#13 DONE 3.1s

 3 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 4)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 5)
+ docker rm temp
Error response from daemon: No such container: temp
+ true
+ docker container create --name temp jitolabs/build-solana
e6a21ae2b4caf3425a66e290f542d4b84721f7b4e73f91e3504aad48a7b8b093
+ mkdir -p /home/eric/dev/jito-solana/docker-output
+ docker container cp temp:/solana/docker-output /home/eric/dev/jito-solana/
Successfully copied 550MB to /home/eric/dev/jito-solana/
+ docker rm temp
temp
```