### PR TITLE
Eric/delete patch

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -868,12 +868,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         if !dead_keys.is_empty() {
             for key in dead_keys.iter() {
                 let w_index = self.get_bin(key);
-                if w_index.remove_if_slot_list_empty(*key) {
-                    pubkeys_removed_from_accounts_index.insert(*key);
-                    // Note it's only safe to remove all the entries for this key
-                    // because we have the lock for this key's entry in the AccountsIndex,
-                    // so no other thread is also updating the index
+                if w_index.remove_if_slot_list_empty(*key, || {
                     self.purge_secondary_indexes_by_inner_key(key, account_indexes);
+                }) {
+                    pubkeys_removed_from_accounts_index.insert(*key);
                 }
             }
         }
@@ -1552,7 +1550,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         // remove() below.
         if is_slot_list_empty {
             let w_maps = self.get_bin(pubkey);
-            removed = w_maps.remove_if_slot_list_empty(*pubkey);
+            removed = w_maps.remove_if_slot_list_empty(*pubkey, || {});
         }
         removed || missing_in_accounts_index
     }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -442,8 +442,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     }
 
     // If the slot list for pubkey exists in the index and is empty, remove the index entry for pubkey and return true.
-    // Return false otherwise.
-    pub fn remove_if_slot_list_empty(&self, pubkey: Pubkey) -> bool {
+    // Return false otherwise. `if_removed` is called while this bin's write lock is still held.
+    pub fn remove_if_slot_list_empty(
+        &self,
+        pubkey: Pubkey,
+        if_removed: impl FnOnce(),
+    ) -> bool {
         let mut m = Measure::start("entry");
         let mut map = self.map_internal.write().unwrap();
         let capacity_pre = map.capacity();
@@ -451,6 +455,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         m.stop();
         let found = matches!(entry, Entry::Occupied(_));
         let result = self.remove_if_slot_list_empty_entry(entry);
+        if result {
+            if_removed();
+        }
         let capacity_post = map.capacity();
         drop(map);
         self.stats()


### PR DESCRIPTION
• Summary
  Fixes a race in dead-key cleanup by making the caller hold the bin write lock while purging secondary indexes, instead of relaxing secondary-index assertions.

  Root Cause
  handle_dead_keys() assumed it still held the per-key primary-index lock when calling purge_secondary_indexes_by_inner_key(), but remove_if_slot_list_empty() released that lock before returning. That allowed interleaving updates and could trip the secondary-index assert.

  Changes

  1. Extended InMemAccountsIndex::remove_if_slot_list_empty to accept a callback that runs before releasing the bin write lock
  2. Updated AccountsIndex::handle_dead_keys to purge secondary indexes inside that callback, preserving the original lock-safety assumption