### PR TITLE
Fix client ID: identify as JitoLabs/JitoBAM instead of Agave/AgaveBam 

### DIFF
--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -122,7 +122,7 @@ impl BamManager {
 
         let fallback_client_id = ClientId::JitoLabs;
         let mut current_client_id = fallback_client_id;
-        let bam_client_id = ClientId::AgaveBam;
+        let bam_client_id = ClientId::JitoBam;
 
         while !exit.load(Ordering::Relaxed) {
             let connection = match current_connection.take() {

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -68,6 +68,12 @@ pub struct BamManager {
 }
 
 impl BamManager {
+    /// Client id advertised in gossip when BAM is not connected. Also used as the
+    /// default before the manager's run loop first touches `ClusterInfo`.
+    pub(crate) const FALLBACK_CLIENT_ID: ClientId = ClientId::JitoLabs;
+    /// Client id advertised in gossip while connected to BAM.
+    pub(crate) const BAM_CLIENT_ID: ClientId = ClientId::JitoBam;
+
     pub fn new(
         exit: Arc<AtomicBool>,
         bam_url: Arc<ArcSwap<Option<String>>>,
@@ -120,9 +126,9 @@ impl BamManager {
             .add(KeyUpdaterType::BamConnection, identity_updater);
         info!("BAM Manager: Added BAM connection key updater");
 
-        let fallback_client_id = ClientId::JitoLabs;
+        let fallback_client_id = Self::FALLBACK_CLIENT_ID;
         let mut current_client_id = fallback_client_id;
-        let bam_client_id = ClientId::JitoBam;
+        let bam_client_id = Self::BAM_CLIENT_ID;
 
         while !exit.load(Ordering::Relaxed) {
             let connection = match current_connection.take() {
@@ -494,5 +500,65 @@ impl BamManager {
 
     pub fn join(self) -> std::thread::Result<()> {
         self.thread.join()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
+        solana_keypair::Keypair,
+        solana_net_utils::SocketAddrSpace,
+        solana_signer::Signer,
+        solana_time_utils::timestamp,
+    };
+
+    fn new_test_cluster_info() -> ClusterInfo {
+        let keypair = Arc::new(Keypair::new());
+        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), timestamp());
+        ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
+    }
+
+    #[test]
+    fn fallback_and_bam_client_ids_match_spec() {
+        // Locks in the gossip identities requested in jito-foundation/jito-solana#1357:
+        // default/disconnected -> JitoLabs, connected to BAM -> JitoBam.
+        assert_eq!(BamManager::FALLBACK_CLIENT_ID, ClientId::JitoLabs);
+        assert_eq!(BamManager::BAM_CLIENT_ID, ClientId::JitoBam);
+    }
+
+    #[test]
+    fn cluster_info_defaults_to_jito_labs() {
+        // A freshly-constructed ClusterInfo (i.e. a validator that has not yet
+        // started BamManager) must already advertise as JitoLabs, not Agave.
+        let cluster_info = new_test_cluster_info();
+        assert_eq!(cluster_info.get_client_id(), ClientId::JitoLabs);
+    }
+
+    #[test]
+    fn set_client_id_transitions_disconnected_then_connected() {
+        // Walk the client id through the same transitions the run loop performs:
+        // start (JitoLabs) -> connected (JitoBam) -> disconnected (JitoLabs).
+        let cluster_info = new_test_cluster_info();
+        assert_eq!(cluster_info.get_client_id(), ClientId::JitoLabs);
+
+        BamManager::set_client_id(&cluster_info, BamManager::BAM_CLIENT_ID);
+        assert_eq!(cluster_info.get_client_id(), ClientId::JitoBam);
+
+        BamManager::set_client_id(&cluster_info, BamManager::FALLBACK_CLIENT_ID);
+        assert_eq!(cluster_info.get_client_id(), ClientId::JitoLabs);
+    }
+
+    #[test]
+    fn set_client_id_is_noop_when_already_set() {
+        // The wrapper skips the write (and the resulting refresh) when the
+        // cluster info is already reporting the requested client id.
+        let cluster_info = new_test_cluster_info();
+        BamManager::set_client_id(&cluster_info, BamManager::BAM_CLIENT_ID);
+        assert_eq!(cluster_info.get_client_id(), ClientId::JitoBam);
+
+        BamManager::set_client_id(&cluster_info, BamManager::BAM_CLIENT_ID);
+        assert_eq!(cluster_info.get_client_id(), ClientId::JitoBam);
     }
 }

--- a/version/src/client_ids.rs
+++ b/version/src/client_ids.rs
@@ -10,6 +10,7 @@ pub enum ClientId {
     Firedancer,
     AgaveBam,
     Sig,
+    JitoBam,
     // If new variants are added, update From<u16> and TryFrom<ClientId>.
     Unknown(u16),
 }
@@ -25,6 +26,7 @@ impl fmt::Display for ClientId {
             Self::Firedancer => write!(f, "Firedancer"),
             Self::AgaveBam => write!(f, "AgaveBam"),
             Self::Sig => write!(f, "Sig"),
+            Self::JitoBam => write!(f, "JitoBam"),
             Self::Unknown(id) => write!(f, "Unknown({id})"),
         }
     }
@@ -41,6 +43,7 @@ impl From<u16> for ClientId {
             5u16 => Self::Firedancer,
             6u16 => Self::AgaveBam,
             7u16 => Self::Sig,
+            8u16 => Self::JitoBam,
             _ => Self::Unknown(client),
         }
     }
@@ -59,7 +62,8 @@ impl TryFrom<ClientId> for u16 {
             ClientId::Firedancer => Ok(5u16),
             ClientId::AgaveBam => Ok(6u16),
             ClientId::Sig => Ok(7u16),
-            ClientId::Unknown(client @ 0u16..=7u16) => Err(format!("Invalid client: {client}")),
+            ClientId::JitoBam => Ok(8u16),
+            ClientId::Unknown(client @ 0u16..=8u16) => Err(format!("Invalid client: {client}")),
             ClientId::Unknown(client) => Ok(client),
         }
     }
@@ -68,7 +72,7 @@ impl TryFrom<ClientId> for u16 {
 impl ClientId {
     pub const fn this_client() -> Self {
         // Other client implementations need to modify this line.
-        Self::Agave
+        Self::JitoLabs
     }
 }
 
@@ -86,7 +90,8 @@ mod test {
         assert_eq!(ClientId::from(5u16), ClientId::Firedancer);
         assert_eq!(ClientId::from(6u16), ClientId::AgaveBam);
         assert_eq!(ClientId::from(7u16), ClientId::Sig);
-        for client in 8u16..=u16::MAX {
+        assert_eq!(ClientId::from(8u16), ClientId::JitoBam);
+        for client in 9u16..=u16::MAX {
             assert_eq!(ClientId::from(client), ClientId::Unknown(client));
         }
         assert_eq!(u16::try_from(ClientId::SolanaLabs), Ok(0u16));
@@ -97,13 +102,14 @@ mod test {
         assert_eq!(u16::try_from(ClientId::Firedancer), Ok(5u16));
         assert_eq!(u16::try_from(ClientId::AgaveBam), Ok(6u16));
         assert_eq!(u16::try_from(ClientId::Sig), Ok(7u16));
-        for client in 0..=7u16 {
+        assert_eq!(u16::try_from(ClientId::JitoBam), Ok(8u16));
+        for client in 0..=8u16 {
             assert_eq!(
                 u16::try_from(ClientId::Unknown(client)),
                 Err(format!("Invalid client: {client}"))
             );
         }
-        for client in 8u16..=u16::MAX {
+        for client in 9u16..=u16::MAX {
             assert_eq!(u16::try_from(ClientId::Unknown(client)), Ok(client));
         }
     }
@@ -118,6 +124,7 @@ mod test {
         assert_eq!(format!("{}", ClientId::Firedancer), "Firedancer");
         assert_eq!(format!("{}", ClientId::AgaveBam), "AgaveBam");
         assert_eq!(format!("{}", ClientId::Sig), "Sig");
+        assert_eq!(format!("{}", ClientId::JitoBam), "JitoBam");
         assert_eq!(format!("{}", ClientId::Unknown(0)), "Unknown(0)");
         assert_eq!(format!("{}", ClientId::Unknown(u16::MAX)), "Unknown(65535)");
     }

--- a/version/src/v4.rs
+++ b/version/src/v4.rs
@@ -694,7 +694,7 @@ mod tests {
             Version::new_from_parts(0, 0, 0, 0, 0, ClientId::this_client(), Prerelease::Stable);
         assert_eq!(
             version.as_detailed_string(),
-            "0.0.0 (src:00000000; feat:00000000, client:Agave)",
+            "0.0.0 (src:00000000; feat:00000000, client:JitoLabs)",
         );
 
         let version = Version::new_from_parts(
@@ -708,7 +708,7 @@ mod tests {
         );
         assert_eq!(
             version.as_detailed_string(),
-            "0.0.0-rc.0 (src:00000000; feat:00000000, client:Agave)",
+            "0.0.0-rc.0 (src:00000000; feat:00000000, client:JitoLabs)",
         );
     }
 }


### PR DESCRIPTION
#### Problem
  https://github.com/jito-foundation/jito-solana/issues/1357

  The validator was advertising the wrong client id in gossip:
  - **Default (no BAM):** identified as `Agave` instead of `JitoLabs`.
  - **Connected to BAM:** identified as `AgaveBam` instead of a Jito-specific id.

  Only the disconnected-from-BAM path was already correct (`JitoLabs`).

  #### Summary of Changes

  **`version/src/client_ids.rs`**
  - Added a new `ClientId::JitoBam` variant (`u16 = 8`); extended `Display`, `From<u16>`, `TryFrom<ClientId>`, and the existing enum tests.
  - `ClientId::this_client()` now returns `Self::JitoLabs` (was `Self::Agave`), so the default gossip identity is correct before `BamManager` ever runs.

  **`version/src/v4.rs`**
  - Updated `test_version_as_detailed_string` expected output from `client:Agave` to `client:JitoLabs` to match the new `this_client()`.

  **`core/src/bam_manager.rs`**
  - `bam_client_id` is now `ClientId::JitoBam` instead of `ClientId::AgaveBam`.
  - Promoted the two local `let` bindings in `run()` to `pub(crate) const` associated constants on `BamManager`
  (`FALLBACK_CLIENT_ID = JitoLabs`, `BAM_CLIENT_ID = JitoBam`) so they're self-documenting and directly testable.
  - Added a new `#[cfg(test)] mod tests` with 4 tests:
    - `fallback_and_bam_client_ids_match_spec` — locks in the two constants.
    - `cluster_info_defaults_to_jito_labs` — a freshly-constructed `ClusterInfo` already reports `JitoLabs` before any
  `BamManager` activity.
    - `set_client_id_transitions_disconnected_then_connected` — walks `JitoLabs → JitoBam → JitoLabs` through
  `BamManager::set_client_id` and asserts each observed state.
    - `set_client_id_is_noop_when_already_set` — exercises the wrapper's short-circuit path.

  **Behavior delta**

  | State | Before | After |
  |---|---|---|
  | Default (no BAM) | `Agave` | `JitoLabs` |
  | Disconnected from BAM | `JitoLabs` | `JitoLabs` |
  | Connected to BAM | `AgaveBam` | `JitoBam` |

  **Test results**
  - `cargo test -p solana-version --features agave-unstable-api` → 14/14 pass.
  - `cargo test -p solana-core --lib bam_manager::` → 4/4 pass.

  Fixes #1357  and #1122
