### PR TITLE
Reduce verbosity of slot logging 

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -524,22 +524,18 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         container: &mut impl StateContainer<Tx>,
     ) {
         // Check if no bank or slot has changed
-        let maybe_bank = decision.bank();
-        if maybe_bank.map(|bank| bank.slot()) == self.slot {
+        let bank_slot = decision.bank().map(|bank| bank.slot());
+        if bank_slot == self.slot {
             return;
         }
         let prev_slot = self.slot;
-        if let Some(bank) = maybe_bank {
-            info!(
-                "Bank boundary detected: slot changed from {:?} to {:?}",
-                self.slot,
-                bank.slot()
-            );
-            self.slot = Some(bank.slot());
-        } else {
-            info!("Bank boundary detected: slot changed to None");
-            self.slot = None;
+        match bank_slot {
+            Some(bank_slot) => {
+                debug!("Bank boundary detected: slot changed from {prev_slot:?} to {bank_slot}")
+            }
+            None => debug!("Bank boundary detected: slot changed to None"),
         }
+        self.slot = bank_slot;
 
         // Drain container and send back 'retryable'
         if self.slot.is_none() {


### PR DESCRIPTION
This change refactors bank-boundary slot handling in `BamScheduler::maybe_bank_boundary_actions` to reduce duplication and log noise.

  ## Motivation
  - Reduce repeated slot extraction logic.
  - Make slot-transition code easier to read and maintain.
  - Lower verbosity for frequent bank-boundary log events.
