### PR TITLE
Support multiple --shred-receiver-address values

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -88,6 +88,6 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub banking_control_sender: mpsc::Sender<BankingControlMsg>,
     pub block_engine_config: Arc<Mutex<BlockEngineConfig>>,
     pub relayer_config: Arc<Mutex<RelayerConfig>>,
-    pub shred_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
+    pub shred_receiver_address: Arc<ArcSwap<Vec<SocketAddr>>>,
     pub shred_retransmit_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
 }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -199,7 +199,7 @@ impl Tpu {
         block_engine_config: Arc<Mutex<BlockEngineConfig>>,
         relayer_config: Arc<Mutex<RelayerConfig>>,
         tip_manager_config: TipManagerConfig,
-        shred_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
+        shred_receiver_address: Arc<ArcSwap<Vec<SocketAddr>>>,
         bam_url: Arc<Mutex<Option<String>>>,
     ) -> Self {
         let TpuSockets {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -387,7 +387,7 @@ pub struct ValidatorConfig {
     // jito configuration
     pub relayer_config: Arc<Mutex<RelayerConfig>>,
     pub block_engine_config: Arc<Mutex<BlockEngineConfig>>,
-    pub shred_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
+    pub shred_receiver_address: Arc<ArcSwap<Vec<SocketAddr>>>,
     pub shred_retransmit_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     pub tip_manager_config: TipManagerConfig,
     pub bam_url: Arc<Mutex<Option<String>>>,
@@ -476,7 +476,7 @@ impl ValidatorConfig {
             repair_handler_type: RepairHandlerType::default(),
             relayer_config: Arc::new(Mutex::new(RelayerConfig::default())),
             block_engine_config: Arc::new(Mutex::new(BlockEngineConfig::default())),
-            shred_receiver_address: Arc::new(ArcSwap::from_pointee(None)),
+            shred_receiver_address: Arc::new(ArcSwap::from_pointee(Vec::new())),
             shred_retransmit_receiver_address: Arc::new(ArcSwap::from_pointee(None)),
             tip_manager_config: TipManagerConfig::default(),
             bam_url: Arc::new(Mutex::new(None)),

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -128,7 +128,7 @@ impl BroadcastStageType {
         quic_endpoint_sender: AsyncSender<(SocketAddr, Bytes)>,
         xdp_sender: Option<XdpSender>,
         shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
-        shred_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
+        shred_receiver_address: Arc<ArcSwap<Vec<SocketAddr>>>,
     ) -> BroadcastStage {
         match self {
             BroadcastStageType::Standard => BroadcastStage::new(
@@ -158,7 +158,7 @@ impl BroadcastStageType {
                 FailEntryVerificationBroadcastRun::new(shred_version),
                 xdp_sender,
                 shredstream_receiver_address,
-                Arc::new(ArcSwap::from_pointee(None)),
+                Arc::new(ArcSwap::from_pointee(Vec::new())),
             ),
 
             BroadcastStageType::BroadcastFakeShreds => BroadcastStage::new(
@@ -173,7 +173,7 @@ impl BroadcastStageType {
                 BroadcastFakeShredsRun::new(0, shred_version),
                 xdp_sender,
                 shredstream_receiver_address,
-                Arc::new(ArcSwap::from_pointee(None)),
+                Arc::new(ArcSwap::from_pointee(Vec::new())),
             ),
 
             BroadcastStageType::BroadcastDuplicates(config) => BroadcastStage::new(
@@ -188,7 +188,7 @@ impl BroadcastStageType {
                 BroadcastDuplicatesRun::new(shred_version, config.clone()),
                 xdp_sender,
                 shredstream_receiver_address,
-                Arc::new(ArcSwap::from_pointee(None)),
+                Arc::new(ArcSwap::from_pointee(Vec::new())),
             ),
         }
     }
@@ -211,7 +211,7 @@ trait BroadcastRun {
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        shred_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        shred_receiver_address: &ArcSwap<Vec<SocketAddr>>,
     ) -> Result<()>;
     fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()>;
 }
@@ -310,7 +310,7 @@ impl BroadcastStage {
         mut broadcast_stage_run: impl BroadcastRun + Send + 'static + Clone,
         xdp_sender: Option<XdpSender>,
         shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
-        shred_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
+        shred_receiver_address: Arc<ArcSwap<Vec<SocketAddr>>>,
     ) -> Self {
         let (socket_sender, socket_receiver) = unbounded();
         let (blockstore_sender, blockstore_receiver) = unbounded();
@@ -516,7 +516,7 @@ pub fn broadcast_shreds(
     socket_addr_space: &SocketAddrSpace,
     quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
     shredstream_receiver_address: &Option<SocketAddr>,
-    shred_receiver_address: &Option<SocketAddr>,
+    shred_receiver_addresses: &[SocketAddr],
 ) -> Result<()> {
     let mut result = Ok(());
     // Compute destinations & transmission protocols for each of the shreds to be sent
@@ -551,20 +551,18 @@ pub fn broadcast_shreds(
         .partition_map(std::convert::identity);
 
     // forward shreds to external receivers, avoid duplicates if addresses match
-    match (shredstream_receiver_address, shred_receiver_address) {
-        (Some(ss_addr), Some(sr_addr)) => {
-            packets.extend(shreds.iter().map(|shred| (shred.payload(), *ss_addr)));
-            if ss_addr != sr_addr {
-                packets.extend(shreds.iter().map(|shred| (shred.payload(), *sr_addr)));
-            }
+    if let Some(ss_addr) = shredstream_receiver_address {
+        packets.extend(shreds.iter().map(|shred| (shred.payload(), *ss_addr)));
+    }
+    for sr_addr in shred_receiver_addresses {
+        // avoid duplicate sends if a shred_receiver_address matches shredstream
+        if shredstream_receiver_address
+            .map(|ss_addr| ss_addr == *sr_addr)
+            .unwrap_or(false)
+        {
+            continue;
         }
-        (Some(ss_addr), None) => {
-            packets.extend(shreds.iter().map(|shred| (shred.payload(), *ss_addr)))
-        }
-        (None, Some(sr_addr)) => {
-            packets.extend(shreds.iter().map(|shred| (shred.payload(), *sr_addr)))
-        }
-        (None, None) => {}
+        packets.extend(shreds.iter().map(|shred| (shred.payload(), *sr_addr)));
     }
 
     shred_select.stop();

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -299,7 +299,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         bank_forks: &RwLock<BankForks>,
         _quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        _shred_receiver_addr: &ArcSwap<Option<SocketAddr>>,
+        _shred_receiver_addr: &ArcSwap<Vec<SocketAddr>>,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         if shreds.is_empty() {

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -157,7 +157,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         _bank_forks: &RwLock<BankForks>,
         _quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        _shred_receiver_addr: &ArcSwap<Option<SocketAddr>>,
+        _shred_receiver_addr: &ArcSwap<Vec<SocketAddr>>,
     ) -> Result<()> {
         let sock = match sock {
             BroadcastSocket::Udp(sock) => sock,

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -183,7 +183,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        shred_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        shred_receiver_address: &ArcSwap<Vec<SocketAddr>>,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         broadcast_shreds(

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -385,7 +385,7 @@ impl StandardBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         shredstream_receiver_address: &Option<SocketAddr>,
-        shred_receiver_addr: &Option<SocketAddr>,
+        shred_receiver_addrs: &[SocketAddr],
     ) -> Result<()> {
         trace!("Broadcasting {:?} shreds", shreds.len());
         let mut transmit_stats = TransmitShredsStats {
@@ -408,7 +408,7 @@ impl StandardBroadcastRun {
             cluster_info.socket_addr_space(),
             quic_endpoint_sender,
             shredstream_receiver_address,
-            shred_receiver_addr,
+            shred_receiver_addrs,
         )?;
         transmit_time.stop();
 
@@ -482,7 +482,7 @@ impl BroadcastRun for StandardBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        shred_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        shred_receiver_address: &ArcSwap<Vec<SocketAddr>>,
     ) -> Result<()> {
         let (shreds, batch_info) = receiver.recv()?;
         self.broadcast(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1350,9 +1350,12 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("shred-receiver-address")
             .value_name("SHRED_RECEIVER_ADDRESS")
             .takes_value(true)
+            .multiple(true)
+            .number_of_values(1)
             .help(
                 "Validator will forward all leader shreds to this address in addition to normal \
-                 turbine operation. Set to empty string to disable.",
+                 turbine operation. Can be specified multiple times for multiple destinations. \
+                 Set to empty string to disable.",
             ),
     )
     .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -547,8 +547,15 @@ pub fn execute(
 
     let shred_receiver_address = Arc::new(ArcSwap::from_pointee(
         matches
-            .value_of("shred_receiver_address")
-            .map(|addr| SocketAddr::from_str(addr).expect("shred_receiver_address invalid")),
+            .values_of("shred_receiver_address")
+            .map(|addrs| {
+                addrs
+                    .map(|addr| {
+                        SocketAddr::from_str(addr).expect("shred_receiver_address invalid")
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
     ));
     let shred_retransmit_receiver_address = Arc::new(ArcSwap::from_pointee(
         matches


### PR DESCRIPTION
Allow the --shred-receiver-address CLI argument to be specified multiple times so that leader shreds are forwarded to all provided destinations. This brings the validator in line with the shredstream-proxy's --dest-ip-ports multi-destination capability.

Changes:
- CLI arg accepts multiple occurrences (--shred-receiver-address can be repeated); parsed into Vec<SocketAddr> instead of Option<SocketAddr>
- Config structs (ValidatorConfig, AdminRpcRequestMetadataPostInit) and all pass-through signatures updated from Option<SocketAddr> to Vec<SocketAddr>
- broadcast_shreds() iterates over all receiver addresses, deduplicating against the shredstream address to avoid double-sends
- Admin RPC set_shred_receiver_address accepts comma-separated addresses for runtime updates; empty string clears all destinations
- Fully backward compatible: a single address behaves identically to before; zero addresses is equivalent to the old None/disabled state

Note: only the broadcast path (leader shreds via TPU) is affected. The retransmit path (shred_retransmit_receiver_address via TVU) is unchanged as it flows through a separate config field.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
