### PR TITLE
Disconnect BAM when url is cleared

### DIFF
--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -243,11 +243,8 @@ impl BamManager {
                     continue;
                 }
 
-                // Check if url changed; if yes then disconnect
-                if current_url
-                    .as_ref()
-                    .is_some_and(|url| url != connection.url())
-                {
+                // Check if url changed or was cleared; if yes then disconnect
+                if current_url.as_deref() != Some(connection.url()) {
                     cached_builder_config = None;
                     dependencies
                         .bam_enabled


### PR DESCRIPTION
#### Problem

set-bam-config --bam-url "" didn't stop bam connection.

This is a bug in the code, where a cleared BAM url (none) is not treated as a url
change so active connections are not dropped.


#### Summary of Changes

Treat a cleared bam url (None) as a url change so that active connections are
dropped.


Fixes https://github.com/jito-foundation/jito-solana/issues/1194
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
