### PR TITLE
[v4.0] turbine: use a dedicated 0.0.0.0-bound socket for ShredReceiverAddresses

### DIFF
--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -9,7 +9,7 @@ use {
         genesis_utils::{GenesisConfigInfo, create_genesis_config},
         shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
     },
-    solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
+    solana_net_utils::{SocketAddrSpace, bind_to_unspecified, sockets::bind_to_localhost_unique},
     solana_pubkey as pubkey,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_signer::Signer,
@@ -35,7 +35,8 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
         SocketAddrSpace::Unspecified,
     );
     let socket = bind_to_localhost_unique().expect("should bind");
-    let socket = BroadcastSocket::Udp(&socket);
+    let broadcast_socket = BroadcastSocket::Udp(&socket);
+    let shred_receiver_socket = bind_to_unspecified().expect("should bind");
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_benches(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(bank);
@@ -83,7 +84,8 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
     b.iter(move || {
         let shreds = shreds.clone();
         broadcast_shreds(
-            socket,
+            broadcast_socket,
+            &shred_receiver_socket,
             &shreds,
             &cluster_nodes_cache,
             &last_datapoint,

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -26,7 +26,7 @@ use {
     solana_ledger::{blockstore::Blockstore, shred::Shred},
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_error,
-    solana_net_utils::SocketAddrSpace,
+    solana_net_utils::{SocketAddrSpace, bind_to_unspecified},
     solana_poh::poh_recorder::WorkingBankEntry,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::MAX_LEADER_SCHEDULE_STAKES, bank_forks::BankForks},
@@ -219,6 +219,7 @@ trait BroadcastRun {
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        shred_receiver_socket: &UdpSocket,
     ) -> Result<()>;
     fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()>;
 }
@@ -343,6 +344,16 @@ impl BroadcastStage {
                 .unwrap()
         };
         let mut thread_hdls = vec![thread_hdl];
+
+        // Dedicated socket bound to 0.0.0.0:0 for sending shreds to ShredReceiverAddresses
+        // and multicast_receiver_address. Not constrained by --bind-address, so the OS
+        // routing table selects the appropriate interface for each destination.
+        let shred_receiver_socket =
+            Arc::new(bind_to_unspecified().expect("bind shred_receiver_socket 0.0.0.0:0"));
+        shred_receiver_socket
+            .set_multicast_ttl_v4(64)
+            .expect("set multicast ttl");
+
         let num_broadcast_sockets_per_interface = socks.len() / cluster_info.bind_ip_addrs().len();
         let num_interfaces: usize = cluster_info.bind_ip_addrs().len();
 
@@ -379,6 +390,7 @@ impl BroadcastStage {
             let shredstream_receiver_address = shredstream_receiver_address.clone();
             let shred_receiver_addresses = shred_receiver_addresses.clone();
             let multicast_receiver_address = multicast_receiver_address.clone();
+            let shred_receiver_socket = shred_receiver_socket.clone();
 
             let run_transmit = move || loop {
                 let sock_variant = match xdp_sender.as_ref() {
@@ -397,6 +409,7 @@ impl BroadcastStage {
                     &shredstream_receiver_address,
                     &shred_receiver_addresses,
                     &multicast_receiver_address,
+                    &shred_receiver_socket,
                 );
                 if let Some(res) = Self::handle_error(res, "solana-broadcaster-transmit") {
                     return res;
@@ -520,6 +533,7 @@ pub enum BroadcastSocket<'a> {
 #[allow(clippy::too_many_arguments)]
 pub fn broadcast_shreds(
     socket: BroadcastSocket,
+    shred_receiver_socket: &UdpSocket,
     shreds: &[Shred],
     cluster_nodes_cache: &ClusterNodesCache<BroadcastStage>,
     last_datapoint_submit: &AtomicInterval,
@@ -565,28 +579,49 @@ pub fn broadcast_shreds(
     if let Some(addr) = shredstream_receiver_address {
         packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
     }
-    let external_receiver_addrs = shred_receiver_addresses
+    let external_packets_start = packets.len();
+    packets.reserve(
+        shreds.len().saturating_mul(
+            shred_receiver_addresses.len() + multicast_receiver_address.iter().len(),
+        ),
+    );
+    for addr in shred_receiver_addresses
         .iter()
+        .filter(|addr| shredstream_receiver_address.as_ref() != Some(addr))
         .chain(multicast_receiver_address.iter().filter(|addr| {
-            !shred_receiver_addresses.contains(addr)
-                && shred_receiver_addresses.len() < MAX_SHRED_RECEIVER_ADDRESSES
+            shred_receiver_addresses.len() < MAX_SHRED_RECEIVER_ADDRESSES
+                && !shred_receiver_addresses.contains(addr)
+                && shredstream_receiver_address.as_ref() != Some(addr)
         }))
-        .filter(|addr| Some(**addr) != *shredstream_receiver_address);
-    for &addr in external_receiver_addrs {
-        packets.extend(shreds.iter().map(|shred| (shred.payload(), addr)));
+    {
+        packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
     }
+    let (packets, external_packets) = packets.split_at(external_packets_start);
 
     shred_select.stop();
     transmit_stats.shred_select += shred_select.as_us();
-    let num_udp_packets = packets.len();
+    let num_udp_packets = packets.len() + external_packets.len();
     match socket {
         BroadcastSocket::Udp(s) => {
             let mut send_mmsg_time = Measure::start("send_mmsg");
-            match batch_send(s, packets) {
+            // `.copied()` copies only `(&Payload, SocketAddr)`, not payload bytes.
+            match batch_send(s, packets.iter().copied()) {
                 Ok(()) => (),
                 Err(SendPktsError::IoError(ioerr, num_failed)) => {
                     transmit_stats.dropped_packets_udp += num_failed;
                     result = Err(Error::Io(ioerr));
+                }
+            }
+            if !external_packets.is_empty() {
+                // `.copied()` copies only `(&Payload, SocketAddr)`, not payload bytes.
+                match batch_send(shred_receiver_socket, external_packets.iter().copied()) {
+                    Ok(()) => (),
+                    Err(SendPktsError::IoError(ioerr, num_failed)) => {
+                        transmit_stats.dropped_packets_udp += num_failed;
+                        if result.is_ok() {
+                            result = Err(Error::Io(ioerr));
+                        }
+                    }
                 }
             }
             send_mmsg_time.stop();
@@ -594,7 +629,8 @@ pub fn broadcast_shreds(
         }
         BroadcastSocket::Xdp(s) => {
             let mut send_xdp_time = Measure::start("send_xdp");
-            for (idx, (payload, addr)) in packets.into_iter().enumerate() {
+            // `.copied()` copies only `(&Payload, SocketAddr)`; `payload.bytes.clone()` is refcount-only.
+            for (idx, (payload, addr)) in packets.iter().copied().enumerate() {
                 if let Err(e) = s.try_send(idx, addr, payload.bytes.clone()) {
                     log::warn!("xdp channel full: {e:?}");
                     transmit_stats.dropped_packets_xdp += 1;
@@ -603,6 +639,26 @@ pub fn broadcast_shreds(
             }
             send_xdp_time.stop();
             transmit_stats.send_xdp_elapsed += send_xdp_time.as_us();
+            // External receivers (ShredReceiverAddresses + multicast) must be sent via
+            // the dedicated UDP socket bound to 0.0.0.0, even when XDP is active.
+            // XDP bypasses the kernel network stack and is attached to the specific NIC
+            // that corresponds to --bind-address. It has no visibility into the routing
+            // table, so packets destined for an address reachable only through a different
+            // interface will be dropped by the NIC driver or never reach the destination.
+            // The dedicated 0.0.0.0 socket goes through the normal kernel IP stack, which
+            // uses the routing table to select the correct outbound interface per destination.
+            if !external_packets.is_empty() {
+                // `.copied()` copies only `(&Payload, SocketAddr)`, not payload bytes.
+                match batch_send(shred_receiver_socket, external_packets.iter().copied()) {
+                    Ok(()) => (),
+                    Err(SendPktsError::IoError(ioerr, num_failed)) => {
+                        transmit_stats.dropped_packets_udp += num_failed;
+                        if result.is_ok() {
+                            result = Err(Error::Io(ioerr));
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -331,6 +331,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        _shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         if shreds.is_empty() {

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -160,6 +160,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        _shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
         let sock = match sock {
             BroadcastSocket::Udp(sock) => sock,

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -4,7 +4,11 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
-    std::{net::SocketAddr, thread::sleep, time::Duration},
+    std::{
+        net::{SocketAddr, UdpSocket},
+        thread::sleep,
+        time::Duration,
+    },
 };
 
 pub const NUM_BAD_SLOTS: u64 = 10;
@@ -183,10 +187,12 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         broadcast_shreds(
             sock,
+            shred_receiver_socket,
             &shreds,
             &self.cluster_nodes_cache,
             &AtomicInterval::default(),

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -180,6 +180,8 @@ impl StandardBroadcastRun {
             &mut ProcessShredsStats::default(),
         )?;
         // Data and coding shreds are sent in a single batch.
+        let shred_receiver_socket =
+            solana_net_utils::bind_to_unspecified().expect("bind test shred_receiver_socket");
         let _ = self.transmit(
             &srecv,
             cluster_info,
@@ -188,6 +190,7 @@ impl StandardBroadcastRun {
             &ArcSwap::default(),
             &ArcSwap::default(),
             &ArcSwap::default(),
+            &shred_receiver_socket,
         );
         let _ = self.record(&brecv, blockstore);
         Ok(())
@@ -390,9 +393,11 @@ impl StandardBroadcastRun {
         insert_shreds_stats.update(new_insertion_shreds_stats, broadcast_shred_batch_info);
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn broadcast(
         &mut self,
         sock: BroadcastSocket,
+        shred_receiver_socket: &UdpSocket,
         cluster_info: &ClusterInfo,
         shreds: Arc<Vec<Shred>>,
         broadcast_shred_batch_info: Option<BroadcastShredBatchInfo>,
@@ -413,6 +418,7 @@ impl StandardBroadcastRun {
 
         broadcast_shreds(
             sock,
+            shred_receiver_socket,
             &shreds,
             &self.cluster_nodes_cache,
             &self.last_datapoint_submit,
@@ -492,10 +498,12 @@ impl BroadcastRun for StandardBroadcastRun {
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
         let (shreds, batch_info) = receiver.recv()?;
         self.broadcast(
             sock,
+            shred_receiver_socket,
             cluster_info,
             shreds,
             batch_info,


### PR DESCRIPTION
Rebase of #1412