### PR TITLE
GRPC latency measurement

### DIFF
--- a/core/src/proxy/block_engine_stage.rs
+++ b/core/src/proxy/block_engine_stage.rs
@@ -419,8 +419,6 @@ impl BlockEngineStage {
         )))
     }
 
-    /// Discover candidate endpoints either ranked via gRPC RTT probe or using global fallback.
-    /// Use u64::MAX for latency value to indicate global fallback (no RTT probe data).
     fn map_bam_enabled(bam_enabled: &Arc<AtomicU8>, err: ProxyError) -> ProxyError {
         match BamConnectionState::from_u8(bam_enabled.load(Ordering::Relaxed)) {
             BamConnectionState::Disconnected => err,
@@ -430,6 +428,8 @@ impl BlockEngineStage {
         }
     }
 
+    /// Discover candidate endpoints either ranked via gRPC RTT probe or using global fallback.
+    /// Use u64::MAX for latency value to indicate global fallback (no RTT probe data).
     async fn get_ranked_endpoints(
         backend_endpoint: &Endpoint,
     ) -> crate::proxy::Result<


### PR DESCRIPTION
Fixes Issue: https://github.com/jito-foundation/jito-solana/issues/1191

 - Replace ICMP ping-based endpoint ranking with gRPC RTT probing (multiple samples on one channel), and update metrics/error reporting to reflect gRPC probes and RTT.
  - Autoconfig now ranks endpoints using gRPC RTT results with the same global-endpoint fallback when no regional probes succeed, plus clearer error messaging.
  - When autoconfig is disabled, skip probing entirely and use the global endpoint (including shredstream address resolution) for direct connection.
  
  ### Testing
  (a) start with auto, we confirm that grpc probs works and selected the best endpoint and connect. 
  (b) start with disabled, we confirm no probing and use the global default endpoint config. 
  (3) start with auto, then use admin cli to switch to disable, we observed the following logs
  Observed logs (Dallas testnet) show this flow:

- Admin RPC becomes ready:
```
[INFO agave_validator::admin_rpc_service] All services have completed (2026-02-10 22:37:51)
```

- Autoconfig runs + selects best endpoint + connects:
```
datapoint: block_engine_stage-connect,type=autoconfig
datapoint: block_engine_stage-autoconfig ... best_endpoint_url="https://dallas.testnet.block-engine.jito.wtf" ...
[INFO solana_core::proxy::block_engine_stage] connected to packet and bundle stream
datapoint: block_engine_stage-connected url="https://dallas.testnet.block-engine.jito.wtf/"
```
- Admin config switch request received:
```
[DEBUG agave_validator::admin_rpc_service] set_block_engine_config request received (2026-02-10 22:39:45)
```
- Stage reports config-change-driven disconnect/reconfigure (expected during transition):
```
datapoint: block_engine_stage-autoconfig_error ... error="BlockEngineConfigChanged"
datapoint: block_engine_stage-proxy_error ... error="BlockEngineConfigChanged"
```
- Stage reconnects under the new (direct) config:
```
datapoint: block_engine_stage-connect,type=direct_global
datapoint: block_engine_stage-connect,type=direct
[INFO solana_core::proxy::block_engine_stage] connected to packet and bundle stream
datapoint: block_engine_stage-connected url="https://testnet.block-engine.jito.wtf/"
```