### PR TITLE
fix: suppress WARN log when --relayer-url is not configured

### DIFF
--- a/core/src/proxy/relayer_stage.rs
+++ b/core/src/proxy/relayer_stage.rs
@@ -474,7 +474,6 @@ impl RelayerStage {
 
     pub fn is_valid_relayer_config(config: &RelayerConfig) -> bool {
         if config.relayer_url.is_empty() {
-            warn!("can't connect to relayer. missing relayer_url.");
             return false;
         }
         if config.oldest_allowed_heartbeat.is_zero() {


### PR DESCRIPTION
## Summary

- Removes a `warn!` log message that fired every 5 seconds when `--relayer-url` was not provided
- The Jito relayer system is deprecated; running without a relayer URL is now the expected default state for most validators
- Some operators may still run their own relayer (fully supported), but the absence of one should not produce log noise

## Details

`is_valid_relayer_config` is called on every iteration of the retry loop (`CONNECTION_BACKOFF_S = 5s`). Previously, an empty `relayer_url` triggered:

```
WARN can't connect to relayer. missing relayer_url.
```

every 5 seconds for the entire lifetime of the validator. This change silently returns `false` instead, preserving all existing behavior (no connection attempt is made) without spamming operator logs.

## Test plan

- [ ] Build and run a validator without `--relayer-url` — no WARN log emitted
- [ ] Build and run a validator with `--relayer-url` set — relayer connects as before, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)