### PR TITLE
[MEV-8694] feat: publish near leader shreds to bampc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "rayon",
+ "smallvec",
  "solana-client",
  "solana-compute-budget-interface",
  "solana-core",

--- a/bam-banking-bench/Cargo.toml
+++ b/bam-banking-bench/Cargo.toml
@@ -25,6 +25,7 @@ jito-protos = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
+smallvec.workspace = true
 solana-client = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-core = { workspace = true }

--- a/bam-banking-bench/src/main.rs
+++ b/bam-banking-bench/src/main.rs
@@ -8,6 +8,7 @@ use {
     clap::{Arg, Command, crate_description, crate_name},
     crossbeam_channel::{Receiver, unbounded},
     log::*,
+    smallvec::SmallVec,
     solana_core::{
         bam_dependencies::{BamConnectionState, BamDependencies},
         banking_stage::{
@@ -126,6 +127,7 @@ fn main() {
         bank_forks: bank_forks.clone(),
         bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::new_unique())),
         bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
+        bam_shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(SmallVec::default())),
     };
 
     let keypairs = (0..matches.value_of_t::<usize>("num_keypairs").unwrap())

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -74,6 +74,33 @@ cargo_audit_ignores=(
   # Solution:  Upgrade to >=0.17.12
   --ignore RUSTSEC-2025-0009
 
+  # Crate:     rustls-webpki
+  # Version:   0.103.10
+  # Title:     Name constraints for URI names were incorrectly accepted
+  # Date:      2026-04-14
+  # ID:        RUSTSEC-2026-0098
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
+  # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
+  --ignore RUSTSEC-2026-0098
+
+  # Crate:     rustls-webpki
+  # Version:   0.103.10
+  # Title:     Name constraints were accepted for certificates asserting a wildcard name
+  # Date:      2026-04-14
+  # ID:        RUSTSEC-2026-0099
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
+  # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
+  --ignore RUSTSEC-2026-0099
+
+  # Crate:     rustls-webpki
+  # Version:   0.103.10
+  # Title:     Reachable panic in certificate revocation list parsing
+  # Date:      2026-04-22
+  # ID:        RUSTSEC-2026-0104
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0104
+  # Solution:  Upgrade to >=0.103.13, <0.104.0-alpha.1 OR >=0.104.0-alpha.7
+  --ignore RUSTSEC-2026-0104
+
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s

--- a/core/src/bam_dependencies.rs
+++ b/core/src/bam_dependencies.rs
@@ -11,6 +11,7 @@ use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
+    solana_turbine::ShredReceiverAddresses,
     std::sync::RwLock,
 };
 
