### PR TITLE
Add tag to scheduler metrics to distinguish between schedulers

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -105,6 +105,8 @@ const DEFAULT_NUM_WORKERS: NonZeroUsize = NonZeroUsize::new(4).unwrap();
 const TOTAL_BUFFERED_PACKETS: usize = 100_000;
 const SLOT_BOUNDARY_CHECK_PERIOD: Duration = Duration::from_millis(10);
 
+const BAM_METRICS_ID_OFFSET: u32 = 10_000;
+
 #[derive(Debug, Default)]
 pub struct BankingStageStats {
     last_report: AtomicInterval,
@@ -713,7 +715,7 @@ impl BankingStage {
             for index in 0..num_workers {
                 let id = index as u32;
                 let consume_worker = ConsumeWorker::new_with_tip_processing_deps(
-                    id,
+                    id + BAM_METRICS_ID_OFFSET,
                     exit.clone(),
                     work_receiver.clone(),
                     Consumer::new(
@@ -762,7 +764,8 @@ impl BankingStage {
                             blacklisted_accounts.clone(),
                         );
 
-                        let scheduler_controller = SchedulerController::new(
+                        let scheduler_controller = SchedulerController::new_with_metrics_id(
+                            BAM_METRICS_ID_OFFSET,
                             bam_scheduler_exit,
                             scheduler_config,
                             decision_maker.clone(),

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -104,6 +104,37 @@ where
         bam_controller: bool,
         bam_enabled: Arc<AtomicU8>,
     ) -> Self {
+        SchedulerController::new_with_metrics(
+            exit,
+            config,
+            decision_maker,
+            receive_and_buffer,
+            bank_forks,
+            scheduler,
+            SchedulerCountMetrics::default(),
+            SchedulerTimingMetrics::default(),
+            worker_metrics,
+            SchedulingDetails::default(),
+            bam_controller,
+            bam_enabled,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_metrics(
+        exit: Arc<AtomicBool>,
+        config: SchedulerConfig,
+        decision_maker: DecisionMaker,
+        receive_and_buffer: R,
+        bank_forks: Arc<RwLock<BankForks>>,
+        scheduler: S,
+        count_metrics: SchedulerCountMetrics,
+        timing_metrics: SchedulerTimingMetrics,
+        worker_metrics: Vec<Arc<ConsumeWorkerMetrics>>,
+        scheduling_details: SchedulingDetails,
+        bam_controller: bool,
+        bam_enabled: Arc<AtomicU8>,
+    ) -> Self {
         Self {
             exit,
             config,
@@ -112,13 +143,42 @@ where
             bank_forks,
             container: R::Container::with_capacity(TOTAL_BUFFERED_PACKETS),
             scheduler,
-            count_metrics: SchedulerCountMetrics::default(),
-            timing_metrics: SchedulerTimingMetrics::default(),
+            count_metrics,
+            timing_metrics,
             worker_metrics,
-            scheduling_details: SchedulingDetails::default(),
+            scheduling_details,
             bam_controller,
             bam_enabled,
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_metrics_id(
+        id: u32,
+        exit: Arc<AtomicBool>,
+        config: SchedulerConfig,
+        decision_maker: DecisionMaker,
+        receive_and_buffer: R,
+        bank_forks: Arc<RwLock<BankForks>>,
+        scheduler: S,
+        worker_metrics: Vec<Arc<ConsumeWorkerMetrics>>,
+        bam_controller: bool,
+        bam_enabled: Arc<AtomicU8>,
+    ) -> Self {
+        SchedulerController::new_with_metrics(
+            exit,
+            config,
+            decision_maker,
+            receive_and_buffer,
+            bank_forks,
+            scheduler,
+            SchedulerCountMetrics::new(id),
+            SchedulerTimingMetrics::new(id),
+            worker_metrics,
+            SchedulingDetails::new(id),
+            bam_controller,
+            bam_enabled,
+        )
     }
 
     pub fn run(mut self) -> Result<(), SchedulerError> {


### PR DESCRIPTION
#### Problem
https://github.com/jito-foundation/jito-solana/issues/1175

#### Summary of Changes
Add a unique id to the metrics so that when its bam connected, its easily distinguishable.

Sample output
```
Feb 19 16:19:09 ny-testnet-validator-1 agave-validator[1473961]: [2026-02-19T16:19:09.718345724Z INFO  solana_metrics::metrics] datapoint: scheduling_details,id=10000 num_schedule_calls=6062i min_starting_queue_size=0i max_starting_queue_size=0i avg_starting_queue_size=0i min_starting_buffer_size=0i max_starting_buffer_size=0i avg_starting_buffer_size=0i num_scheduled=0i num_unschedulable_conflicts=0i num_unschedulable_threads=0i


Feb 19 16:19:10 ny-testnet-validator-1 agave-validator[1473961]: [2026-02-19T16:19:10.062487584Z INFO  solana_metrics::metrics] datapoint: banking_stage_scheduler_slot_counts,id=10000 num_received=0i num_buffered=0i num_scheduled=0i num_unschedulable_conflicts=0i num_unschedulable_threads=0i num_schedule_filtered_out=0i num_finished=0i num_retryable=0i num_dropped_on_receive=0i num_dropped_on_parsing_and_sanitization=0i num_dropped_on_validate_locks=0i num_dropped_on_receive_compute_budget=0i num_dropped_on_receive_age=0i num_dropped_on_receive_already_processed=0i num_dropped_on_receive_fee_payer=0i num_dropped_on_clear=0i num_dropped_on_clean=0i num_dropped_on_capacity=0i min_priority=0i max_priority=0i num_dropped_on_blacklisted_account=0i slot=389573176i


Feb 19 16:19:10 ny-testnet-validator-1 agave-validator[1473961]: [2026-02-19T16:19:10.062495714Z INFO  solana_metrics::metrics] datapoint: banking_stage_scheduler_slot_timing,id=10000 decision_time_us=77i receive_time_us=341919i buffer_time_us=0i schedule_filter_time_us=478i schedule_time_us=650i clear_time_us=0i clean_time_us=0i receive_completed_time_us=149i slot=389573176i
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
