### PR TITLE
Propagate RUST_LOG to bam-local-cluster & use a valid merkle root upload authority

### DIFF
--- a/bam-local-cluster/src/cluster_manager.rs
+++ b/bam-local-cluster/src/cluster_manager.rs
@@ -125,7 +125,7 @@ impl BamValidator {
         .arg("--tip-payment-program-pubkey")
         .arg(&cluster_config.tip_payment_program_id)
         .arg("--merkle-root-upload-authority")
-        .arg(merkle_root_upload_authority.to_string())
+        .arg(merkle_root_upload_authority)
         .arg("--commission-bps")
         .arg("100");
 


### PR DESCRIPTION
#### Problem
- RUST_LOG was not propagated from the calling process.
- Merkle root upload authority was set to Pubkey::default(), which prevented bundles from getting processed.

#### Summary of Changes
- Propagate RUST_LOG from the calling process
- Use validator's own key as the approved merkle root authority.