@@ -55,6 +56,7 @@ pub struct BamDependencies {
     pub bank_forks: Arc<RwLock<BankForks>>,
     pub bam_node_pubkey: Arc<ArcSwap<Pubkey>>,
     pub bam_tpu_info: Arc<ArcSwap<Option<(std::net::SocketAddr, std::net::SocketAddr)>>>,
+    pub bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
 }
 
 pub fn v0_to_versioned_proto(v0: SchedulerMessageV0) -> SchedulerMessage {

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -32,6 +32,7 @@ use {
     solana_runtime::bank::Bank,
     solana_signer::Signer,
     solana_tls_utils::NotifyKeyUpdate,
+    solana_turbine::{MAX_SHRED_RECEIVER_ADDRESSES, ShredReceiverAddresses},
     solana_version::ClientId,
 };
 
@@ -155,6 +156,7 @@ impl BamManager {
                         dependencies
                             .bam_enabled
                             .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                        Self::clear_bam_shred_receiver_addresses(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     };
@@ -175,6 +177,7 @@ impl BamManager {
                             dependencies
                                 .bam_enabled
                                 .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                            Self::clear_bam_shred_receiver_addresses(&dependencies);
                             std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                             continue;
                         }
@@ -194,6 +197,7 @@ impl BamManager {
                         dependencies
                             .bam_enabled
                             .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                        Self::clear_bam_shred_receiver_addresses(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     }
@@ -201,6 +205,7 @@ impl BamManager {
                     info!("BAM connection established");
                     if let Some(builder_config) = connection.get_latest_config() {
                         Self::update_tpu_config(Some(&builder_config), &dependencies);
+                        Self::update_shred_socks_config(Some(&builder_config), &dependencies);
                         Self::update_block_engine_key_and_commission(
                             Some(&builder_config),
                             &dependencies.block_builder_fee_info,
@@ -221,6 +226,7 @@ impl BamManager {
                 dependencies
                     .bam_enabled
                     .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                Self::clear_bam_shred_receiver_addresses(&dependencies);
                 warn!("BAM connection unhealthy");
                 continue;
             }
@@ -244,6 +250,7 @@ impl BamManager {
                 dependencies
                     .bam_enabled
                     .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                Self::clear_bam_shred_receiver_addresses(&dependencies);
                 if let Some(new_url) = configured_bam_url.as_deref() {
                     info!("BAM URL changed, connecting to new URL: {new_url}");
                 } else {
@@ -256,6 +263,7 @@ impl BamManager {
             if let Some(builder_config) = connection.get_latest_config() {
                 if Some(&builder_config) != cached_builder_config.as_ref() {
                     Self::update_tpu_config(Some(&builder_config), &dependencies);
+                    Self::update_shred_socks_config(Some(&builder_config), &dependencies);
                     Self::update_block_engine_key_and_commission(
                         Some(&builder_config),
                         &dependencies.block_builder_fee_info,
@@ -315,6 +323,7 @@ impl BamManager {
         dependencies
             .bam_enabled
             .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+        Self::clear_bam_shred_receiver_addresses(dependencies);
 
         // When we are still holding a live connection, disconnect first and wait in the
         // disconnected path before starting a new BAM auth handshake.
@@ -380,6 +389,50 @@ impl BamManager {
         dependencies
             .bam_tpu_info
             .store(Arc::new(Some((tpu, tpu_fwd))));
+    }
+
+    fn clear_bam_shred_receiver_addresses(dependencies: &BamDependencies) {
+        dependencies
+            .bam_shred_receiver_addresses
+            .store(Arc::new(ShredReceiverAddresses::new()));
+    }
+
+    fn update_shred_socks_config(config: Option<&ConfigResponse>, dependencies: &BamDependencies) {
+        let Some(bam_config) = config.and_then(|c| c.bam_config.as_ref()) else {
+            Self::clear_bam_shred_receiver_addresses(dependencies);
+            return;
+        };
+
+        let mut shred_receiver_addresses = ShredReceiverAddresses::new();
+        for socket in &bam_config.shred_socks {
+            let Some(addr) = Self::get_sockaddr(Some(socket)) else {
+                warn!(
+                    "Dropping invalid BAM shred receiver socket {}:{}",
+                    socket.ip, socket.port
+                );
+                continue;
+            };
+            if shred_receiver_addresses.contains(&addr) {
+                continue;
+            }
+            if shred_receiver_addresses.len() >= MAX_SHRED_RECEIVER_ADDRESSES {
+                warn!(
+                    "Dropping excess BAM shred receiver socket {}:{}; maximum is {}",
+                    socket.ip, socket.port, MAX_SHRED_RECEIVER_ADDRESSES
+                );
+                continue;
+            }
+            shred_receiver_addresses.push(addr);
+        }
+
+        info!(
+            "Setting {} BAM shred receiver address(es) from BAM config: {:?}",
+            shred_receiver_addresses.len(),
+            shred_receiver_addresses
+        );
+        dependencies
+            .bam_shred_receiver_addresses
+            .store(Arc::new(shred_receiver_addresses));
     }
 
     fn update_block_engine_key_and_commission(

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -857,6 +857,7 @@ impl BankingSimulator {
             Arc::new(ArcSwap::default()),
             Arc::new(ArcSwap::default()),
             Arc::new(ArcSwap::default()),
+            Arc::new(ArcSwap::default()),
         );
 
         info!("Start banking stage!...");

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -179,6 +179,7 @@ impl Tpu {
         relayer_config: Arc<ArcSwap<RelayerConfig>>,
         tip_manager_config: TipManagerConfig,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         bam_url: Arc<ArcSwap<Option<String>>>,
     ) -> Self {
@@ -421,6 +422,7 @@ impl Tpu {
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bank_forks: bank_forks.clone(),
             bam_tpu_info,
+            bam_shred_receiver_addresses: bam_shred_receiver_addresses.clone(),
         };
 
         let mut blacklisted_accounts = HashSet::new();
@@ -525,6 +527,7 @@ impl Tpu {
             votor_event_sender,
             shredstream_receiver_address,
             shred_receiver_addresses,
+            bam_shred_receiver_addresses,
             multicast_receiver_address,
         );
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -237,6 +237,7 @@ impl Tvu {
         vote_connection_cache: Arc<ConnectionCache>,
         votor_init: AlpenglowInitializationState,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
     ) -> Result<Self, String> {
         let migration_status = bank_forks.read().unwrap().migration_status();
 
@@ -375,6 +376,7 @@ impl Tvu {
             tvu_config.xdp_sender,
             votor_event_sender.clone(),
             shred_receiver_addresses,
+            bam_shred_receiver_addresses,
         );
 
         let (ancestor_duplicate_slots_sender, ancestor_duplicate_slots_receiver) = unbounded();
@@ -859,6 +861,7 @@ pub mod tests {
                 bls_connection_cache: Arc::new(bls_connection_cache),
                 voting_service_test_override: None,
             },
+            Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
             Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
         )
         .expect("assume success");

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1529,6 +1529,9 @@ impl Validator {
             "New shred signal for the TVU should be the same as the clear bank signal."
         );
 
+        let bam_shred_receiver_addresses =
+            Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new()));
+
         let vote_tracker = Arc::<VoteTracker>::default();
 
         let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
@@ -1713,6 +1716,7 @@ impl Validator {
                 voting_service_test_override: config.voting_service_test_override.clone(),
             },
             config.shred_retransmit_receiver_addresses.clone(),
+            bam_shred_receiver_addresses.clone(),
         )
         .map_err(ValidatorError::Other)?;
 
@@ -1791,6 +1795,7 @@ impl Validator {
             config.relayer_config.clone(),
             config.tip_manager_config.clone(),
             config.shred_receiver_addresses.clone(),
+            bam_shred_receiver_addresses,
             config.multicast_receiver_address.clone(),
             config.bam_url.clone(),
         );

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -141,6 +141,7 @@ impl BamNodeApi for MockBamNode {
                     ip: "127.0.0.1".to_string(),
                     port: 8001,
                 }),
+                shred_socks: vec![],
             }),
         }))
     }
@@ -543,6 +544,7 @@ mod bam_manager_tests {
     use {
         super::*,
         arc_swap::ArcSwap,
+        smallvec::SmallVec,
         solana_core::{
             admin_rpc_post_init::{KeyUpdaterType, KeyUpdaters},
             bam_dependencies::{BamConnectionState, BamDependencies},
@@ -574,6 +576,7 @@ mod bam_manager_tests {
             bank_forks,
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
+            bam_shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(SmallVec::default())),
         }
     }
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -8,6 +8,7 @@ use {
     solana_sdk_ids::sysvar,
     solana_svm_type_overrides::sync::Arc,
     solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
+    std::collections::{HashMap, HashSet},
 };
 use {
     crate::{
@@ -46,7 +47,6 @@ use {
         alloc::Layout,
         borrow::Cow,
         cell::RefCell,
-        collections::{HashMap, HashSet},
         fmt::{self, Debug},
         rc::Rc,
     },
@@ -1090,6 +1090,7 @@ mod tests {
         solana_signer::Signer,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION,
+        std::collections::HashSet,
         test_case::test_case,
     };
 

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -81,6 +81,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
     let shreds = Arc::new(shreds);
     let last_datapoint = Arc::new(AtomicInterval::default());
     let shred_receiver_addresses = ShredReceiverAddresses::new();
+    let bam_shred_receiver_addresses = ShredReceiverAddresses::new();
     b.iter(move || {
         let shreds = shreds.clone();
         broadcast_shreds(
@@ -95,6 +96,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
             &SocketAddrSpace::Unspecified,
             &None,
             &shred_receiver_addresses,
+            &bam_shred_receiver_addresses,
             &None,
         )
         .unwrap();

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -33,7 +33,7 @@ use {
     solana_streamer::sendmmsg::{SendPktsError, batch_send},
     solana_time_utils::{AtomicInterval, timestamp},
     std::{
-        collections::{HashMap, HashSet},
+        collections::HashSet,
         net::{SocketAddr, UdpSocket},
         sync::{
             Arc, Mutex, RwLock,
@@ -129,6 +129,7 @@ impl BroadcastStageType {
         votor_event_sender: VotorEventSender,
         shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> BroadcastStage {
         let migration_status = bank_forks.read().unwrap().migration_status();
@@ -145,6 +146,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 shred_receiver_addresses,
+                bam_shred_receiver_addresses,
                 multicast_receiver_address,
             ),
 
@@ -160,6 +162,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
 
@@ -174,6 +177,7 @@ impl BroadcastStageType {
                 BroadcastFakeShredsRun::new(0, shred_version),
                 xdp_sender,
                 shredstream_receiver_address,
+                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
@@ -195,6 +199,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
         }
@@ -210,6 +215,7 @@ trait BroadcastRun {
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()>;
+    #[allow(clippy::too_many_arguments)]
     fn transmit(
         &mut self,
         receiver: &TransmitReceiver,
@@ -218,6 +224,7 @@ trait BroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_socket: &UdpSocket,
     ) -> Result<()>;
@@ -318,6 +325,7 @@ impl BroadcastStage {
         xdp_sender: Option<XdpSender>,
         shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> Self {
         let (socket_sender, socket_receiver) = unbounded();
@@ -389,6 +397,7 @@ impl BroadcastStage {
             let xdp_sender = xdp_sender.clone();
             let shredstream_receiver_address = shredstream_receiver_address.clone();
             let shred_receiver_addresses = shred_receiver_addresses.clone();
+            let bam_shred_receiver_addresses = bam_shred_receiver_addresses.clone();
             let multicast_receiver_address = multicast_receiver_address.clone();
             let shred_receiver_socket = shred_receiver_socket.clone();
 
@@ -408,6 +417,7 @@ impl BroadcastStage {
                     &bank_forks,
                     &shredstream_receiver_address,
                     &shred_receiver_addresses,
+                    &bam_shred_receiver_addresses,
                     &multicast_receiver_address,
                     &shred_receiver_socket,
                 );
@@ -522,6 +532,36 @@ fn update_peer_stats(
     }
 }
 
+fn get_additional_external_shred_receiver_addresses(
+    shredstream_receiver_address: &Option<SocketAddr>,
+    shred_receiver_addresses: &ShredReceiverAddresses,
+    bam_shred_receiver_addresses: &ShredReceiverAddresses,
+    multicast_receiver_address: &Option<SocketAddr>,
+) -> ShredReceiverAddresses {
+    let shredstream_receiver_address = shredstream_receiver_address.as_ref();
+    let mut additional_external_addrs = ShredReceiverAddresses::new();
+    for addr in shred_receiver_addresses {
+        if Some(addr) != shredstream_receiver_address && !additional_external_addrs.contains(addr) {
+            additional_external_addrs.push(*addr);
+        }
+    }
+    for addr in bam_shred_receiver_addresses {
+        if Some(addr) != shredstream_receiver_address && !additional_external_addrs.contains(addr) {
+            additional_external_addrs.push(*addr);
+        }
+    }
+    if let Some(addr) = multicast_receiver_address
+        && Some(addr) != shredstream_receiver_address
+        && !additional_external_addrs.contains(addr)
+    {
+        additional_external_addrs.push(*addr);
+    }
+    // Always truncate to MAX_SHRED_RECEIVER_ADDRESSES at the end.
+    additional_external_addrs.truncate(MAX_SHRED_RECEIVER_ADDRESSES);
+
+    additional_external_addrs
+}
+
 #[derive(Clone, Copy)]
 pub enum BroadcastSocket<'a> {
     Udp(&'a UdpSocket),
@@ -543,6 +583,7 @@ pub fn broadcast_shreds(
     socket_addr_space: &SocketAddrSpace,
     shredstream_receiver_address: &Option<SocketAddr>,
     shred_receiver_addresses: &ShredReceiverAddresses,
+    bam_shred_receiver_addresses: &ShredReceiverAddresses,
     multicast_receiver_address: &Option<SocketAddr>,
 ) -> Result<()> {
     let mut result = Ok(());
@@ -575,27 +616,24 @@ pub fn broadcast_shreds(
 
     // Mirror this validator's own broadcast shreds to external receivers
     // (`--shred-receiver-address`), avoiding duplicates when addresses overlap.
-    // Add the cluster multicast address only when the route is present and the
-    // address is not already added.
+    // Add BAM and cluster multicast addresses only when they are present and
+    // not already added.
     if let Some(addr) = shredstream_receiver_address {
         packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
     }
     let external_packets_start = packets.len();
-    packets.reserve(
-        shreds.len().saturating_mul(
-            shred_receiver_addresses.len() + multicast_receiver_address.iter().len(),
-        ),
-    );
-    for addr in shred_receiver_addresses
-        .iter()
-        .filter(|addr| shredstream_receiver_address.as_ref() != Some(addr))
-        .chain(multicast_receiver_address.iter().filter(|addr| {
-            shred_receiver_addresses.len() < MAX_SHRED_RECEIVER_ADDRESSES
-                && !shred_receiver_addresses.contains(addr)
-                && shredstream_receiver_address.as_ref() != Some(addr)
-        }))
-    {
-        packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
+    packets.reserve(shreds.len().saturating_mul(
+        shred_receiver_addresses.len()
+            + bam_shred_receiver_addresses.len()
+            + multicast_receiver_address.iter().len(),
+    ));
+    for addr in get_additional_external_shred_receiver_addresses(
+        shredstream_receiver_address,
+        shred_receiver_addresses,
+        bam_shred_receiver_addresses,
+        multicast_receiver_address,
+    ) {
+        packets.extend(shreds.iter().map(|shred| (shred.payload(), addr)));
     }
     let (packets, external_packets) = packets.split_at(external_packets_start);
 
@@ -767,6 +805,34 @@ pub mod test {
     }
 
     #[test]
+    fn test_bam_shred_receivers_are_added_and_deduped_for_leader_broadcast() {
+        let shredstream_addr = "127.0.0.1:10".parse().unwrap();
+        let regular_addr_1 = "127.0.0.1:11".parse().unwrap();
+        let regular_addr_2 = "127.0.0.1:12".parse().unwrap();
+        let bam_addr = "127.0.0.1:13".parse().unwrap();
+        let multicast_addr = "127.0.0.1:14".parse().unwrap();
+
+        let shred_receiver_addresses: ShredReceiverAddresses =
+            [regular_addr_1, regular_addr_2].into_iter().collect();
+        let bam_shred_receiver_addresses: ShredReceiverAddresses =
+            [regular_addr_2, bam_addr, shredstream_addr]
+                .into_iter()
+                .collect();
+
+        let additional_external_addrs = get_additional_external_shred_receiver_addresses(
+            &Some(shredstream_addr),
+            &shred_receiver_addresses,
+            &bam_shred_receiver_addresses,
+            &Some(multicast_addr),
+        );
+
+        assert_eq!(
+            additional_external_addrs.as_slice(),
+            &[regular_addr_1, regular_addr_2, bam_addr, multicast_addr]
+        );
+    }
+
+    #[test]
     fn test_duplicate_retransmit_signal() {
         // Setup
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -862,6 +928,7 @@ pub mod test {
             bank_forks,
             StandardBroadcastRun::new(0, Arc::new(MigrationStatus::default()), votor_event_sender),
             None,
+            Arc::default(),
             Arc::default(),
             Arc::default(),
             Arc::default(),

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -337,6 +337,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         bank_forks: &RwLock<BankForks>,
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        _bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -159,6 +159,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         _bank_forks: &RwLock<BankForks>,
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        _bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {

--- a/turbine/src/broadcast_stage/broadcast_metrics.rs
+++ b/turbine/src/broadcast_stage/broadcast_metrics.rs
@@ -1,4 +1,4 @@
-use super::*;
+use {super::*, std::collections::HashMap};
 
 pub(crate) trait BroadcastStats {
     fn update(&mut self, new_stats: &Self);

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -186,6 +186,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
@@ -202,6 +203,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             cluster_info.socket_addr_space(),
             &shredstream_receiver_address.load(),
             &shred_receiver_addresses.load(),
+            &bam_shred_receiver_addresses.load(),
             &multicast_receiver_address.load(),
         )
     }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -190,6 +190,7 @@ impl StandardBroadcastRun {
             &ArcSwap::default(),
             &ArcSwap::default(),
             &ArcSwap::default(),
+            &ArcSwap::default(),
             &shred_receiver_socket,
         );
         let _ = self.record(&brecv, blockstore);
@@ -404,6 +405,7 @@ impl StandardBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &Option<SocketAddr>,
         shred_receiver_addresses: &ShredReceiverAddresses,
+        bam_shred_receiver_addresses: &ShredReceiverAddresses,
         multicast_receiver_address: &Option<SocketAddr>,
     ) -> Result<()> {
         trace!("Broadcasting {:?} shreds", shreds.len());
@@ -428,6 +430,7 @@ impl StandardBroadcastRun {
             cluster_info.socket_addr_space(),
             shredstream_receiver_address,
             shred_receiver_addresses,
+            bam_shred_receiver_addresses,
             multicast_receiver_address,
         )?;
         transmit_time.stop();
@@ -497,6 +500,7 @@ impl BroadcastRun for StandardBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
@@ -510,6 +514,7 @@ impl BroadcastRun for StandardBroadcastRun {
             bank_forks,
             &shredstream_receiver_address.load(),
             &shred_receiver_addresses.load(),
+            &bam_shred_receiver_addresses.load(),
             &multicast_receiver_address.load(),
         )
     }

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -23,7 +23,7 @@ use {
         shred::{self, ShredFlags, ShredId, ShredType},
     },
     solana_measure::measure::Measure,
-    solana_net_utils::SocketAddrSpace,
+    solana_net_utils::{SocketAddrSpace, bind_to_unspecified},
     solana_perf::deduper::Deduper,
     solana_pubkey::Pubkey,
     solana_rpc::{
@@ -294,6 +294,7 @@ fn retransmit(
     cluster_info: &ClusterInfo,
     retransmit_receiver: &Receiver<Vec<shred::Payload>>,
     retransmit_sockets: &[UdpSocket],
+    external_sender_socket: &UdpSocket,
     xdp_sender: Option<&XdpSender>,
     stats: &mut RetransmitStats,
     cluster_nodes_cache: &ClusterNodesCache<RetransmitStage>,
@@ -306,6 +307,7 @@ fn retransmit(
     votor_event_sender: &Sender<VotorEvent>,
     migration_status: &MigrationStatus,
     shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+    bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
 ) -> Result<(), ()> {
     // Try to receive shreds from the channel without blocking. If the channel
     // is empty precompute turbine trees speculatively. If no cache updates are
@@ -361,12 +363,20 @@ fn retransmit(
     );
     epoch_cache_update.stop();
     stats.epoch_cache_update += epoch_cache_update.as_us();
-    // Lookup slot leader and cluster nodes for each slot.
-    let cache: HashMap<Slot, _> = shred_buf
+    let shred_slots: HashSet<Slot> = shred_buf
         .iter()
         .flatten()
         .filter_map(|shred| shred::layout::get_slot(shred))
-        .collect::<HashSet<Slot>>()
+        .collect();
+    let bam_forward_slots = get_bam_forward_slots(
+        &shred_slots,
+        leader_schedule_cache,
+        &cluster_info.id(),
+        &working_bank,
+    );
+
+    // Lookup slot leader and cluster nodes for each slot.
+    let cache: HashMap<Slot, _> = shred_slots
         .into_iter()
         .filter_map(|slot: Slot| {
             max_slots.retransmit.fetch_max(slot, Ordering::Relaxed);
@@ -393,6 +403,7 @@ fn retransmit(
         stats
     };
     let shred_receiver_addresses_local = shred_receiver_addresses.load();
+    let bam_shred_receiver_addresses_local = bam_shred_receiver_addresses.load();
     let retransmit_shred = |shred, socket, stats| {
         retransmit_shred(
             shred,
@@ -402,8 +413,11 @@ fn retransmit(
             addr_cache,
             socket_addr_space,
             socket,
+            external_sender_socket,
             stats,
             &shred_receiver_addresses_local,
+            &bam_forward_slots,
+            &bam_shred_receiver_addresses_local,
         )
     };
 
@@ -456,6 +470,46 @@ fn retransmit(
     Ok(())
 }
 
+fn should_forward_to_bam_for_slot(
+    slot: Slot,
+    leader_schedule_cache: &LeaderScheduleCache,
+    my_pubkey: &Pubkey,
+    working_bank: &Bank,
+) -> bool {
+    should_forward_to_bam_for_slot_with_leader_lookup(slot, my_pubkey, |slot| {
+        leader_schedule_cache
+            .slot_leader_at(slot, Some(working_bank))
+            .map(|leader| leader.id)
+    })
+}
+
+fn should_forward_to_bam_for_slot_with_leader_lookup(
+    slot: Slot,
+    my_pubkey: &Pubkey,
+    mut leader_at_slot: impl FnMut(Slot) -> Option<Pubkey>,
+) -> bool {
+    (0..3).any(|offset| {
+        slot.checked_add(offset)
+            .and_then(&mut leader_at_slot)
+            .is_some_and(|leader| leader == *my_pubkey)
+    })
+}
+
+fn get_bam_forward_slots(
+    shred_slots: &HashSet<Slot>,
+    leader_schedule_cache: &LeaderScheduleCache,
+    my_pubkey: &Pubkey,
+    working_bank: &Bank,
+) -> HashSet<Slot> {
+    shred_slots
+        .iter()
+        .copied()
+        .filter(|slot| {
+            should_forward_to_bam_for_slot(*slot, leader_schedule_cache, my_pubkey, working_bank)
+        })
+        .collect()
+}
+
 // Retransmit a single shred to all downstream nodes
 #[allow(clippy::too_many_arguments)]
 fn retransmit_shred(
@@ -466,8 +520,11 @@ fn retransmit_shred(
     addr_cache: &AddrCache,
     socket_addr_space: &SocketAddrSpace,
     socket: RetransmitSocket<'_>,
+    external_sender_socket: &UdpSocket,
     stats: &RetransmitStats,
     shred_receiver_addresses: &ShredReceiverAddresses,
+    bam_forward_slots: &HashSet<Slot>,
+    bam_shred_receiver_addresses: &ShredReceiverAddresses,
 ) -> Option<RetransmitShredOutput> {
     let key = shred::layout::get_shred_id(shred.as_ref())?;
     if key.slot() < root_bank.slot()
@@ -487,19 +544,40 @@ fn retransmit_shred(
         .map(|flags| flags.contains(ShredFlags::LAST_SHRED_IN_SLOT))
         .unwrap_or_default();
     let mut retransmit_time = Measure::start("retransmit_to");
-    let num_addrs = addrs.len();
+    let include_bam_shred_receivers = bam_forward_slots.contains(&key.slot());
+    let mut turbine_addrs = Vec::with_capacity(addrs.len());
+    for addr in addrs.iter() {
+        if !turbine_addrs.contains(addr) {
+            turbine_addrs.push(*addr);
+        }
+    }
+    let mut external_addrs = Vec::with_capacity(shred_receiver_addresses.len().saturating_add(
+        if include_bam_shred_receivers {
+            bam_shred_receiver_addresses.len()
+        } else {
+            0
+        },
+    ));
+    for addr in shred_receiver_addresses.iter() {
+        if !turbine_addrs.contains(addr) && !external_addrs.contains(addr) {
+            external_addrs.push(*addr);
+        }
+    }
+    if include_bam_shred_receivers {
+        for addr in bam_shred_receiver_addresses.iter() {
+            if !turbine_addrs.contains(addr) && !external_addrs.contains(addr) {
+                external_addrs.push(*addr);
+            }
+        }
+    }
+    let num_addrs = turbine_addrs.len();
     let num_nodes = match socket {
         RetransmitSocket::Xdp(sender) => {
             let mut sent = num_addrs;
-            let mut send_addrs =
-                Vec::with_capacity(num_addrs.saturating_add(shred_receiver_addresses.len()));
-            send_addrs.extend(addrs.iter().copied());
-            send_addrs.extend(shred_receiver_addresses.iter().copied());
-            if !send_addrs.is_empty()
-                && let Err(e) = sender.try_send(key.index() as usize, send_addrs, shred.bytes)
+            if !turbine_addrs.is_empty()
+                && let Err(e) =
+                    sender.try_send(key.index() as usize, turbine_addrs, shred.bytes.clone())
             {
-                // External retransmit receivers (`--shred-retransmit-receiver-address`) are
-                // intentionally not included in retransmit stats.
                 log::warn!("xdp channel full: {e:?}");
                 stats
                     .num_shreds_dropped_xdp_full
@@ -510,14 +588,10 @@ fn retransmit_shred(
         }
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();
-            let mut send_addrs =
-                Vec::with_capacity(num_addrs.saturating_add(shred_receiver_addresses.len()));
-            send_addrs.extend(addrs.iter().copied());
-            send_addrs.extend(shred_receiver_addresses.iter().copied());
-            if send_addrs.is_empty() {
+            if turbine_addrs.is_empty() {
                 0
             } else {
-                match multi_target_send(socket, shred, &send_addrs) {
+                match multi_target_send(socket, &shred, &turbine_addrs) {
                     Ok(()) => num_addrs,
                     Err(SendPktsError::IoError(ioerr, num_failed)) => {
                         let num_failed = num_failed.min(num_addrs);
@@ -531,6 +605,16 @@ fn retransmit_shred(
             }
         }
     };
+    if !external_addrs.is_empty()
+        && let Err(SendPktsError::IoError(ioerr, num_failed)) =
+            multi_target_send(external_sender_socket, &shred, &external_addrs)
+    {
+        warn!(
+            "retransmit_to external multi_target_send error: {ioerr:?}, {num_failed}/{} packets \
+             failed",
+            external_addrs.len()
+        );
+    }
     retransmit_time.stop();
     stats
         .num_addrs_failed
@@ -666,6 +750,7 @@ impl RetransmitStage {
         xdp_sender: Option<XdpSender>,
         votor_event_sender: Sender<VotorEvent>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
     ) -> Self {
         let migration_status = bank_forks.read().unwrap().migration_status();
         let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
@@ -689,6 +774,10 @@ impl RetransmitStage {
         let retransmit_thread_handle = Builder::new()
             .name("solRetransmittr".to_string())
             .spawn({
+                let external_sender_socket = Arc::new(
+                    bind_to_unspecified()
+                        .expect("bind retransmit external_sender_socket 0.0.0.0:0"),
+                );
                 move || {
                     let mut shred_buf = Vec::with_capacity(RETRANSMIT_BATCH_SIZE);
                     while retransmit(
@@ -698,6 +787,7 @@ impl RetransmitStage {
                         &cluster_info,
                         &retransmit_receiver,
                         &retransmit_sockets,
+                        &external_sender_socket,
                         xdp_sender.as_ref(),
                         &mut stats,
                         &cluster_nodes_cache,
@@ -710,6 +800,7 @@ impl RetransmitStage {
                         &votor_event_sender,
                         &migration_status,
                         &shred_receiver_addresses,
+                        &bam_shred_receiver_addresses,
                     )
                     .is_ok()
                     {}
@@ -957,6 +1048,51 @@ mod tests {
             .map(Keypair::try_from)
             .unwrap()
             .unwrap()
+    }
+
+    #[test]
+    fn test_should_forward_to_bam_for_slot_near_leader_window() {
+        let my_pubkey = Pubkey::new_unique();
+        let other_pubkey = Pubkey::new_unique();
+        let leader_window = 10..=13;
+        let leader_at_slot = |slot| {
+            Some(if leader_window.contains(&slot) {
+                my_pubkey
+            } else {
+                other_pubkey
+            })
+        };
+
+        assert!(!should_forward_to_bam_for_slot_with_leader_lookup(
+            7,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            8,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            9,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            10,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            13,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(!should_forward_to_bam_for_slot_with_leader_lookup(
+            14,
+            &my_pubkey,
+            leader_at_slot
+        ));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Publish near leader shreds to bampc


#### Summary of Changes
Add feature to publish near leader shreds to bampc.

- propagate bamconfig.shred_socks
- tpu broadcast leader shreds to bam endpoints
- tvu retransmit near leader shreds to bam endpoints (2 slots before its leader slot).

#### Test
1. `bam_shred` config propagated to validator 

```
[2026-04-21T00:37:50.320390000Z INFO  solana_core::bam_manager] Setting 1 BAM shred receiver address(es) from BAM config
```

2. jito validator forwarded shreds to BAM

leader broadcast
```
[2026-04-21T00:38:00.228487000Z INFO  solana_turbine::broadcast_stage] broadcast_shreds: slots=[37] bam_shred_receiver_addresses=[127.0.0.1:12001] additional_external_addrs=[127.0.0.1:12001]
```

pre-leader retransmit 
```
[2026-04-21T00:37:50.740889000Z INFO  solana_turbine::retransmit_stage] retransmit batch: batch_slots=[18] bam_forward_slots=[18] bam_shred_receiver_addresses=[127.0.0.1:12001]
  [2026-04-21T00:37:50.740916000Z INFO  solana_turbine::retransmit_stage] retransmit_shred: slot=18 index=0 including bam_shred_receiver_addresses=[127.0.0.1:12001]
```

3. bam received forwarded shreds

```
[2026-04-21T00:38:12.286664Z INFO  solana_metrics::metrics] datapoint: shred_fetch index_overrun=0i shred_count=2433i ...
  [2026-04-21T00:38:12.286694Z INFO  solana_metrics::metrics] datapoint: validator_service_metrics heartbeats=0i auth_proofs=0i auth_challenges=0i leader_states=33i ...

```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
