### PR TITLE
turbine: route multicast shreds through unbound socket

### DIFF
--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -52,6 +52,14 @@ pub(crate) mod broadcast_utils;
 mod fail_entry_verification_broadcast_run;
 pub(crate) mod standard_broadcast_run;
 
+thread_local! {
+    pub(crate) static MC_SOCKET: UdpSocket = {
+        let sock = UdpSocket::bind("0.0.0.0:0").expect("multicast socket bind");
+        sock.set_multicast_ttl_v4(64).expect("set multicast ttl");
+        sock
+    };
+}
+
 const _: () = const {
     // From https://github.com/anza-xyz/agave/pull/1735#discussion_r1644899183:
     // 1. There must be at least two epochs because near an epoch boundary you might receive
@@ -582,12 +590,26 @@ pub fn broadcast_shreds(
     match socket {
         BroadcastSocket::Udp(s) => {
             let mut send_mmsg_time = Measure::start("send_mmsg");
-            match batch_send(s, packets) {
-                Ok(()) => (),
-                Err(SendPktsError::IoError(ioerr, num_failed)) => {
+            let (mc_packets, uc_packets): (Vec<_>, Vec<_>) = packets
+                .into_iter()
+                .partition(|(_, addr)| addr.ip().is_multicast());
+            if !uc_packets.is_empty() {
+                if let Err(SendPktsError::IoError(ioerr, num_failed)) =
+                    batch_send(s, uc_packets)
+                {
                     transmit_stats.dropped_packets_udp += num_failed;
                     result = Err(Error::Io(ioerr));
                 }
+            }
+            if !mc_packets.is_empty() {
+                MC_SOCKET.with(|mc_sock| {
+                    if let Err(SendPktsError::IoError(ioerr, num_failed)) =
+                        batch_send(mc_sock, mc_packets)
+                    {
+                        transmit_stats.dropped_packets_udp += num_failed;
+                        result = Err(Error::Io(ioerr));
+                    }
+                });
             }
             send_mmsg_time.stop();
             transmit_stats.send_mmsg_elapsed += send_mmsg_time.as_us();

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -509,14 +509,21 @@ fn retransmit_shred(
         }
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();
-            let mut send_addrs =
+            let mut uc_addrs =
                 Vec::with_capacity(num_addrs.saturating_add(shred_receiver_addresses.len()));
-            send_addrs.extend(addrs.iter().copied());
-            send_addrs.extend(shred_receiver_addresses.iter().copied());
-            if send_addrs.is_empty() {
+            uc_addrs.extend(addrs.iter().copied());
+            let mut mc_addrs: Vec<SocketAddr> = Vec::new();
+            for &addr in shred_receiver_addresses {
+                if addr.ip().is_multicast() {
+                    mc_addrs.push(addr);
+                } else {
+                    uc_addrs.push(addr);
+                }
+            }
+            let uc_sent = if uc_addrs.is_empty() {
                 0
             } else {
-                match multi_target_send(socket, shred, &send_addrs) {
+                match multi_target_send(socket, shred, &uc_addrs) {
                     Ok(()) => num_addrs,
                     Err(SendPktsError::IoError(ioerr, num_failed)) => {
                         let num_failed = num_failed.min(num_addrs);
@@ -527,7 +534,20 @@ fn retransmit_shred(
                         num_addrs - num_failed
                     }
                 }
+            };
+            if !mc_addrs.is_empty() {
+                crate::broadcast_stage::MC_SOCKET.with(|mc_sock| {
+                    if let Err(SendPktsError::IoError(ioerr, num_failed)) =
+                        multi_target_send(mc_sock, shred, &mc_addrs)
+                    {
+                        error!(
+                            "retransmit multicast multi_target_send error: {ioerr:?}, \
+                             {num_failed} packets failed"
+                        );
+                    }
+                });
             }
+            uc_sent
         }
     };
     retransmit_time.stop();


### PR DESCRIPTION
When --bind-address is set, broadcast and retransmit sockets are bound to that IP. The kernel's route lookup then uses the bound source IP as a constraint, forcing multicast traffic out the bound interface regardless of the multicast routing table.

Fix: in broadcast_shreds() and retransmit_shred(), partition packets by is_multicast() and send multicast destinations through a thread-local UDP socket bound to 0.0.0.0:0 (with TTL=64). The kernel then picks the correct egress interface from its routing table. Unicast traffic continues to use the original bound sockets.
