### PR TITLE
Eric/cleanup shred

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "rayon",
+ "smallvec",
  "solana-client",
  "solana-compute-budget-interface",
  "solana-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,6 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "rayon",
- "smallvec",
  "solana-client",
  "solana-compute-budget-interface",
  "solana-core",

--- a/bam-banking-bench/Cargo.toml
+++ b/bam-banking-bench/Cargo.toml
@@ -25,7 +25,6 @@ jito-protos = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-smallvec.workspace = true
 solana-client = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-core = { workspace = true }

--- a/bam-banking-bench/Cargo.toml
+++ b/bam-banking-bench/Cargo.toml
@@ -25,6 +25,7 @@ jito-protos = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
+smallvec.workspace = true
 solana-client = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-core = { workspace = true }

--- a/bam-banking-bench/src/main.rs
+++ b/bam-banking-bench/src/main.rs
@@ -8,7 +8,6 @@ use {
     clap::{Arg, Command, crate_description, crate_name},
     crossbeam_channel::{Receiver, unbounded},
     log::*,
-    smallvec::SmallVec,
     solana_core::{
         bam_dependencies::{BamConnectionState, BamDependencies},
         banking_stage::{
@@ -127,7 +126,7 @@ fn main() {
         bank_forks: bank_forks.clone(),
         bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::new_unique())),
         bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
-        bam_shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(SmallVec::default())),
+        bam_shred_receiver_addresses: Arc::default(),
     };
 
     let keypairs = (0..matches.value_of_t::<usize>("num_keypairs").unwrap())

