### PR TITLE
[improvement] adding --limit-ledger-size to cluster manager to limit RocksDB size i…

### DIFF
--- a/bam-local-cluster/src/cluster_manager.rs
+++ b/bam-local-cluster/src/cluster_manager.rs
@@ -150,6 +150,11 @@ impl BamValidator {
             cmd.arg("--geyser-plugin-config").arg(geyser_config);
         }
 
+        if let Some(limit_ledger_size) = cluster_config.limit_ledger_size {
+            cmd.arg("--limit-ledger-size")
+                .arg(limit_ledger_size.to_string());
+        }
+
         info!("Starting {node_name} node with command: {cmd:?}");
 
         // Print the command as it would appear on the CLI

--- a/bam-local-cluster/src/config.rs
+++ b/bam-local-cluster/src/config.rs
@@ -17,6 +17,7 @@ pub struct LocalClusterConfig {
     pub hashes_per_tick: Option<u64>,
     pub bind_address: Option<String>,
     pub gossip_host: Option<String>,
+    pub limit_ledger_size: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
local cluster mode

#### Problem

In local cluster mode, need ``--limit-ledger-size `` to restrict the size of validator's RocksDB to prevent dev boxes from falling over.

#### Summary of Changes

1. Adding ``--limit-ledger-size`` to ``bam-local-cluster/src/cluster_manager.rs`` and ``bam-local-cluster/src/config.rs``
