### PR TITLE
Fix race condition in admin RPC BAM URL updater registration

### DIFF
--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -75,36 +75,6 @@ impl BamManager {
         poh_recorder: Arc<RwLock<PohRecorder>>,
         identity_notifiers: Arc<RwLock<KeyUpdaters>>,
     ) -> Self {
-        Self {
-            thread: std::thread::spawn(move || {
-                Self::run(
-                    exit,
-                    bam_url,
-                    dependencies,
-                    poh_recorder,
-                    identity_notifiers,
-                )
-            }),
-        }
-    }
-
-    fn run(
-        exit: Arc<AtomicBool>,
-        bam_url: Arc<ArcSwap<Option<String>>>,
-        dependencies: BamDependencies,
-        poh_recorder: Arc<RwLock<PohRecorder>>,
-        identity_notifiers: Arc<RwLock<KeyUpdaters>>,
-    ) {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(8)
-            .enable_all()
-            .build()
-            .unwrap();
-
-        let mut current_connection = None;
-        let mut cached_builder_config = None;
-        let shared_leader_state = poh_recorder.read().unwrap().shared_leader_state();
-
         let identity_changed = Arc::new(AtomicBool::new(false));
         let new_identity = Arc::new(ArcSwap::from_pointee(None));
 
@@ -119,6 +89,38 @@ impl BamManager {
             .unwrap()
             .add(KeyUpdaterType::BamConnection, identity_updater);
         info!("BAM Manager: Added BAM connection key updater");
+
+        Self {
+            thread: std::thread::spawn(move || {
+                Self::run(
+                    exit,
+                    bam_url,
+                    dependencies,
+                    poh_recorder,
+                    identity_changed,
+                    new_identity,
+                )
+            }),
+        }
+    }
+
+    fn run(
+        exit: Arc<AtomicBool>,
+        bam_url: Arc<ArcSwap<Option<String>>>,
+        dependencies: BamDependencies,
+        poh_recorder: Arc<RwLock<PohRecorder>>,
+        identity_changed: Arc<AtomicBool>,
+        new_identity: Arc<ArcSwap<Option<Pubkey>>>,
+    ) {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(8)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut current_connection = None;
+        let mut cached_builder_config = None;
+        let shared_leader_state = poh_recorder.read().unwrap().shared_leader_state();
 
         let fallback_client_id = ClientId::JitoLabs;
         let mut current_client_id = fallback_client_id;

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1443,6 +1443,7 @@ mod tests {
                     KeyUpdaterType::RpcService,
                     KeyUpdaterType::Bls,
                     KeyUpdaterType::BlsConnectionCache,
+                    KeyUpdaterType::BamConnection,
                 ])
             );
             let mut io = MetaIoHandler::default();


### PR DESCRIPTION

#### Problem

This PR fixes a race in registering the admin RPC BAM URL path.

  `BamConnection` identity updater registration previously happened inside
`BamManager::run()`, after the BAM manager background thread was spawned. That
meant `Validator::new()` could finish and admin RPC test setup could inspect
the post-init key updater set before the BAM
  manager thread had registered `KeyUpdaterType::BamConnection`.

  This could make the validator admin RPC test fail intermittently when
asserting the registered updater keys.


#### Summary of Changes

Move `BamConnection` identity updater registration into `BamManager::new()`,
before spawning the manager thread.

  The shared identity-change state is now created in `BamManager::new()` and
passed into `BamManager::run()`, preserving the existing reconnect behavior
while making updater registration deterministic.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