--- a/bam-banking-bench/src/main.rs
+++ b/bam-banking-bench/src/main.rs
@@ -8,6 +8,7 @@ use {
     clap::{Arg, Command, crate_description, crate_name},
     crossbeam_channel::{Receiver, unbounded},
     log::*,
+    smallvec::SmallVec,
     solana_core::{
         bam_dependencies::{BamConnectionState, BamDependencies},
         banking_stage::{
@@ -126,6 +127,7 @@ fn main() {
         bank_forks: bank_forks.clone(),
         bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::new_unique())),
         bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
+        bam_shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(SmallVec::default())),
     };
 
     let keypairs = (0..matches.value_of_t::<usize>("num_keypairs").unwrap())

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -92,6 +92,15 @@ cargo_audit_ignores=(
   # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
   --ignore RUSTSEC-2026-0099
 
+  # Crate:     rustls-webpki
+  # Version:   0.103.10
+  # Title:     Reachable panic in certificate revocation list parsing
+  # Date:      2026-04-22
+  # ID:        RUSTSEC-2026-0104
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0104
+  # Solution:  Upgrade to >=0.103.13, <0.104.0-alpha.1 OR >=0.104.0-alpha.7
+  --ignore RUSTSEC-2026-0104
+
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -74,6 +74,24 @@ cargo_audit_ignores=(
   # Solution:  Upgrade to >=0.17.12
   --ignore RUSTSEC-2025-0009
 
+  # Crate:     rustls-webpki
+  # Version:   0.103.10
+  # Title:     Name constraints for URI names were incorrectly accepted
+  # Date:      2026-04-14
+  # ID:        RUSTSEC-2026-0098
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
+  # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
+  --ignore RUSTSEC-2026-0098
+
+  # Crate:     rustls-webpki
+  # Version:   0.103.10
+  # Title:     Name constraints were accepted for certificates asserting a wildcard name
+  # Date:      2026-04-14
+  # ID:        RUSTSEC-2026-0099
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
+  # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
+  --ignore RUSTSEC-2026-0099
+
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s

--- a/core/src/bam_dependencies.rs
+++ b/core/src/bam_dependencies.rs
@@ -11,6 +11,7 @@ use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
+    solana_turbine::ShredReceiverAddresses,
     std::sync::RwLock,
 };
 
@@ -55,6 +56,7 @@ pub struct BamDependencies {
     pub bank_forks: Arc<RwLock<BankForks>>,
     pub bam_node_pubkey: Arc<ArcSwap<Pubkey>>,
     pub bam_tpu_info: Arc<ArcSwap<Option<(std::net::SocketAddr, std::net::SocketAddr)>>>,
+    pub bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
 }
 
 pub fn v0_to_versioned_proto(v0: SchedulerMessageV0) -> SchedulerMessage {

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -32,6 +32,7 @@ use {
     solana_runtime::bank::Bank,
     solana_signer::Signer,
     solana_tls_utils::NotifyKeyUpdate,
+    solana_turbine::{MAX_SHRED_RECEIVER_ADDRESSES, ShredReceiverAddresses},
     solana_version::ClientId,
 };
 
@@ -155,6 +156,7 @@ impl BamManager {
                         dependencies
                             .bam_enabled
                             .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                        Self::clear_bam_shred_receiver_addresses(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     };
@@ -175,6 +177,7 @@ impl BamManager {
                             dependencies
                                 .bam_enabled
                                 .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                            Self::clear_bam_shred_receiver_addresses(&dependencies);
                             std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                             continue;
                         }
@@ -194,6 +197,7 @@ impl BamManager {
                         dependencies
                             .bam_enabled
                             .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                        Self::clear_bam_shred_receiver_addresses(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     }
@@ -201,6 +205,7 @@ impl BamManager {
                     info!("BAM connection established");
                     if let Some(builder_config) = connection.get_latest_config() {
                         Self::update_tpu_config(Some(&builder_config), &dependencies);
+                        Self::update_shred_socks_config(Some(&builder_config), &dependencies);
                         Self::update_block_engine_key_and_commission(
                             Some(&builder_config),
                             &dependencies.block_builder_fee_info,
@@ -221,6 +226,7 @@ impl BamManager {
                 dependencies
                     .bam_enabled
                     .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                Self::clear_bam_shred_receiver_addresses(&dependencies);
                 warn!("BAM connection unhealthy");
                 continue;
             }
@@ -244,6 +250,7 @@ impl BamManager {
                 dependencies
                     .bam_enabled
                     .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                Self::clear_bam_shred_receiver_addresses(&dependencies);
                 if let Some(new_url) = configured_bam_url.as_deref() {
                     info!("BAM URL changed, connecting to new URL: {new_url}");
                 } else {
@@ -256,6 +263,7 @@ impl BamManager {
             if let Some(builder_config) = connection.get_latest_config() {
                 if Some(&builder_config) != cached_builder_config.as_ref() {
                     Self::update_tpu_config(Some(&builder_config), &dependencies);
+                    Self::update_shred_socks_config(Some(&builder_config), &dependencies);
                     Self::update_block_engine_key_and_commission(
                         Some(&builder_config),
                         &dependencies.block_builder_fee_info,
@@ -315,6 +323,7 @@ impl BamManager {
         dependencies
             .bam_enabled
             .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+        Self::clear_bam_shred_receiver_addresses(dependencies);
 
         // When we are still holding a live connection, disconnect first and wait in the
         // disconnected path before starting a new BAM auth handshake.
@@ -359,9 +368,10 @@ impl BamManager {
     fn get_sockaddr(info: Option<&Socket>) -> Option<SocketAddr> {
         let info = info?;
         let Socket { ip, port } = info;
+        let port = u16::try_from(*port).ok().filter(|port| *port != 0)?;
         Some(SocketAddr::V4(SocketAddrV4::new(
             Ipv4Addr::from_str(ip).ok()?,
-            *port as u16,
+            port,
         )))
     }
 
@@ -380,6 +390,50 @@ impl BamManager {
         dependencies
             .bam_tpu_info
             .store(Arc::new(Some((tpu, tpu_fwd))));
+    }
+
+    fn clear_bam_shred_receiver_addresses(dependencies: &BamDependencies) {
+        dependencies
+            .bam_shred_receiver_addresses
+            .store(Arc::new(ShredReceiverAddresses::new()));
+    }
+
+    fn update_shred_socks_config(config: Option<&ConfigResponse>, dependencies: &BamDependencies) {
+        let Some(bam_config) = config.and_then(|c| c.bam_config.as_ref()) else {
+            Self::clear_bam_shred_receiver_addresses(dependencies);
+            return;
+        };
+
+        let mut shred_receiver_addresses = ShredReceiverAddresses::new();
+        for socket in &bam_config.shred_socks {
+            let Some(addr) = Self::get_sockaddr(Some(socket)) else {
+                warn!(
+                    "Dropping invalid BAM shred receiver socket {}:{}",
+                    socket.ip, socket.port
+                );
+                continue;
+            };
+            if shred_receiver_addresses.contains(&addr) {
+                continue;
+            }
+            if shred_receiver_addresses.len() >= MAX_SHRED_RECEIVER_ADDRESSES {
+                warn!(
+                    "Dropping excess BAM shred receiver socket {}:{}; maximum is {}",
+                    socket.ip, socket.port, MAX_SHRED_RECEIVER_ADDRESSES
+                );
+                continue;
+            }
+            shred_receiver_addresses.push(addr);
+        }
+
+        info!(
+            "Setting {} BAM shred receiver address(es) from BAM config: {:?}",
+            shred_receiver_addresses.len(),
+            shred_receiver_addresses
+        );
+        dependencies
+            .bam_shred_receiver_addresses
+            .store(Arc::new(shred_receiver_addresses));
     }
 
     fn update_block_engine_key_and_commission(

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -153,10 +153,7 @@ impl BamManager {
                     // Try to connect to BAM
                     let bam_url = bam_url.load();
                     let Some(url) = bam_url.as_ref() else {
-                        dependencies
-                            .bam_enabled
-                            .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-                        Self::clear_bam_shred_receiver_addresses(&dependencies);
+                        Self::set_bam_disconnected(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     };
@@ -174,10 +171,7 @@ impl BamManager {
                         Ok(connection) => connection,
                         Err(e) => {
                             error!("Failed to connect to BAM with url: {url}: {e}");
-                            dependencies
-                                .bam_enabled
-                                .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-                            Self::clear_bam_shred_receiver_addresses(&dependencies);
+                            Self::set_bam_disconnected(&dependencies);
                             std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                             continue;
                         }
@@ -194,20 +188,17 @@ impl BamManager {
                              retry",
                         );
                         cached_builder_config = None;
-                        dependencies
-                            .bam_enabled
-                            .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-                        Self::clear_bam_shred_receiver_addresses(&dependencies);
+                        Self::set_bam_disconnected(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     }
 
                     info!("BAM connection established");
                     if let Some(builder_config) = connection.get_latest_config() {
-                        Self::update_tpu_config(Some(&builder_config), &dependencies);
-                        Self::update_shred_socks_config(Some(&builder_config), &dependencies);
+                        Self::update_tpu_config(&builder_config, &dependencies);
+                        Self::update_shred_socks_config(&builder_config, &dependencies);
                         Self::update_block_engine_key_and_commission(
-                            Some(&builder_config),
+                            &builder_config,
                             &dependencies.block_builder_fee_info,
                         );
                         Self::update_bam_recipient_and_commission(
@@ -223,10 +214,7 @@ impl BamManager {
 
             if !connection.is_healthy() {
                 cached_builder_config = None;
-                dependencies
-                    .bam_enabled
-                    .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-                Self::clear_bam_shred_receiver_addresses(&dependencies);
+                Self::set_bam_disconnected(&dependencies);
                 warn!("BAM connection unhealthy");
                 continue;
             }
@@ -247,10 +235,7 @@ impl BamManager {
             let configured_bam_url = bam_url.load();
             if configured_bam_url.as_deref() != Some(connection.url()) {
                 cached_builder_config = None;
-                dependencies
-                    .bam_enabled
-                    .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-                Self::clear_bam_shred_receiver_addresses(&dependencies);
+                Self::set_bam_disconnected(&dependencies);
                 if let Some(new_url) = configured_bam_url.as_deref() {
                     info!("BAM URL changed, connecting to new URL: {new_url}");
                 } else {
@@ -262,10 +247,10 @@ impl BamManager {
             // Check if block builder info has changed
             if let Some(builder_config) = connection.get_latest_config() {
                 if Some(&builder_config) != cached_builder_config.as_ref() {
-                    Self::update_tpu_config(Some(&builder_config), &dependencies);
-                    Self::update_shred_socks_config(Some(&builder_config), &dependencies);
+                    Self::update_tpu_config(&builder_config, &dependencies);
+                    Self::update_shred_socks_config(&builder_config, &dependencies);
                     Self::update_block_engine_key_and_commission(
-                        Some(&builder_config),
+                        &builder_config,
                         &dependencies.block_builder_fee_info,
                     );
                     Self::update_bam_recipient_and_commission(
@@ -320,10 +305,7 @@ impl BamManager {
         }
 
         *cached_builder_config = None;
-        dependencies
-            .bam_enabled
-            .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-        Self::clear_bam_shred_receiver_addresses(dependencies);
+        Self::set_bam_disconnected(dependencies);
 
         // When we are still holding a live connection, disconnect first and wait in the
         // disconnected path before starting a new BAM auth handshake.
@@ -365,24 +347,23 @@ impl BamManager {
         }
     }
 
-    fn get_sockaddr(info: Option<&Socket>) -> Option<SocketAddr> {
-        let info = info?;
-        let Socket { ip, port } = info;
+    fn get_sockaddr(Socket { ip, port }: &Socket) -> Option<SocketAddr> {
+        let port = u16::try_from(*port).ok().filter(|port| *port != 0)?;
         Some(SocketAddr::V4(SocketAddrV4::new(
             Ipv4Addr::from_str(ip).ok()?,
-            *port as u16,
+            port,
         )))
     }
 
-    fn update_tpu_config(config: Option<&ConfigResponse>, dependencies: &BamDependencies) {
-        let Some(tpu_info) = config.and_then(|c| c.bam_config.as_ref()) else {
+    fn update_tpu_config(config: &ConfigResponse, dependencies: &BamDependencies) {
+        let Some(tpu_info) = config.bam_config.as_ref() else {
             return;
         };
 
-        let Some(tpu) = Self::get_sockaddr(tpu_info.tpu_sock.as_ref()) else {
-            return;
-        };
-        let Some(tpu_fwd) = Self::get_sockaddr(tpu_info.tpu_fwd_sock.as_ref()) else {
+        let (Some(tpu), Some(tpu_fwd)) = (
+            tpu_info.tpu_sock.as_ref().and_then(Self::get_sockaddr),
+            tpu_info.tpu_fwd_sock.as_ref().and_then(Self::get_sockaddr),
+        ) else {
             return;
         };
         info!("Setting TPU={tpu}, TPU Forward={tpu_fwd} from BAM config");
@@ -391,21 +372,28 @@ impl BamManager {
             .store(Arc::new(Some((tpu, tpu_fwd))));
     }
 
+    fn set_bam_disconnected(dependencies: &BamDependencies) {
+        dependencies
+            .bam_enabled
+            .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+        Self::clear_bam_shred_receiver_addresses(dependencies);
+    }
+
     fn clear_bam_shred_receiver_addresses(dependencies: &BamDependencies) {
         dependencies
             .bam_shred_receiver_addresses
             .store(Arc::new(ShredReceiverAddresses::new()));
     }
 
-    fn update_shred_socks_config(config: Option<&ConfigResponse>, dependencies: &BamDependencies) {
-        let Some(bam_config) = config.and_then(|c| c.bam_config.as_ref()) else {
+    fn update_shred_socks_config(config: &ConfigResponse, dependencies: &BamDependencies) {
+        let Some(bam_config) = config.bam_config.as_ref() else {
             Self::clear_bam_shred_receiver_addresses(dependencies);
             return;
         };
 
         let mut shred_receiver_addresses = ShredReceiverAddresses::new();
         for socket in &bam_config.shred_socks {
-            let Some(addr) = Self::get_sockaddr(Some(socket)) else {
+            let Some(addr) = Self::get_sockaddr(socket) else {
                 warn!(
                     "Dropping invalid BAM shred receiver socket {}:{}",
                     socket.ip, socket.port
@@ -436,10 +424,10 @@ impl BamManager {
     }
 
     fn update_block_engine_key_and_commission(
-        config: Option<&ConfigResponse>,
+        config: &ConfigResponse,
         block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
     ) {
-        let Some(builder_info) = config.and_then(|c| c.block_engine_config.as_ref()) else {
+        let Some(builder_info) = config.block_engine_config.as_ref() else {
             return;
         };
         if builder_info.builder_commission > 100 {

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -368,10 +368,9 @@ impl BamManager {
     fn get_sockaddr(info: Option<&Socket>) -> Option<SocketAddr> {
         let info = info?;
         let Socket { ip, port } = info;
-        let port = u16::try_from(*port).ok().filter(|port| *port != 0)?;
         Some(SocketAddr::V4(SocketAddrV4::new(
             Ipv4Addr::from_str(ip).ok()?,
-            port,
+            *port as u16,
         )))
     }
 

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -857,6 +857,7 @@ impl BankingSimulator {
             Arc::new(ArcSwap::default()),
             Arc::new(ArcSwap::default()),
             Arc::new(ArcSwap::default()),
+            Arc::new(ArcSwap::default()),
         );
 
         info!("Start banking stage!...");

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -179,6 +179,7 @@ impl Tpu {
         relayer_config: Arc<ArcSwap<RelayerConfig>>,
         tip_manager_config: TipManagerConfig,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         bam_url: Arc<ArcSwap<Option<String>>>,
     ) -> Self {
@@ -421,6 +422,7 @@ impl Tpu {
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bank_forks: bank_forks.clone(),
             bam_tpu_info,
+            bam_shred_receiver_addresses: bam_shred_receiver_addresses.clone(),
         };
 
         let mut blacklisted_accounts = HashSet::new();
@@ -525,6 +527,7 @@ impl Tpu {
             votor_event_sender,
             shredstream_receiver_address,
             shred_receiver_addresses,
+            bam_shred_receiver_addresses,
             multicast_receiver_address,
         );
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -237,6 +237,7 @@ impl Tvu {
         vote_connection_cache: Arc<ConnectionCache>,
         votor_init: AlpenglowInitializationState,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
     ) -> Result<Self, String> {
         let migration_status = bank_forks.read().unwrap().migration_status();
 
@@ -375,6 +376,7 @@ impl Tvu {
             tvu_config.xdp_sender,
             votor_event_sender.clone(),
             shred_receiver_addresses,
+            bam_shred_receiver_addresses,
         );
 
         let (ancestor_duplicate_slots_sender, ancestor_duplicate_slots_receiver) = unbounded();
@@ -859,6 +861,7 @@ pub mod tests {
                 bls_connection_cache: Arc::new(bls_connection_cache),
                 voting_service_test_override: None,
             },
+            Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
             Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
         )
         .expect("assume success");

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -862,7 +862,7 @@ pub mod tests {
                 voting_service_test_override: None,
             },
             Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
-            Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+            Arc::default(),
         )
         .expect("assume success");
         exit.store(true, Ordering::Relaxed);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1529,6 +1529,9 @@ impl Validator {
             "New shred signal for the TVU should be the same as the clear bank signal."
         );
 
+        let bam_shred_receiver_addresses =
+            Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new()));
+
         let vote_tracker = Arc::<VoteTracker>::default();
 
         let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
@@ -1713,6 +1716,7 @@ impl Validator {
                 voting_service_test_override: config.voting_service_test_override.clone(),
             },
             config.shred_retransmit_receiver_addresses.clone(),
+            bam_shred_receiver_addresses.clone(),
         )
         .map_err(ValidatorError::Other)?;
 
@@ -1791,6 +1795,7 @@ impl Validator {
             config.relayer_config.clone(),
             config.tip_manager_config.clone(),
             config.shred_receiver_addresses.clone(),
+            bam_shred_receiver_addresses,
             config.multicast_receiver_address.clone(),
             config.bam_url.clone(),
         );

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -394,12 +394,9 @@ pub struct ValidatorConfig {
     // jito configuration
     pub relayer_config: Arc<ArcSwap<RelayerConfig>>,
     pub block_engine_config: Arc<ArcSwap<BlockEngineConfig>>,
-    /// Configured external receivers for this validator's own broadcast path.
-    /// Used for direct leader shreds and replay-triggered rebroadcasts of this
-    /// validator's slots.
+    /// External receivers for this validator's broadcast shreds.
     pub shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
-    /// Configured external receivers for TVU retransmit-stage shreds.
-    /// Does not apply to this validator's own direct leader broadcast path.
+    /// External receivers for TVU retransmit-stage shreds.
     pub shred_retransmit_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
     /// Automatically detected multicast destination for leader shreds.
     pub multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
@@ -1529,8 +1526,7 @@ impl Validator {
             "New shred signal for the TVU should be the same as the clear bank signal."
         );
 
-        let bam_shred_receiver_addresses =
-            Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new()));
+        let bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>> = Arc::default();
 
         let vote_tracker = Arc::<VoteTracker>::default();
 

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -544,7 +544,6 @@ mod bam_manager_tests {
     use {
         super::*,
         arc_swap::ArcSwap,
-        smallvec::SmallVec,
         solana_core::{
             admin_rpc_post_init::{KeyUpdaterType, KeyUpdaters},
             bam_dependencies::{BamConnectionState, BamDependencies},
@@ -576,7 +575,7 @@ mod bam_manager_tests {
             bank_forks,
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
-            bam_shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(SmallVec::default())),
+            bam_shred_receiver_addresses: Arc::default(),
         }
     }
 

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -141,6 +141,7 @@ impl BamNodeApi for MockBamNode {
                     ip: "127.0.0.1".to_string(),
                     port: 8001,
                 }),
+                shred_socks: vec![],
             }),
         }))
     }
@@ -543,6 +544,7 @@ mod bam_manager_tests {
     use {
         super::*,
         arc_swap::ArcSwap,
+        smallvec::SmallVec,
         solana_core::{
             admin_rpc_post_init::{KeyUpdaterType, KeyUpdaters},
             bam_dependencies::{BamConnectionState, BamDependencies},
@@ -574,6 +576,7 @@ mod bam_manager_tests {
             bank_forks,
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
+            bam_shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(SmallVec::default())),
         }
     }
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -8,6 +8,7 @@ use {
     solana_sdk_ids::sysvar,
     solana_svm_type_overrides::sync::Arc,
     solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
+    std::collections::{HashMap, HashSet},
 };
 use {
     crate::{
@@ -46,7 +47,6 @@ use {
         alloc::Layout,
         borrow::Cow,
         cell::RefCell,
-        collections::{HashMap, HashSet},
         fmt::{self, Debug},
         rc::Rc,
     },
@@ -1090,6 +1090,7 @@ mod tests {
         solana_signer::Signer,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION,
+        std::collections::HashSet,
         test_case::test_case,
     };
 

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -9,7 +9,7 @@ use {
         genesis_utils::{GenesisConfigInfo, create_genesis_config},
         shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
     },
-    solana_net_utils::{SocketAddrSpace, bind_to_unspecified, sockets::bind_to_localhost_unique},
+    solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
     solana_pubkey as pubkey,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_signer::Signer,
@@ -35,8 +35,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
         SocketAddrSpace::Unspecified,
     );
     let socket = bind_to_localhost_unique().expect("should bind");
-    let broadcast_socket = BroadcastSocket::Udp(&socket);
-    let shred_receiver_socket = bind_to_unspecified().expect("should bind");
+    let socket = BroadcastSocket::Udp(&socket);
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_benches(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(bank);
@@ -85,8 +84,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
     b.iter(move || {
         let shreds = shreds.clone();
         broadcast_shreds(
-            broadcast_socket,
-            &shred_receiver_socket,
+            socket,
             &shreds,
             &cluster_nodes_cache,
             &last_datapoint,

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -80,7 +80,6 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
     let shreds = Arc::new(shreds);
     let last_datapoint = Arc::new(AtomicInterval::default());
     let shred_receiver_addresses = ShredReceiverAddresses::new();
-    let bam_shred_receiver_addresses = ShredReceiverAddresses::new();
     b.iter(move || {
         let shreds = shreds.clone();
         broadcast_shreds(
@@ -94,7 +93,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
             &SocketAddrSpace::Unspecified,
             &None,
             &shred_receiver_addresses,
-            &bam_shred_receiver_addresses,
+            &shred_receiver_addresses,
             &None,
         )
         .unwrap();

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -81,6 +81,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
     let shreds = Arc::new(shreds);
     let last_datapoint = Arc::new(AtomicInterval::default());
     let shred_receiver_addresses = ShredReceiverAddresses::new();
+    let bam_shred_receiver_addresses = ShredReceiverAddresses::new();
     b.iter(move || {
         let shreds = shreds.clone();
         broadcast_shreds(
@@ -95,6 +96,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
             &SocketAddrSpace::Unspecified,
             &None,
             &shred_receiver_addresses,
+            &bam_shred_receiver_addresses,
             &None,
         )
         .unwrap();

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -33,7 +33,7 @@ use {
     solana_streamer::sendmmsg::{SendPktsError, batch_send},
     solana_time_utils::{AtomicInterval, timestamp},
     std::{
-        collections::{HashMap, HashSet},
+        collections::HashSet,
         net::{SocketAddr, UdpSocket},
         sync::{
             Arc, Mutex, RwLock,
@@ -538,26 +538,22 @@ fn get_additional_external_shred_receiver_addresses(
     bam_shred_receiver_addresses: &ShredReceiverAddresses,
     multicast_receiver_address: &Option<SocketAddr>,
 ) -> ShredReceiverAddresses {
-    let mut seen = HashMap::new();
-    if let Some(addr) = shredstream_receiver_address {
-        seen.insert(*addr, ());
-    }
-
+    let shredstream_receiver_address = shredstream_receiver_address.as_ref();
     let mut additional_external_addrs = ShredReceiverAddresses::new();
     for addr in shred_receiver_addresses {
-        if seen.insert(*addr, ()).is_none() {
+        if Some(addr) != shredstream_receiver_address && !additional_external_addrs.contains(addr) {
             additional_external_addrs.push(*addr);
         }
     }
     for addr in bam_shred_receiver_addresses {
-        if seen.insert(*addr, ()).is_none() {
+        if Some(addr) != shredstream_receiver_address && !additional_external_addrs.contains(addr) {
             additional_external_addrs.push(*addr);
         }
     }
     if let Some(addr) = multicast_receiver_address
-        && !seen.contains_key(addr)
+        && Some(addr) != shredstream_receiver_address
+        && !additional_external_addrs.contains(addr)
     {
-        seen.insert(*addr, ());
         additional_external_addrs.push(*addr);
     }
     // Always truncate to MAX_SHRED_RECEIVER_ADDRESSES at the end.

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -129,6 +129,7 @@ impl BroadcastStageType {
         votor_event_sender: VotorEventSender,
         shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> BroadcastStage {
         let migration_status = bank_forks.read().unwrap().migration_status();
@@ -145,6 +146,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 shred_receiver_addresses,
+                bam_shred_receiver_addresses,
                 multicast_receiver_address,
             ),
 
@@ -160,6 +162,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
 
@@ -174,6 +177,7 @@ impl BroadcastStageType {
                 BroadcastFakeShredsRun::new(0, shred_version),
                 xdp_sender,
                 shredstream_receiver_address,
+                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
@@ -195,6 +199,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
         }
@@ -210,6 +215,7 @@ trait BroadcastRun {
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()>;
+    #[allow(clippy::too_many_arguments)]
     fn transmit(
         &mut self,
         receiver: &TransmitReceiver,
@@ -218,6 +224,7 @@ trait BroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_socket: &UdpSocket,
     ) -> Result<()>;
@@ -318,6 +325,7 @@ impl BroadcastStage {
         xdp_sender: Option<XdpSender>,
         shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> Self {
         let (socket_sender, socket_receiver) = unbounded();
@@ -389,6 +397,7 @@ impl BroadcastStage {
             let xdp_sender = xdp_sender.clone();
             let shredstream_receiver_address = shredstream_receiver_address.clone();
             let shred_receiver_addresses = shred_receiver_addresses.clone();
+            let bam_shred_receiver_addresses = bam_shred_receiver_addresses.clone();
             let multicast_receiver_address = multicast_receiver_address.clone();
             let shred_receiver_socket = shred_receiver_socket.clone();
 
@@ -408,6 +417,7 @@ impl BroadcastStage {
                     &bank_forks,
                     &shredstream_receiver_address,
                     &shred_receiver_addresses,
+                    &bam_shred_receiver_addresses,
                     &multicast_receiver_address,
                     &shred_receiver_socket,
                 );
@@ -522,6 +532,40 @@ fn update_peer_stats(
     }
 }
 
+fn get_additional_external_shred_receiver_addresses(
+    shredstream_receiver_address: &Option<SocketAddr>,
+    shred_receiver_addresses: &ShredReceiverAddresses,
+    bam_shred_receiver_addresses: &ShredReceiverAddresses,
+    multicast_receiver_address: &Option<SocketAddr>,
+) -> ShredReceiverAddresses {
+    let mut seen = HashMap::new();
+    if let Some(addr) = shredstream_receiver_address {
+        seen.insert(*addr, ());
+    }
+
+    let mut additional_external_addrs = ShredReceiverAddresses::new();
+    for addr in shred_receiver_addresses {
+        if seen.insert(*addr, ()).is_none() {
+            additional_external_addrs.push(*addr);
+        }
+    }
+    for addr in bam_shred_receiver_addresses {
+        if seen.insert(*addr, ()).is_none() {
+            additional_external_addrs.push(*addr);
+        }
+    }
+    if let Some(addr) = multicast_receiver_address
+        && !seen.contains_key(addr)
+    {
+        seen.insert(*addr, ());
+        additional_external_addrs.push(*addr);
+    }
+    // Always truncate to MAX_SHRED_RECEIVER_ADDRESSES at the end.
+    additional_external_addrs.truncate(MAX_SHRED_RECEIVER_ADDRESSES);
+
+    additional_external_addrs
+}
+
 #[derive(Clone, Copy)]
 pub enum BroadcastSocket<'a> {
     Udp(&'a UdpSocket),
@@ -543,6 +587,7 @@ pub fn broadcast_shreds(
     socket_addr_space: &SocketAddrSpace,
     shredstream_receiver_address: &Option<SocketAddr>,
     shred_receiver_addresses: &ShredReceiverAddresses,
+    bam_shred_receiver_addresses: &ShredReceiverAddresses,
     multicast_receiver_address: &Option<SocketAddr>,
 ) -> Result<()> {
     let mut result = Ok(());
@@ -575,27 +620,24 @@ pub fn broadcast_shreds(
 
     // Mirror this validator's own broadcast shreds to external receivers
     // (`--shred-receiver-address`), avoiding duplicates when addresses overlap.
-    // Add the cluster multicast address only when the route is present and the
-    // address is not already added.
+    // Add BAM and cluster multicast addresses only when they are present and
+    // not already added.
     if let Some(addr) = shredstream_receiver_address {
         packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
     }
     let external_packets_start = packets.len();
-    packets.reserve(
-        shreds.len().saturating_mul(
-            shred_receiver_addresses.len() + multicast_receiver_address.iter().len(),
-        ),
-    );
-    for addr in shred_receiver_addresses
-        .iter()
-        .filter(|addr| shredstream_receiver_address.as_ref() != Some(addr))
-        .chain(multicast_receiver_address.iter().filter(|addr| {
-            shred_receiver_addresses.len() < MAX_SHRED_RECEIVER_ADDRESSES
-                && !shred_receiver_addresses.contains(addr)
-                && shredstream_receiver_address.as_ref() != Some(addr)
-        }))
-    {
-        packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
+    packets.reserve(shreds.len().saturating_mul(
+        shred_receiver_addresses.len()
+            + bam_shred_receiver_addresses.len()
+            + multicast_receiver_address.iter().len(),
+    ));
+    for addr in get_additional_external_shred_receiver_addresses(
+        shredstream_receiver_address,
+        shred_receiver_addresses,
+        bam_shred_receiver_addresses,
+        multicast_receiver_address,
+    ) {
+        packets.extend(shreds.iter().map(|shred| (shred.payload(), addr)));
     }
     let (packets, external_packets) = packets.split_at(external_packets_start);
 
@@ -767,6 +809,34 @@ pub mod test {
     }
 
     #[test]
+    fn test_bam_shred_receivers_are_added_and_deduped_for_leader_broadcast() {
+        let shredstream_addr = "127.0.0.1:10".parse().unwrap();
+        let regular_addr_1 = "127.0.0.1:11".parse().unwrap();
+        let regular_addr_2 = "127.0.0.1:12".parse().unwrap();
+        let bam_addr = "127.0.0.1:13".parse().unwrap();
+        let multicast_addr = "127.0.0.1:14".parse().unwrap();
+
+        let shred_receiver_addresses: ShredReceiverAddresses =
+            [regular_addr_1, regular_addr_2].into_iter().collect();
+        let bam_shred_receiver_addresses: ShredReceiverAddresses =
+            [regular_addr_2, bam_addr, shredstream_addr]
+                .into_iter()
+                .collect();
+
+        let additional_external_addrs = get_additional_external_shred_receiver_addresses(
+            &Some(shredstream_addr),
+            &shred_receiver_addresses,
+            &bam_shred_receiver_addresses,
+            &Some(multicast_addr),
+        );
+
+        assert_eq!(
+            additional_external_addrs.as_slice(),
+            &[regular_addr_1, regular_addr_2, bam_addr, multicast_addr]
+        );
+    }
+
+    #[test]
     fn test_duplicate_retransmit_signal() {
         // Setup
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -862,6 +932,7 @@ pub mod test {
             bank_forks,
             StandardBroadcastRun::new(0, Arc::new(MigrationStatus::default()), votor_event_sender),
             None,
+            Arc::default(),
             Arc::default(),
             Arc::default(),
             Arc::default(),

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -26,7 +26,7 @@ use {
     solana_ledger::{blockstore::Blockstore, shred::Shred},
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_error,
-    solana_net_utils::{SocketAddrSpace, bind_to_unspecified},
+    solana_net_utils::SocketAddrSpace,
     solana_poh::poh_recorder::WorkingBankEntry,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::MAX_LEADER_SCHEDULE_STAKES, bank_forks::BankForks},
@@ -226,7 +226,6 @@ trait BroadcastRun {
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        shred_receiver_socket: &UdpSocket,
     ) -> Result<()>;
     fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()>;
 }
@@ -352,16 +351,6 @@ impl BroadcastStage {
                 .unwrap()
         };
         let mut thread_hdls = vec![thread_hdl];
-
-        // Dedicated socket bound to 0.0.0.0:0 for sending shreds to ShredReceiverAddresses
-        // and multicast_receiver_address. Not constrained by --bind-address, so the OS
-        // routing table selects the appropriate interface for each destination.
-        let shred_receiver_socket =
-            Arc::new(bind_to_unspecified().expect("bind shred_receiver_socket 0.0.0.0:0"));
-        shred_receiver_socket
-            .set_multicast_ttl_v4(64)
-            .expect("set multicast ttl");
-
         let num_broadcast_sockets_per_interface = socks.len() / cluster_info.bind_ip_addrs().len();
         let num_interfaces: usize = cluster_info.bind_ip_addrs().len();
 
@@ -399,7 +388,6 @@ impl BroadcastStage {
             let shred_receiver_addresses = shred_receiver_addresses.clone();
             let bam_shred_receiver_addresses = bam_shred_receiver_addresses.clone();
             let multicast_receiver_address = multicast_receiver_address.clone();
-            let shred_receiver_socket = shred_receiver_socket.clone();
 
             let run_transmit = move || loop {
                 let sock_variant = match xdp_sender.as_ref() {
@@ -419,7 +407,6 @@ impl BroadcastStage {
                     &shred_receiver_addresses,
                     &bam_shred_receiver_addresses,
                     &multicast_receiver_address,
-                    &shred_receiver_socket,
                 );
                 if let Some(res) = Self::handle_error(res, "solana-broadcaster-transmit") {
                     return res;
@@ -573,7 +560,6 @@ pub enum BroadcastSocket<'a> {
 #[allow(clippy::too_many_arguments)]
 pub fn broadcast_shreds(
     socket: BroadcastSocket,
-    shred_receiver_socket: &UdpSocket,
     shreds: &[Shred],
     cluster_nodes_cache: &ClusterNodesCache<BroadcastStage>,
     last_datapoint_submit: &AtomicInterval,
@@ -621,7 +607,6 @@ pub fn broadcast_shreds(
     if let Some(addr) = shredstream_receiver_address {
         packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
     }
-    let external_packets_start = packets.len();
     packets.reserve(shreds.len().saturating_mul(
         shred_receiver_addresses.len()
             + bam_shred_receiver_addresses.len()
@@ -635,32 +620,18 @@ pub fn broadcast_shreds(
     ) {
         packets.extend(shreds.iter().map(|shred| (shred.payload(), addr)));
     }
-    let (packets, external_packets) = packets.split_at(external_packets_start);
 
     shred_select.stop();
     transmit_stats.shred_select += shred_select.as_us();
-    let num_udp_packets = packets.len() + external_packets.len();
+    let num_udp_packets = packets.len();
     match socket {
         BroadcastSocket::Udp(s) => {
             let mut send_mmsg_time = Measure::start("send_mmsg");
-            // `.copied()` copies only `(&Payload, SocketAddr)`, not payload bytes.
-            match batch_send(s, packets.iter().copied()) {
+            match batch_send(s, packets) {
                 Ok(()) => (),
                 Err(SendPktsError::IoError(ioerr, num_failed)) => {
                     transmit_stats.dropped_packets_udp += num_failed;
                     result = Err(Error::Io(ioerr));
-                }
-            }
-            if !external_packets.is_empty() {
-                // `.copied()` copies only `(&Payload, SocketAddr)`, not payload bytes.
-                match batch_send(shred_receiver_socket, external_packets.iter().copied()) {
-                    Ok(()) => (),
-                    Err(SendPktsError::IoError(ioerr, num_failed)) => {
-                        transmit_stats.dropped_packets_udp += num_failed;
-                        if result.is_ok() {
-                            result = Err(Error::Io(ioerr));
-                        }
-                    }
                 }
             }
             send_mmsg_time.stop();
@@ -668,8 +639,7 @@ pub fn broadcast_shreds(
         }
         BroadcastSocket::Xdp(s) => {
             let mut send_xdp_time = Measure::start("send_xdp");
-            // `.copied()` copies only `(&Payload, SocketAddr)`; `payload.bytes.clone()` is refcount-only.
-            for (idx, (payload, addr)) in packets.iter().copied().enumerate() {
+            for (idx, (payload, addr)) in packets.into_iter().enumerate() {
                 if let Err(e) = s.try_send(idx, addr, payload.bytes.clone()) {
                     log::warn!("xdp channel full: {e:?}");
                     transmit_stats.dropped_packets_xdp += 1;
@@ -678,26 +648,6 @@ pub fn broadcast_shreds(
             }
             send_xdp_time.stop();
             transmit_stats.send_xdp_elapsed += send_xdp_time.as_us();
-            // External receivers (ShredReceiverAddresses + multicast) must be sent via
-            // the dedicated UDP socket bound to 0.0.0.0, even when XDP is active.
-            // XDP bypasses the kernel network stack and is attached to the specific NIC
-            // that corresponds to --bind-address. It has no visibility into the routing
-            // table, so packets destined for an address reachable only through a different
-            // interface will be dropped by the NIC driver or never reach the destination.
-            // The dedicated 0.0.0.0 socket goes through the normal kernel IP stack, which
-            // uses the routing table to select the correct outbound interface per destination.
-            if !external_packets.is_empty() {
-                // `.copied()` copies only `(&Payload, SocketAddr)`, not payload bytes.
-                match batch_send(shred_receiver_socket, external_packets.iter().copied()) {
-                    Ok(()) => (),
-                    Err(SendPktsError::IoError(ioerr, num_failed)) => {
-                        transmit_stats.dropped_packets_udp += num_failed;
-                        if result.is_ok() {
-                            result = Err(Error::Io(ioerr));
-                        }
-                    }
-                }
-            }
         }
     }
 

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -162,7 +162,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
-                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::default(),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
 
@@ -178,7 +178,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
-                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::default(),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
 
@@ -199,7 +199,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
-                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::default(),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
         }
@@ -519,34 +519,36 @@ fn update_peer_stats(
     }
 }
 
-fn get_additional_external_shred_receiver_addresses(
+fn get_external_shred_receiver_addresses(
     shredstream_receiver_address: &Option<SocketAddr>,
     shred_receiver_addresses: &ShredReceiverAddresses,
     bam_shred_receiver_addresses: &ShredReceiverAddresses,
     multicast_receiver_address: &Option<SocketAddr>,
 ) -> ShredReceiverAddresses {
     let shredstream_receiver_address = shredstream_receiver_address.as_ref();
-    let mut additional_external_addrs = ShredReceiverAddresses::new();
-    for addr in shred_receiver_addresses {
-        if Some(addr) != shredstream_receiver_address && !additional_external_addrs.contains(addr) {
-            additional_external_addrs.push(*addr);
-        }
-    }
-    for addr in bam_shred_receiver_addresses {
-        if Some(addr) != shredstream_receiver_address && !additional_external_addrs.contains(addr) {
-            additional_external_addrs.push(*addr);
-        }
-    }
-    if let Some(addr) = multicast_receiver_address
-        && Some(addr) != shredstream_receiver_address
-        && !additional_external_addrs.contains(addr)
+    let num_shred_receiver_addresses = shred_receiver_addresses
+        .len()
+        .min(MAX_SHRED_RECEIVER_ADDRESSES);
+    let external_addr_capacity = num_shred_receiver_addresses
+        .saturating_add(multicast_receiver_address.iter().len())
+        .saturating_add(usize::from(shredstream_receiver_address.is_some()))
+        .saturating_add(bam_shred_receiver_addresses.len());
+    let mut external_addrs = ShredReceiverAddresses::with_capacity(external_addr_capacity);
+    for &addr in shredstream_receiver_address
+        .into_iter()
+        .chain(
+            shred_receiver_addresses
+                .iter()
+                .take(num_shred_receiver_addresses),
+        )
+        .chain(bam_shred_receiver_addresses)
+        .chain(multicast_receiver_address.iter())
     {
-        additional_external_addrs.push(*addr);
+        if !external_addrs.contains(&addr) {
+            external_addrs.push(addr);
+        }
     }
-    // Always truncate to MAX_SHRED_RECEIVER_ADDRESSES at the end.
-    additional_external_addrs.truncate(MAX_SHRED_RECEIVER_ADDRESSES);
-
-    additional_external_addrs
+    external_addrs
 }
 
 #[derive(Clone, Copy)]
@@ -579,46 +581,35 @@ pub fn broadcast_shreds(
         let bank_forks = bank_forks.read().unwrap();
         (bank_forks.root_bank(), bank_forks.working_bank())
     };
-    let mut packets: Vec<_> = shreds
-        .iter()
-        .chunk_by(|shred| shred.slot())
-        .into_iter()
-        .flat_map(|(slot, shreds)| {
-            let cluster_nodes =
-                cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);
-            update_peer_stats(&cluster_nodes, last_datapoint_submit);
-
-            shreds.filter_map(move |shred| {
-                let key = shred.id();
-                let addr = cluster_nodes
-                    .get_broadcast_peer(&key)?
-                    .tvu(Protocol::UDP)
-                    .filter(|addr| socket_addr_space.check(addr))?;
-
-                Some((shred.payload(), addr))
-            })
-        })
-        .collect();
-
-    // Mirror this validator's own broadcast shreds to external receivers
-    // (`--shred-receiver-address`), avoiding duplicates when addresses overlap.
-    // Add BAM and cluster multicast addresses only when they are present and
-    // not already added.
-    if let Some(addr) = shredstream_receiver_address {
-        packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
-    }
-    packets.reserve(shreds.len().saturating_mul(
-        shred_receiver_addresses.len()
-            + bam_shred_receiver_addresses.len()
-            + multicast_receiver_address.iter().len(),
-    ));
-    for addr in get_additional_external_shred_receiver_addresses(
+    let external_addrs = get_external_shred_receiver_addresses(
         shredstream_receiver_address,
         shred_receiver_addresses,
         bam_shred_receiver_addresses,
         multicast_receiver_address,
-    ) {
-        packets.extend(shreds.iter().map(|shred| (shred.payload(), addr)));
+    );
+    let packet_capacity = shreds.len().saturating_mul(1 + external_addrs.len());
+    let mut packets = Vec::with_capacity(packet_capacity);
+    for (slot, shreds) in shreds.iter().chunk_by(|shred| shred.slot()).into_iter() {
+        let cluster_nodes = cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);
+        update_peer_stats(&cluster_nodes, last_datapoint_submit);
+
+        for shred in shreds {
+            let key = shred.id();
+            if let Some(addr) = cluster_nodes
+                .get_broadcast_peer(&key)
+                .and_then(|peer| peer.tvu(Protocol::UDP))
+                .filter(|addr| socket_addr_space.check(addr))
+            {
+                packets.push((shred.payload(), addr));
+            }
+        }
+    }
+
+    // Mirror broadcast shreds to external receivers.
+    for addr in external_addrs {
+        for shred in shreds {
+            packets.push((shred.payload(), addr));
+        }
     }
 
     shred_select.stop();
@@ -755,31 +746,34 @@ pub mod test {
     }
 
     #[test]
-    fn test_bam_shred_receivers_are_added_and_deduped_for_leader_broadcast() {
-        let shredstream_addr = "127.0.0.1:10".parse().unwrap();
-        let regular_addr_1 = "127.0.0.1:11".parse().unwrap();
-        let regular_addr_2 = "127.0.0.1:12".parse().unwrap();
-        let bam_addr = "127.0.0.1:13".parse().unwrap();
-        let multicast_addr = "127.0.0.1:14".parse().unwrap();
+    fn test_external_shred_receivers_are_deduped_and_configured_cap_only() {
+        let addr = |port| SocketAddr::from(([127, 0, 0, 1], port));
+        let shredstream_addr = addr(9_999);
+        let configured_addrs: ShredReceiverAddresses = (0..=MAX_SHRED_RECEIVER_ADDRESSES)
+            .map(|i| addr(10_000 + u16::try_from(i).unwrap()))
+            .collect();
+        let bam_addr = addr(20_000);
+        let multicast_addr = addr(20_001);
+        let bam_addrs: ShredReceiverAddresses = [configured_addrs[1], bam_addr, shredstream_addr]
+            .into_iter()
+            .collect();
 
-        let shred_receiver_addresses: ShredReceiverAddresses =
-            [regular_addr_1, regular_addr_2].into_iter().collect();
-        let bam_shred_receiver_addresses: ShredReceiverAddresses =
-            [regular_addr_2, bam_addr, shredstream_addr]
-                .into_iter()
-                .collect();
-
-        let additional_external_addrs = get_additional_external_shred_receiver_addresses(
+        let external_addrs = get_external_shred_receiver_addresses(
             &Some(shredstream_addr),
-            &shred_receiver_addresses,
-            &bam_shred_receiver_addresses,
+            &configured_addrs,
+            &bam_addrs,
             &Some(multicast_addr),
         );
 
+        assert_eq!(external_addrs[0], shredstream_addr);
         assert_eq!(
-            additional_external_addrs.as_slice(),
-            &[regular_addr_1, regular_addr_2, bam_addr, multicast_addr]
+            &external_addrs.as_slice()[1..=MAX_SHRED_RECEIVER_ADDRESSES],
+            &configured_addrs.as_slice()[..MAX_SHRED_RECEIVER_ADDRESSES]
         );
+        assert!(!external_addrs.contains(&configured_addrs[MAX_SHRED_RECEIVER_ADDRESSES]));
+        assert!(external_addrs.contains(&bam_addr));
+        assert!(external_addrs.contains(&multicast_addr));
+        assert_eq!(external_addrs.len(), MAX_SHRED_RECEIVER_ADDRESSES + 3);
     }
 
     #[test]

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -339,7 +339,6 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         _shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        _shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         if shreds.is_empty() {

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -337,6 +337,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         bank_forks: &RwLock<BankForks>,
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        _bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -159,6 +159,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         _bank_forks: &RwLock<BankForks>,
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        _bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -161,7 +161,6 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         _shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        _shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
         let sock = match sock {
             BroadcastSocket::Udp(sock) => sock,

--- a/turbine/src/broadcast_stage/broadcast_metrics.rs
+++ b/turbine/src/broadcast_stage/broadcast_metrics.rs
@@ -1,4 +1,4 @@
-use super::*;
+use {super::*, std::collections::HashMap};
 
 pub(crate) trait BroadcastStats {
     fn update(&mut self, new_stats: &Self);

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -186,6 +186,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
@@ -202,6 +203,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             cluster_info.socket_addr_space(),
             &shredstream_receiver_address.load(),
             &shred_receiver_addresses.load(),
+            &bam_shred_receiver_addresses.load(),
             &multicast_receiver_address.load(),
         )
     }

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -4,11 +4,7 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
-    std::{
-        net::{SocketAddr, UdpSocket},
-        thread::sleep,
-        time::Duration,
-    },
+    std::{net::SocketAddr, thread::sleep, time::Duration},
 };
 
 pub const NUM_BAD_SLOTS: u64 = 10;
@@ -188,12 +184,10 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         broadcast_shreds(
             sock,
-            shred_receiver_socket,
             &shreds,
             &self.cluster_nodes_cache,
             &AtomicInterval::default(),

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -190,6 +190,7 @@ impl StandardBroadcastRun {
             &ArcSwap::default(),
             &ArcSwap::default(),
             &ArcSwap::default(),
+            &ArcSwap::default(),
             &shred_receiver_socket,
         );
         let _ = self.record(&brecv, blockstore);
@@ -404,6 +405,7 @@ impl StandardBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &Option<SocketAddr>,
         shred_receiver_addresses: &ShredReceiverAddresses,
+        bam_shred_receiver_addresses: &ShredReceiverAddresses,
         multicast_receiver_address: &Option<SocketAddr>,
     ) -> Result<()> {
         trace!("Broadcasting {:?} shreds", shreds.len());
@@ -428,6 +430,7 @@ impl StandardBroadcastRun {
             cluster_info.socket_addr_space(),
             shredstream_receiver_address,
             shred_receiver_addresses,
+            bam_shred_receiver_addresses,
             multicast_receiver_address,
         )?;
         transmit_time.stop();
@@ -497,6 +500,7 @@ impl BroadcastRun for StandardBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
@@ -510,6 +514,7 @@ impl BroadcastRun for StandardBroadcastRun {
             bank_forks,
             &shredstream_receiver_address.load(),
             &shred_receiver_addresses.load(),
+            &bam_shred_receiver_addresses.load(),
             &multicast_receiver_address.load(),
         )
     }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -180,8 +180,6 @@ impl StandardBroadcastRun {
             &mut ProcessShredsStats::default(),
         )?;
         // Data and coding shreds are sent in a single batch.
-        let shred_receiver_socket =
-            solana_net_utils::bind_to_unspecified().expect("bind test shred_receiver_socket");
         let _ = self.transmit(
             &srecv,
             cluster_info,
@@ -191,7 +189,6 @@ impl StandardBroadcastRun {
             &ArcSwap::default(),
             &ArcSwap::default(),
             &ArcSwap::default(),
-            &shred_receiver_socket,
         );
         let _ = self.record(&brecv, blockstore);
         Ok(())
@@ -394,11 +391,9 @@ impl StandardBroadcastRun {
         insert_shreds_stats.update(new_insertion_shreds_stats, broadcast_shred_batch_info);
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn broadcast(
         &mut self,
         sock: BroadcastSocket,
-        shred_receiver_socket: &UdpSocket,
         cluster_info: &ClusterInfo,
         shreds: Arc<Vec<Shred>>,
         broadcast_shred_batch_info: Option<BroadcastShredBatchInfo>,
@@ -420,7 +415,6 @@ impl StandardBroadcastRun {
 
         broadcast_shreds(
             sock,
-            shred_receiver_socket,
             &shreds,
             &self.cluster_nodes_cache,
             &self.last_datapoint_submit,
@@ -502,12 +496,10 @@ impl BroadcastRun for StandardBroadcastRun {
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
-        shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
         let (shreds, batch_info) = receiver.recv()?;
         self.broadcast(
             sock,
-            shred_receiver_socket,
             cluster_info,
             shreds,
             batch_info,

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        ShredReceiverAddresses,
+        MAX_SHRED_RECEIVER_ADDRESSES, ShredReceiverAddresses,
         addr_cache::AddrCache,
         cluster_nodes::{
             ClusterNodes, ClusterNodesCache, DATA_PLANE_FANOUT, Error, MAX_NUM_TURBINE_HOPS,
@@ -367,12 +367,18 @@ fn retransmit(
         .flatten()
         .filter_map(|shred| shred::layout::get_slot(shred))
         .collect();
-    let bam_forward_slots = get_bam_forward_slots(
-        &shred_slots,
-        leader_schedule_cache,
-        &cluster_info.id(),
-        &working_bank,
-    );
+    let my_pubkey = cluster_info.id();
+    let bam_forward_slots: HashSet<Slot> = shred_slots
+        .iter()
+        .copied()
+        .filter(|slot| {
+            should_forward_to_bam_for_slot_with_leader_lookup(*slot, &my_pubkey, |slot| {
+                leader_schedule_cache
+                    .slot_leader_at(slot, Some(&working_bank))
+                    .map(|leader| leader.id)
+            })
+        })
+        .collect();
 
     // Lookup slot leader and cluster nodes for each slot.
     let cache: HashMap<Slot, _> = shred_slots
@@ -468,19 +474,6 @@ fn retransmit(
     Ok(())
 }
 
-fn should_forward_to_bam_for_slot(
-    slot: Slot,
-    leader_schedule_cache: &LeaderScheduleCache,
-    my_pubkey: &Pubkey,
-    working_bank: &Bank,
-) -> bool {
-    should_forward_to_bam_for_slot_with_leader_lookup(slot, my_pubkey, |slot| {
-        leader_schedule_cache
-            .slot_leader_at(slot, Some(working_bank))
-            .map(|leader| leader.id)
-    })
-}
-
 fn should_forward_to_bam_for_slot_with_leader_lookup(
     slot: Slot,
     my_pubkey: &Pubkey,
@@ -491,21 +484,6 @@ fn should_forward_to_bam_for_slot_with_leader_lookup(
             .and_then(&mut leader_at_slot)
             .is_some_and(|leader| leader == *my_pubkey)
     })
-}
-
-fn get_bam_forward_slots(
-    shred_slots: &HashSet<Slot>,
-    leader_schedule_cache: &LeaderScheduleCache,
-    my_pubkey: &Pubkey,
-    working_bank: &Bank,
-) -> HashSet<Slot> {
-    shred_slots
-        .iter()
-        .copied()
-        .filter(|slot| {
-            should_forward_to_bam_for_slot(*slot, leader_schedule_cache, my_pubkey, working_bank)
-        })
-        .collect()
 }
 
 // Retransmit a single shred to all downstream nodes
@@ -543,40 +521,41 @@ fn retransmit_shred(
     let mut retransmit_time = Measure::start("retransmit_to");
     let num_addrs = addrs.len();
     let include_bam_shred_receivers = bam_forward_slots.contains(&key.slot());
+    let num_shred_receiver_addresses = shred_receiver_addresses
+        .len()
+        .min(MAX_SHRED_RECEIVER_ADDRESSES);
+    let mut send_addrs = Vec::with_capacity(
+        num_addrs
+            .saturating_add(num_shred_receiver_addresses)
+            .saturating_add(if include_bam_shred_receivers {
+                bam_shred_receiver_addresses.len()
+            } else {
+                0
+            }),
+    );
+    for addr in addrs.iter().chain(
+        shred_receiver_addresses
+            .iter()
+            .take(num_shred_receiver_addresses),
+    ) {
+        if !send_addrs.contains(addr) {
+            send_addrs.push(*addr);
+        }
+    }
+    if include_bam_shred_receivers {
+        for addr in bam_shred_receiver_addresses.iter() {
+            if !send_addrs.contains(addr) {
+                send_addrs.push(*addr);
+            }
+        }
+    }
     let num_nodes = match socket {
         RetransmitSocket::Xdp(sender) => {
             let mut sent = num_addrs;
-            let mut send_addrs = Vec::with_capacity(
-                num_addrs
-                    .saturating_add(shred_receiver_addresses.len())
-                    .saturating_add(if include_bam_shred_receivers {
-                        bam_shred_receiver_addresses.len()
-                    } else {
-                        0
-                    }),
-            );
-            for addr in addrs.iter() {
-                if !send_addrs.contains(addr) {
-                    send_addrs.push(*addr);
-                }
-            }
-            for addr in shred_receiver_addresses.iter() {
-                if !send_addrs.contains(addr) {
-                    send_addrs.push(*addr);
-                }
-            }
-            if include_bam_shred_receivers {
-                for addr in bam_shred_receiver_addresses.iter() {
-                    if !send_addrs.contains(addr) {
-                        send_addrs.push(*addr);
-                    }
-                }
-            }
             if !send_addrs.is_empty()
                 && let Err(e) = sender.try_send(key.index() as usize, send_addrs, shred.bytes)
             {
-                // External retransmit receivers (`--shred-retransmit-receiver-address`) are
-                // intentionally not included in retransmit stats.
+                // External shred receivers are intentionally not included in retransmit stats.
                 log::warn!("xdp channel full: {e:?}");
                 stats
                     .num_shreds_dropped_xdp_full
@@ -587,32 +566,6 @@ fn retransmit_shred(
         }
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();
-            let mut send_addrs = Vec::with_capacity(
-                num_addrs
-                    .saturating_add(shred_receiver_addresses.len())
-                    .saturating_add(if include_bam_shred_receivers {
-                        bam_shred_receiver_addresses.len()
-                    } else {
-                        0
-                    }),
-            );
-            for addr in addrs.iter() {
-                if !send_addrs.contains(addr) {
-                    send_addrs.push(*addr);
-                }
-            }
-            for addr in shred_receiver_addresses.iter() {
-                if !send_addrs.contains(addr) {
-                    send_addrs.push(*addr);
-                }
-            }
-            if include_bam_shred_receivers {
-                for addr in bam_shred_receiver_addresses.iter() {
-                    if !send_addrs.contains(addr) {
-                        send_addrs.push(*addr);
-                    }
-                }
-            }
             if send_addrs.is_empty() {
                 0
             } else {

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -306,6 +306,7 @@ fn retransmit(
     votor_event_sender: &Sender<VotorEvent>,
     migration_status: &MigrationStatus,
     shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+    bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
 ) -> Result<(), ()> {
     // Try to receive shreds from the channel without blocking. If the channel
     // is empty precompute turbine trees speculatively. If no cache updates are
@@ -361,12 +362,20 @@ fn retransmit(
     );
     epoch_cache_update.stop();
     stats.epoch_cache_update += epoch_cache_update.as_us();
-    // Lookup slot leader and cluster nodes for each slot.
-    let cache: HashMap<Slot, _> = shred_buf
+    let shred_slots: HashSet<Slot> = shred_buf
         .iter()
         .flatten()
         .filter_map(|shred| shred::layout::get_slot(shred))
-        .collect::<HashSet<Slot>>()
+        .collect();
+    let bam_forward_slots = get_bam_forward_slots(
+        &shred_slots,
+        leader_schedule_cache,
+        &cluster_info.id(),
+        &working_bank,
+    );
+
+    // Lookup slot leader and cluster nodes for each slot.
+    let cache: HashMap<Slot, _> = shred_slots
         .into_iter()
         .filter_map(|slot: Slot| {
             max_slots.retransmit.fetch_max(slot, Ordering::Relaxed);
@@ -393,6 +402,7 @@ fn retransmit(
         stats
     };
     let shred_receiver_addresses_local = shred_receiver_addresses.load();
+    let bam_shred_receiver_addresses_local = bam_shred_receiver_addresses.load();
     let retransmit_shred = |shred, socket, stats| {
         retransmit_shred(
             shred,
@@ -404,6 +414,8 @@ fn retransmit(
             socket,
             stats,
             &shred_receiver_addresses_local,
+            &bam_forward_slots,
+            &bam_shred_receiver_addresses_local,
         )
     };
 
@@ -456,6 +468,46 @@ fn retransmit(
     Ok(())
 }
 
+fn should_forward_to_bam_for_slot(
+    slot: Slot,
+    leader_schedule_cache: &LeaderScheduleCache,
+    my_pubkey: &Pubkey,
+    working_bank: &Bank,
+) -> bool {
+    should_forward_to_bam_for_slot_with_leader_lookup(slot, my_pubkey, |slot| {
+        leader_schedule_cache
+            .slot_leader_at(slot, Some(working_bank))
+            .map(|leader| leader.id)
+    })
+}
+
+fn should_forward_to_bam_for_slot_with_leader_lookup(
+    slot: Slot,
+    my_pubkey: &Pubkey,
+    mut leader_at_slot: impl FnMut(Slot) -> Option<Pubkey>,
+) -> bool {
+    (0..3).any(|offset| {
+        slot.checked_add(offset)
+            .and_then(&mut leader_at_slot)
+            .is_some_and(|leader| leader == *my_pubkey)
+    })
+}
+
+fn get_bam_forward_slots(
+    shred_slots: &HashSet<Slot>,
+    leader_schedule_cache: &LeaderScheduleCache,
+    my_pubkey: &Pubkey,
+    working_bank: &Bank,
+) -> HashSet<Slot> {
+    shred_slots
+        .iter()
+        .copied()
+        .filter(|slot| {
+            should_forward_to_bam_for_slot(*slot, leader_schedule_cache, my_pubkey, working_bank)
+        })
+        .collect()
+}
+
 // Retransmit a single shred to all downstream nodes
 #[allow(clippy::too_many_arguments)]
 fn retransmit_shred(
@@ -468,6 +520,8 @@ fn retransmit_shred(
     socket: RetransmitSocket<'_>,
     stats: &RetransmitStats,
     shred_receiver_addresses: &ShredReceiverAddresses,
+    bam_forward_slots: &HashSet<Slot>,
+    bam_shred_receiver_addresses: &ShredReceiverAddresses,
 ) -> Option<RetransmitShredOutput> {
     let key = shred::layout::get_shred_id(shred.as_ref())?;
     if key.slot() < root_bank.slot()
@@ -488,13 +542,24 @@ fn retransmit_shred(
         .unwrap_or_default();
     let mut retransmit_time = Measure::start("retransmit_to");
     let num_addrs = addrs.len();
+    let include_bam_shred_receivers = bam_forward_slots.contains(&key.slot());
     let num_nodes = match socket {
         RetransmitSocket::Xdp(sender) => {
             let mut sent = num_addrs;
-            let mut send_addrs =
-                Vec::with_capacity(num_addrs.saturating_add(shred_receiver_addresses.len()));
+            let mut send_addrs = Vec::with_capacity(
+                num_addrs
+                    .saturating_add(shred_receiver_addresses.len())
+                    .saturating_add(if include_bam_shred_receivers {
+                        bam_shred_receiver_addresses.len()
+                    } else {
+                        0
+                    }),
+            );
             send_addrs.extend(addrs.iter().copied());
             send_addrs.extend(shred_receiver_addresses.iter().copied());
+            if include_bam_shred_receivers {
+                send_addrs.extend(bam_shred_receiver_addresses.iter().copied());
+            }
             if !send_addrs.is_empty()
                 && let Err(e) = sender.try_send(key.index() as usize, send_addrs, shred.bytes)
             {
@@ -510,10 +575,20 @@ fn retransmit_shred(
         }
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();
-            let mut send_addrs =
-                Vec::with_capacity(num_addrs.saturating_add(shred_receiver_addresses.len()));
+            let mut send_addrs = Vec::with_capacity(
+                num_addrs
+                    .saturating_add(shred_receiver_addresses.len())
+                    .saturating_add(if include_bam_shred_receivers {
+                        bam_shred_receiver_addresses.len()
+                    } else {
+                        0
+                    }),
+            );
             send_addrs.extend(addrs.iter().copied());
             send_addrs.extend(shred_receiver_addresses.iter().copied());
+            if include_bam_shred_receivers {
+                send_addrs.extend(bam_shred_receiver_addresses.iter().copied());
+            }
             if send_addrs.is_empty() {
                 0
             } else {
@@ -666,6 +741,7 @@ impl RetransmitStage {
         xdp_sender: Option<XdpSender>,
         votor_event_sender: Sender<VotorEvent>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
     ) -> Self {
         let migration_status = bank_forks.read().unwrap().migration_status();
         let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
@@ -710,6 +786,7 @@ impl RetransmitStage {
                         &votor_event_sender,
                         &migration_status,
                         &shred_receiver_addresses,
+                        &bam_shred_receiver_addresses,
                     )
                     .is_ok()
                     {}
@@ -957,6 +1034,51 @@ mod tests {
             .map(Keypair::try_from)
             .unwrap()
             .unwrap()
+    }
+
+    #[test]
+    fn test_should_forward_to_bam_for_slot_near_leader_window() {
+        let my_pubkey = Pubkey::new_unique();
+        let other_pubkey = Pubkey::new_unique();
+        let leader_window = 10..=13;
+        let leader_at_slot = |slot| {
+            Some(if leader_window.contains(&slot) {
+                my_pubkey
+            } else {
+                other_pubkey
+            })
+        };
+
+        assert!(!should_forward_to_bam_for_slot_with_leader_lookup(
+            7,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            8,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            9,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            10,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            13,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(!should_forward_to_bam_for_slot_with_leader_lookup(
+            14,
+            &my_pubkey,
+            leader_at_slot
+        ));
     }
 
     #[test]

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -555,20 +555,19 @@ fn retransmit_shred(
                         0
                     }),
             );
-            let mut seen_addrs = HashSet::with_capacity(send_addrs.capacity());
             for addr in addrs.iter() {
-                if seen_addrs.insert(*addr) {
+                if !send_addrs.contains(addr) {
                     send_addrs.push(*addr);
                 }
             }
             for addr in shred_receiver_addresses.iter() {
-                if seen_addrs.insert(*addr) {
+                if !send_addrs.contains(addr) {
                     send_addrs.push(*addr);
                 }
             }
             if include_bam_shred_receivers {
                 for addr in bam_shred_receiver_addresses.iter() {
-                    if seen_addrs.insert(*addr) {
+                    if !send_addrs.contains(addr) {
                         send_addrs.push(*addr);
                     }
                 }
@@ -597,20 +596,19 @@ fn retransmit_shred(
                         0
                     }),
             );
-            let mut seen_addrs = HashSet::with_capacity(send_addrs.capacity());
             for addr in addrs.iter() {
-                if seen_addrs.insert(*addr) {
+                if !send_addrs.contains(addr) {
                     send_addrs.push(*addr);
                 }
             }
             for addr in shred_receiver_addresses.iter() {
-                if seen_addrs.insert(*addr) {
+                if !send_addrs.contains(addr) {
                     send_addrs.push(*addr);
                 }
             }
             if include_bam_shred_receivers {
                 for addr in bam_shred_receiver_addresses.iter() {
-                    if seen_addrs.insert(*addr) {
+                    if !send_addrs.contains(addr) {
                         send_addrs.push(*addr);
                     }
                 }

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -555,10 +555,23 @@ fn retransmit_shred(
                         0
                     }),
             );
-            send_addrs.extend(addrs.iter().copied());
-            send_addrs.extend(shred_receiver_addresses.iter().copied());
+            let mut seen_addrs = HashSet::with_capacity(send_addrs.capacity());
+            for addr in addrs.iter() {
+                if seen_addrs.insert(*addr) {
+                    send_addrs.push(*addr);
+                }
+            }
+            for addr in shred_receiver_addresses.iter() {
+                if seen_addrs.insert(*addr) {
+                    send_addrs.push(*addr);
+                }
+            }
             if include_bam_shred_receivers {
-                send_addrs.extend(bam_shred_receiver_addresses.iter().copied());
+                for addr in bam_shred_receiver_addresses.iter() {
+                    if seen_addrs.insert(*addr) {
+                        send_addrs.push(*addr);
+                    }
+                }
             }
             if !send_addrs.is_empty()
                 && let Err(e) = sender.try_send(key.index() as usize, send_addrs, shred.bytes)
@@ -584,10 +597,23 @@ fn retransmit_shred(
                         0
                     }),
             );
-            send_addrs.extend(addrs.iter().copied());
-            send_addrs.extend(shred_receiver_addresses.iter().copied());
+            let mut seen_addrs = HashSet::with_capacity(send_addrs.capacity());
+            for addr in addrs.iter() {
+                if seen_addrs.insert(*addr) {
+                    send_addrs.push(*addr);
+                }
+            }
+            for addr in shred_receiver_addresses.iter() {
+                if seen_addrs.insert(*addr) {
+                    send_addrs.push(*addr);
+                }
+            }
             if include_bam_shred_receivers {
-                send_addrs.extend(bam_shred_receiver_addresses.iter().copied());
+                for addr in bam_shred_receiver_addresses.iter() {
+                    if seen_addrs.insert(*addr) {
+                        send_addrs.push(*addr);
+                    }
+                }
             }
             if send_addrs.is_empty() {
                 0


### PR DESCRIPTION
1. Refactors BAM disconnect/config code in core/src/bam_manager.rs:347
    - Deduplicates repeated “set disconnected and clear BAM shred receivers” logic into set_bam_disconnected.
    - Changes BAM socket parsing to reject port 0 and ports outside u16 instead of silently casting.
    - Keeps the existing BAM shred receiver cap/dedup behavior.
2. Changes external shred receiver ordering/capping in turbine/src/broadcast_stage.rs:522
    - Before: shredstream was sent separately, then configured + BAM + multicast receivers were deduped and globally truncated to MAX_SHRED_RECEIVER_ADDRESSES.
    - After: external receivers are deduped in one list: shredstream, configured receivers capped at 32, then BAM receivers, then multicast.
    - This means BAM/multicast receivers no longer get dropped just because the operator configured 32 regular shred receivers. That is a real behavior change, not just cleanup.
3. Cleans up retransmit send address assembly in turbine/src/retransmit_stage.rs:521
    - Builds the deduped send list once for both UDP and XDP paths.
    - Caps regular retransmit receiver addresses at 32 before appending BAM addresses.
    - Inlines a couple of small helper functions.
