### PR TITLE
[Master] Shred rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "rayon",
+ "smallvec",
  "solana-client",
  "solana-compute-budget-interface",
  "solana-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,6 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "rayon",
- "smallvec",
  "solana-client",
  "solana-compute-budget-interface",
  "solana-core",

--- a/bam-banking-bench/Cargo.toml
+++ b/bam-banking-bench/Cargo.toml
@@ -25,7 +25,6 @@ jito-protos = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-smallvec.workspace = true
 solana-client = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-core = { workspace = true }

--- a/bam-banking-bench/Cargo.toml
+++ b/bam-banking-bench/Cargo.toml
@@ -25,6 +25,7 @@ jito-protos = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
+smallvec.workspace = true
 solana-client = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-core = { workspace = true }

--- a/bam-banking-bench/src/main.rs
+++ b/bam-banking-bench/src/main.rs
@@ -8,7 +8,6 @@ use {
     clap::{Arg, Command, crate_description, crate_name},
     crossbeam_channel::{Receiver, unbounded},
     log::*,
-    smallvec::SmallVec,
     solana_core::{
         bam_dependencies::{BamConnectionState, BamDependencies},
         banking_stage::{
@@ -127,7 +126,7 @@ fn main() {
         bank_forks: bank_forks.clone(),
         bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::new_unique())),
         bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
-        bam_shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(SmallVec::default())),
+        bam_shred_receiver_addresses: Arc::default(),
     };
 
     let keypairs = (0..matches.value_of_t::<usize>("num_keypairs").unwrap())

--- a/bam-banking-bench/src/main.rs
+++ b/bam-banking-bench/src/main.rs
@@ -8,6 +8,7 @@ use {
     clap::{Arg, Command, crate_description, crate_name},
     crossbeam_channel::{Receiver, unbounded},
     log::*,
+    smallvec::SmallVec,
     solana_core::{
         bam_dependencies::{BamConnectionState, BamDependencies},
         banking_stage::{
@@ -126,6 +127,7 @@ fn main() {
         bank_forks: bank_forks.clone(),
         bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::new_unique())),
         bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
+        bam_shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(SmallVec::default())),
     };
 
     let keypairs = (0..matches.value_of_t::<usize>("num_keypairs").unwrap())

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -74,6 +74,33 @@ cargo_audit_ignores=(
   # Solution:  Upgrade to >=0.17.12
   --ignore RUSTSEC-2025-0009
 
+  # Crate:     rustls-webpki
+  # Version:   0.103.10
+  # Title:     Name constraints for URI names were incorrectly accepted
+  # Date:      2026-04-14
+  # ID:        RUSTSEC-2026-0098
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
+  # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
+  --ignore RUSTSEC-2026-0098
+
+  # Crate:     rustls-webpki
+  # Version:   0.103.10
+  # Title:     Name constraints were accepted for certificates asserting a wildcard name
+  # Date:      2026-04-14
+  # ID:        RUSTSEC-2026-0099
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
+  # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
+  --ignore RUSTSEC-2026-0099
+
+  # Crate:     rustls-webpki
+  # Version:   0.103.10
+  # Title:     Reachable panic in certificate revocation list parsing
+  # Date:      2026-04-22
+  # ID:        RUSTSEC-2026-0104
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0104
+  # Solution:  Upgrade to >=0.103.13, <0.104.0-alpha.1 OR >=0.104.0-alpha.7
+  --ignore RUSTSEC-2026-0104
+
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s

--- a/core/src/bam_dependencies.rs
+++ b/core/src/bam_dependencies.rs
@@ -11,6 +11,7 @@ use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
+    solana_turbine::ShredReceiverAddresses,
     std::sync::RwLock,
 };
 
@@ -55,6 +56,7 @@ pub struct BamDependencies {
     pub bank_forks: Arc<RwLock<BankForks>>,
     pub bam_node_pubkey: Arc<ArcSwap<Pubkey>>,
     pub bam_tpu_info: Arc<ArcSwap<Option<(std::net::SocketAddr, std::net::SocketAddr)>>>,
+    pub bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
 }
 
 pub fn v0_to_versioned_proto(v0: SchedulerMessageV0) -> SchedulerMessage {

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -153,10 +153,7 @@ impl BamManager {
                     // Try to connect to BAM
                     let bam_url = bam_url.load();
                     let Some(url) = bam_url.as_ref() else {
-                        dependencies
-                            .bam_enabled
-                            .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-                        Self::clear_bam_shred_receiver_addresses(&dependencies);
+                        Self::set_bam_disconnected(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     };
@@ -174,10 +171,7 @@ impl BamManager {
                         Ok(connection) => connection,
                         Err(e) => {
                             error!("Failed to connect to BAM with url: {url}: {e}");
-                            dependencies
-                                .bam_enabled
-                                .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-                            Self::clear_bam_shred_receiver_addresses(&dependencies);
+                            Self::set_bam_disconnected(&dependencies);
                             std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                             continue;
                         }
@@ -194,20 +188,17 @@ impl BamManager {
                              retry",
                         );
                         cached_builder_config = None;
-                        dependencies
-                            .bam_enabled
-                            .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-                        Self::clear_bam_shred_receiver_addresses(&dependencies);
+                        Self::set_bam_disconnected(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     }
 
                     info!("BAM connection established");
                     if let Some(builder_config) = connection.get_latest_config() {
-                        Self::update_tpu_config(Some(&builder_config), &dependencies);
-                        Self::update_shred_socks_config(Some(&builder_config), &dependencies);
+                        Self::update_tpu_config(&builder_config, &dependencies);
+                        Self::update_shred_socks_config(&builder_config, &dependencies);
                         Self::update_block_engine_key_and_commission(
-                            Some(&builder_config),
+                            &builder_config,
                             &dependencies.block_builder_fee_info,
                         );
                         Self::update_bam_recipient_and_commission(
@@ -223,10 +214,7 @@ impl BamManager {
 
             if !connection.is_healthy() {
                 cached_builder_config = None;
-                dependencies
-                    .bam_enabled
-                    .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-                Self::clear_bam_shred_receiver_addresses(&dependencies);
+                Self::set_bam_disconnected(&dependencies);
                 warn!("BAM connection unhealthy");
                 continue;
             }
@@ -247,10 +235,7 @@ impl BamManager {
             let configured_bam_url = bam_url.load();
             if configured_bam_url.as_deref() != Some(connection.url()) {
                 cached_builder_config = None;
-                dependencies
-                    .bam_enabled
-                    .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-                Self::clear_bam_shred_receiver_addresses(&dependencies);
+                Self::set_bam_disconnected(&dependencies);
                 if let Some(new_url) = configured_bam_url.as_deref() {
                     info!("BAM URL changed, connecting to new URL: {new_url}");
                 } else {
@@ -262,10 +247,10 @@ impl BamManager {
             // Check if block builder info has changed
             if let Some(builder_config) = connection.get_latest_config() {
                 if Some(&builder_config) != cached_builder_config.as_ref() {
-                    Self::update_tpu_config(Some(&builder_config), &dependencies);
-                    Self::update_shred_socks_config(Some(&builder_config), &dependencies);
+                    Self::update_tpu_config(&builder_config, &dependencies);
+                    Self::update_shred_socks_config(&builder_config, &dependencies);
                     Self::update_block_engine_key_and_commission(
-                        Some(&builder_config),
+                        &builder_config,
                         &dependencies.block_builder_fee_info,
                     );
                     Self::update_bam_recipient_and_commission(
@@ -320,10 +305,7 @@ impl BamManager {
         }
 
         *cached_builder_config = None;
-        dependencies
-            .bam_enabled
-            .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
-        Self::clear_bam_shred_receiver_addresses(dependencies);
+        Self::set_bam_disconnected(dependencies);
 
         // When we are still holding a live connection, disconnect first and wait in the
         // disconnected path before starting a new BAM auth handshake.
@@ -365,24 +347,23 @@ impl BamManager {
         }
     }
 
-    fn get_sockaddr(info: Option<&Socket>) -> Option<SocketAddr> {
-        let info = info?;
-        let Socket { ip, port } = info;
+    fn get_sockaddr(Socket { ip, port }: &Socket) -> Option<SocketAddr> {
+        let port = u16::try_from(*port).ok().filter(|port| *port != 0)?;
         Some(SocketAddr::V4(SocketAddrV4::new(
             Ipv4Addr::from_str(ip).ok()?,
-            *port as u16,
+            port,
         )))
     }
 
-    fn update_tpu_config(config: Option<&ConfigResponse>, dependencies: &BamDependencies) {
-        let Some(tpu_info) = config.and_then(|c| c.bam_config.as_ref()) else {
+    fn update_tpu_config(config: &ConfigResponse, dependencies: &BamDependencies) {
+        let Some(tpu_info) = config.bam_config.as_ref() else {
             return;
         };
 
-        let Some(tpu) = Self::get_sockaddr(tpu_info.tpu_sock.as_ref()) else {
-            return;
-        };
-        let Some(tpu_fwd) = Self::get_sockaddr(tpu_info.tpu_fwd_sock.as_ref()) else {
+        let (Some(tpu), Some(tpu_fwd)) = (
+            tpu_info.tpu_sock.as_ref().and_then(Self::get_sockaddr),
+            tpu_info.tpu_fwd_sock.as_ref().and_then(Self::get_sockaddr),
+        ) else {
             return;
         };
         info!("Setting TPU={tpu}, TPU Forward={tpu_fwd} from BAM config");
@@ -391,21 +372,28 @@ impl BamManager {
             .store(Arc::new(Some((tpu, tpu_fwd))));
     }
 
+    fn set_bam_disconnected(dependencies: &BamDependencies) {
+        dependencies
+            .bam_enabled
+            .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+        Self::clear_bam_shred_receiver_addresses(dependencies);
+    }
+
     fn clear_bam_shred_receiver_addresses(dependencies: &BamDependencies) {
         dependencies
             .bam_shred_receiver_addresses
             .store(Arc::new(ShredReceiverAddresses::new()));
     }
 
-    fn update_shred_socks_config(config: Option<&ConfigResponse>, dependencies: &BamDependencies) {
-        let Some(bam_config) = config.and_then(|c| c.bam_config.as_ref()) else {
+    fn update_shred_socks_config(config: &ConfigResponse, dependencies: &BamDependencies) {
+        let Some(bam_config) = config.bam_config.as_ref() else {
             Self::clear_bam_shred_receiver_addresses(dependencies);
             return;
         };
 
         let mut shred_receiver_addresses = ShredReceiverAddresses::new();
         for socket in &bam_config.shred_socks {
-            let Some(addr) = Self::get_sockaddr(Some(socket)) else {
+            let Some(addr) = Self::get_sockaddr(socket) else {
                 warn!(
                     "Dropping invalid BAM shred receiver socket {}:{}",
                     socket.ip, socket.port
@@ -436,10 +424,10 @@ impl BamManager {
     }
 
     fn update_block_engine_key_and_commission(
-        config: Option<&ConfigResponse>,
+        config: &ConfigResponse,
         block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
     ) {
-        let Some(builder_info) = config.and_then(|c| c.block_engine_config.as_ref()) else {
+        let Some(builder_info) = config.block_engine_config.as_ref() else {
             return;
         };
         if builder_info.builder_commission > 100 {

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -32,6 +32,7 @@ use {
     solana_runtime::bank::Bank,
     solana_signer::Signer,
     solana_tls_utils::NotifyKeyUpdate,
+    solana_turbine::{MAX_SHRED_RECEIVER_ADDRESSES, ShredReceiverAddresses},
     solana_version::ClientId,
 };
 
@@ -155,6 +156,7 @@ impl BamManager {
                         dependencies
                             .bam_enabled
                             .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                        Self::clear_bam_shred_receiver_addresses(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     };
@@ -175,6 +177,7 @@ impl BamManager {
                             dependencies
                                 .bam_enabled
                                 .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                            Self::clear_bam_shred_receiver_addresses(&dependencies);
                             std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                             continue;
                         }
@@ -194,6 +197,7 @@ impl BamManager {
                         dependencies
                             .bam_enabled
                             .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                        Self::clear_bam_shred_receiver_addresses(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     }
@@ -201,6 +205,7 @@ impl BamManager {
                     info!("BAM connection established");
                     if let Some(builder_config) = connection.get_latest_config() {
                         Self::update_tpu_config(Some(&builder_config), &dependencies);
+                        Self::update_shred_socks_config(Some(&builder_config), &dependencies);
                         Self::update_block_engine_key_and_commission(
                             Some(&builder_config),
                             &dependencies.block_builder_fee_info,
@@ -221,6 +226,7 @@ impl BamManager {
                 dependencies
                     .bam_enabled
                     .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                Self::clear_bam_shred_receiver_addresses(&dependencies);
                 warn!("BAM connection unhealthy");
                 continue;
             }
@@ -244,6 +250,7 @@ impl BamManager {
                 dependencies
                     .bam_enabled
                     .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+                Self::clear_bam_shred_receiver_addresses(&dependencies);
                 if let Some(new_url) = configured_bam_url.as_deref() {
                     info!("BAM URL changed, connecting to new URL: {new_url}");
                 } else {
@@ -256,6 +263,7 @@ impl BamManager {
             if let Some(builder_config) = connection.get_latest_config() {
                 if Some(&builder_config) != cached_builder_config.as_ref() {
                     Self::update_tpu_config(Some(&builder_config), &dependencies);
+                    Self::update_shred_socks_config(Some(&builder_config), &dependencies);
                     Self::update_block_engine_key_and_commission(
                         Some(&builder_config),
                         &dependencies.block_builder_fee_info,
@@ -315,6 +323,7 @@ impl BamManager {
         dependencies
             .bam_enabled
             .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+        Self::clear_bam_shred_receiver_addresses(dependencies);
 
         // When we are still holding a live connection, disconnect first and wait in the
         // disconnected path before starting a new BAM auth handshake.
@@ -380,6 +389,50 @@ impl BamManager {
         dependencies
             .bam_tpu_info
             .store(Arc::new(Some((tpu, tpu_fwd))));
+    }
+
+    fn clear_bam_shred_receiver_addresses(dependencies: &BamDependencies) {
+        dependencies
+            .bam_shred_receiver_addresses
+            .store(Arc::new(ShredReceiverAddresses::new()));
+    }
+
+    fn update_shred_socks_config(config: Option<&ConfigResponse>, dependencies: &BamDependencies) {
+        let Some(bam_config) = config.and_then(|c| c.bam_config.as_ref()) else {
+            Self::clear_bam_shred_receiver_addresses(dependencies);
+            return;
+        };
+
+        let mut shred_receiver_addresses = ShredReceiverAddresses::new();
+        for socket in &bam_config.shred_socks {
+            let Some(addr) = Self::get_sockaddr(Some(socket)) else {
+                warn!(
+                    "Dropping invalid BAM shred receiver socket {}:{}",
+                    socket.ip, socket.port
+                );
+                continue;
+            };
+            if shred_receiver_addresses.contains(&addr) {
+                continue;
+            }
+            if shred_receiver_addresses.len() >= MAX_SHRED_RECEIVER_ADDRESSES {
+                warn!(
+                    "Dropping excess BAM shred receiver socket {}:{}; maximum is {}",
+                    socket.ip, socket.port, MAX_SHRED_RECEIVER_ADDRESSES
+                );
+                continue;
+            }
+            shred_receiver_addresses.push(addr);
+        }
+
+        info!(
+            "Setting {} BAM shred receiver address(es) from BAM config: {:?}",
+            shred_receiver_addresses.len(),
+            shred_receiver_addresses
+        );
+        dependencies
+            .bam_shred_receiver_addresses
+            .store(Arc::new(shred_receiver_addresses));
     }
 
     fn update_block_engine_key_and_commission(

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -857,6 +857,7 @@ impl BankingSimulator {
             Arc::new(ArcSwap::default()),
             Arc::new(ArcSwap::default()),
             Arc::new(ArcSwap::default()),
+            Arc::new(ArcSwap::default()),
         );
 
         info!("Start banking stage!...");

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -179,6 +179,7 @@ impl Tpu {
         relayer_config: Arc<ArcSwap<RelayerConfig>>,
         tip_manager_config: TipManagerConfig,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         bam_url: Arc<ArcSwap<Option<String>>>,
     ) -> Self {
@@ -421,6 +422,7 @@ impl Tpu {
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bank_forks: bank_forks.clone(),
             bam_tpu_info,
+            bam_shred_receiver_addresses: bam_shred_receiver_addresses.clone(),
         };
 
         let mut blacklisted_accounts = HashSet::new();
@@ -525,6 +527,7 @@ impl Tpu {
             votor_event_sender,
             shredstream_receiver_address,
             shred_receiver_addresses,
+            bam_shred_receiver_addresses,
             multicast_receiver_address,
         );
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -237,6 +237,7 @@ impl Tvu {
         vote_connection_cache: Arc<ConnectionCache>,
         votor_init: AlpenglowInitializationState,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
     ) -> Result<Self, String> {
         let migration_status = bank_forks.read().unwrap().migration_status();
 
@@ -375,6 +376,7 @@ impl Tvu {
             tvu_config.xdp_sender,
             votor_event_sender.clone(),
             shred_receiver_addresses,
+            bam_shred_receiver_addresses,
         );
 
         let (ancestor_duplicate_slots_sender, ancestor_duplicate_slots_receiver) = unbounded();
@@ -859,6 +861,7 @@ pub mod tests {
                 bls_connection_cache: Arc::new(bls_connection_cache),
                 voting_service_test_override: None,
             },
+            Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
             Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
         )
         .expect("assume success");

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -862,7 +862,7 @@ pub mod tests {
                 voting_service_test_override: None,
             },
             Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
-            Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+            Arc::default(),
         )
         .expect("assume success");
         exit.store(true, Ordering::Relaxed);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1529,6 +1529,9 @@ impl Validator {
             "New shred signal for the TVU should be the same as the clear bank signal."
         );
 
+        let bam_shred_receiver_addresses =
+            Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new()));
+
         let vote_tracker = Arc::<VoteTracker>::default();
 
         let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
@@ -1713,6 +1716,7 @@ impl Validator {
                 voting_service_test_override: config.voting_service_test_override.clone(),
             },
             config.shred_retransmit_receiver_addresses.clone(),
+            bam_shred_receiver_addresses.clone(),
         )
         .map_err(ValidatorError::Other)?;
 
@@ -1791,6 +1795,7 @@ impl Validator {
             config.relayer_config.clone(),
             config.tip_manager_config.clone(),
             config.shred_receiver_addresses.clone(),
+            bam_shred_receiver_addresses,
             config.multicast_receiver_address.clone(),
             config.bam_url.clone(),
         );

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1529,8 +1529,7 @@ impl Validator {
             "New shred signal for the TVU should be the same as the clear bank signal."
         );
 
-        let bam_shred_receiver_addresses =
-            Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new()));
+        let bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>> = Arc::default();
 
         let vote_tracker = Arc::<VoteTracker>::default();
 

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -544,7 +544,6 @@ mod bam_manager_tests {
     use {
         super::*,
         arc_swap::ArcSwap,
-        smallvec::SmallVec,
         solana_core::{
             admin_rpc_post_init::{KeyUpdaterType, KeyUpdaters},
             bam_dependencies::{BamConnectionState, BamDependencies},
@@ -576,7 +575,7 @@ mod bam_manager_tests {
             bank_forks,
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
-            bam_shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(SmallVec::default())),
+            bam_shred_receiver_addresses: Arc::default(),
         }
     }
 

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -141,6 +141,7 @@ impl BamNodeApi for MockBamNode {
                     ip: "127.0.0.1".to_string(),
                     port: 8001,
                 }),
+                shred_socks: vec![],
             }),
         }))
     }
@@ -543,6 +544,7 @@ mod bam_manager_tests {
     use {
         super::*,
         arc_swap::ArcSwap,
+        smallvec::SmallVec,
         solana_core::{
             admin_rpc_post_init::{KeyUpdaterType, KeyUpdaters},
             bam_dependencies::{BamConnectionState, BamDependencies},
@@ -574,6 +576,7 @@ mod bam_manager_tests {
             bank_forks,
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
+            bam_shred_receiver_addresses: Arc::new(ArcSwap::from_pointee(SmallVec::default())),
         }
     }
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -8,6 +8,7 @@ use {
     solana_sdk_ids::sysvar,
     solana_svm_type_overrides::sync::Arc,
     solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
+    std::collections::{HashMap, HashSet},
 };
 use {
     crate::{
@@ -46,7 +47,6 @@ use {
         alloc::Layout,
         borrow::Cow,
         cell::RefCell,
-        collections::{HashMap, HashSet},
         fmt::{self, Debug},
         rc::Rc,
     },
@@ -1090,6 +1090,7 @@ mod tests {
         solana_signer::Signer,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION,
+        std::collections::HashSet,
         test_case::test_case,
     };
 

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -81,6 +81,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
     let shreds = Arc::new(shreds);
     let last_datapoint = Arc::new(AtomicInterval::default());
     let shred_receiver_addresses = ShredReceiverAddresses::new();
+    let bam_shred_receiver_addresses = ShredReceiverAddresses::new();
     b.iter(move || {
         let shreds = shreds.clone();
         broadcast_shreds(
@@ -95,6 +96,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
             &SocketAddrSpace::Unspecified,
             &None,
             &shred_receiver_addresses,
+            &bam_shred_receiver_addresses,
             &None,
         )
         .unwrap();

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -81,7 +81,6 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
     let shreds = Arc::new(shreds);
     let last_datapoint = Arc::new(AtomicInterval::default());
     let shred_receiver_addresses = ShredReceiverAddresses::new();
-    let bam_shred_receiver_addresses = ShredReceiverAddresses::new();
     b.iter(move || {
         let shreds = shreds.clone();
         broadcast_shreds(
@@ -96,7 +95,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
             &SocketAddrSpace::Unspecified,
             &None,
             &shred_receiver_addresses,
-            &bam_shred_receiver_addresses,
+            &shred_receiver_addresses,
             &None,
         )
         .unwrap();

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -33,7 +33,7 @@ use {
     solana_streamer::sendmmsg::{SendPktsError, batch_send},
     solana_time_utils::{AtomicInterval, timestamp},
     std::{
-        collections::{HashMap, HashSet},
+        collections::HashSet,
         net::{SocketAddr, UdpSocket},
         sync::{
             Arc, Mutex, RwLock,
@@ -129,6 +129,7 @@ impl BroadcastStageType {
         votor_event_sender: VotorEventSender,
         shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> BroadcastStage {
         let migration_status = bank_forks.read().unwrap().migration_status();
@@ -145,6 +146,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 shred_receiver_addresses,
+                bam_shred_receiver_addresses,
                 multicast_receiver_address,
             ),
 
@@ -160,6 +162,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
 
@@ -174,6 +177,7 @@ impl BroadcastStageType {
                 BroadcastFakeShredsRun::new(0, shred_version),
                 xdp_sender,
                 shredstream_receiver_address,
+                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
@@ -195,6 +199,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
         }
@@ -210,6 +215,7 @@ trait BroadcastRun {
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()>;
+    #[allow(clippy::too_many_arguments)]
     fn transmit(
         &mut self,
         receiver: &TransmitReceiver,
@@ -218,6 +224,7 @@ trait BroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_socket: &UdpSocket,
     ) -> Result<()>;
@@ -318,6 +325,7 @@ impl BroadcastStage {
         xdp_sender: Option<XdpSender>,
         shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> Self {
         let (socket_sender, socket_receiver) = unbounded();
@@ -389,6 +397,7 @@ impl BroadcastStage {
             let xdp_sender = xdp_sender.clone();
             let shredstream_receiver_address = shredstream_receiver_address.clone();
             let shred_receiver_addresses = shred_receiver_addresses.clone();
+            let bam_shred_receiver_addresses = bam_shred_receiver_addresses.clone();
             let multicast_receiver_address = multicast_receiver_address.clone();
             let shred_receiver_socket = shred_receiver_socket.clone();
 
@@ -408,6 +417,7 @@ impl BroadcastStage {
                     &bank_forks,
                     &shredstream_receiver_address,
                     &shred_receiver_addresses,
+                    &bam_shred_receiver_addresses,
                     &multicast_receiver_address,
                     &shred_receiver_socket,
                 );
@@ -522,6 +532,36 @@ fn update_peer_stats(
     }
 }
 
+fn get_additional_external_shred_receiver_addresses(
+    shredstream_receiver_address: &Option<SocketAddr>,
+    shred_receiver_addresses: &ShredReceiverAddresses,
+    bam_shred_receiver_addresses: &ShredReceiverAddresses,
+    multicast_receiver_address: &Option<SocketAddr>,
+) -> ShredReceiverAddresses {
+    let shredstream_receiver_address = shredstream_receiver_address.as_ref();
+    let mut additional_external_addrs = ShredReceiverAddresses::new();
+    for addr in shred_receiver_addresses {
+        if Some(addr) != shredstream_receiver_address && !additional_external_addrs.contains(addr) {
+            additional_external_addrs.push(*addr);
+        }
+    }
+    for addr in bam_shred_receiver_addresses {
+        if Some(addr) != shredstream_receiver_address && !additional_external_addrs.contains(addr) {
+            additional_external_addrs.push(*addr);
+        }
+    }
+    if let Some(addr) = multicast_receiver_address
+        && Some(addr) != shredstream_receiver_address
+        && !additional_external_addrs.contains(addr)
+    {
+        additional_external_addrs.push(*addr);
+    }
+    // Always truncate to MAX_SHRED_RECEIVER_ADDRESSES at the end.
+    additional_external_addrs.truncate(MAX_SHRED_RECEIVER_ADDRESSES);
+
+    additional_external_addrs
+}
+
 #[derive(Clone, Copy)]
 pub enum BroadcastSocket<'a> {
     Udp(&'a UdpSocket),
@@ -543,6 +583,7 @@ pub fn broadcast_shreds(
     socket_addr_space: &SocketAddrSpace,
     shredstream_receiver_address: &Option<SocketAddr>,
     shred_receiver_addresses: &ShredReceiverAddresses,
+    bam_shred_receiver_addresses: &ShredReceiverAddresses,
     multicast_receiver_address: &Option<SocketAddr>,
 ) -> Result<()> {
     let mut result = Ok(());
@@ -575,27 +616,24 @@ pub fn broadcast_shreds(
 
     // Mirror this validator's own broadcast shreds to external receivers
     // (`--shred-receiver-address`), avoiding duplicates when addresses overlap.
-    // Add the cluster multicast address only when the route is present and the
-    // address is not already added.
+    // Add BAM and cluster multicast addresses only when they are present and
+    // not already added.
     if let Some(addr) = shredstream_receiver_address {
         packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
     }
     let external_packets_start = packets.len();
-    packets.reserve(
-        shreds.len().saturating_mul(
-            shred_receiver_addresses.len() + multicast_receiver_address.iter().len(),
-        ),
-    );
-    for addr in shred_receiver_addresses
-        .iter()
-        .filter(|addr| shredstream_receiver_address.as_ref() != Some(addr))
-        .chain(multicast_receiver_address.iter().filter(|addr| {
-            shred_receiver_addresses.len() < MAX_SHRED_RECEIVER_ADDRESSES
-                && !shred_receiver_addresses.contains(addr)
-                && shredstream_receiver_address.as_ref() != Some(addr)
-        }))
-    {
-        packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
+    packets.reserve(shreds.len().saturating_mul(
+        shred_receiver_addresses.len()
+            + bam_shred_receiver_addresses.len()
+            + multicast_receiver_address.iter().len(),
+    ));
+    for addr in get_additional_external_shred_receiver_addresses(
+        shredstream_receiver_address,
+        shred_receiver_addresses,
+        bam_shred_receiver_addresses,
+        multicast_receiver_address,
+    ) {
+        packets.extend(shreds.iter().map(|shred| (shred.payload(), addr)));
     }
     let (packets, external_packets) = packets.split_at(external_packets_start);
 
@@ -767,6 +805,34 @@ pub mod test {
     }
 
     #[test]
+    fn test_bam_shred_receivers_are_added_and_deduped_for_leader_broadcast() {
+        let shredstream_addr = "127.0.0.1:10".parse().unwrap();
+        let regular_addr_1 = "127.0.0.1:11".parse().unwrap();
+        let regular_addr_2 = "127.0.0.1:12".parse().unwrap();
+        let bam_addr = "127.0.0.1:13".parse().unwrap();
+        let multicast_addr = "127.0.0.1:14".parse().unwrap();
+
+        let shred_receiver_addresses: ShredReceiverAddresses =
+            [regular_addr_1, regular_addr_2].into_iter().collect();
+        let bam_shred_receiver_addresses: ShredReceiverAddresses =
+            [regular_addr_2, bam_addr, shredstream_addr]
+                .into_iter()
+                .collect();
+
+        let additional_external_addrs = get_additional_external_shred_receiver_addresses(
+            &Some(shredstream_addr),
+            &shred_receiver_addresses,
+            &bam_shred_receiver_addresses,
+            &Some(multicast_addr),
+        );
+
+        assert_eq!(
+            additional_external_addrs.as_slice(),
+            &[regular_addr_1, regular_addr_2, bam_addr, multicast_addr]
+        );
+    }
+
+    #[test]
     fn test_duplicate_retransmit_signal() {
         // Setup
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -862,6 +928,7 @@ pub mod test {
             bank_forks,
             StandardBroadcastRun::new(0, Arc::new(MigrationStatus::default()), votor_event_sender),
             None,
+            Arc::default(),
             Arc::default(),
             Arc::default(),
             Arc::default(),

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -162,7 +162,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
-                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::default(),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
 
@@ -178,7 +178,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
-                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::default(),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
 
@@ -199,7 +199,7 @@ impl BroadcastStageType {
                 xdp_sender,
                 shredstream_receiver_address,
                 Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
-                Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
+                Arc::default(),
                 Arc::new(ArcSwap::from_pointee(None)),
             ),
         }
@@ -357,9 +357,10 @@ impl BroadcastStage {
         };
         let mut thread_hdls = vec![thread_hdl];
 
-        // Dedicated socket bound to 0.0.0.0:0 for sending shreds to ShredReceiverAddresses
-        // and multicast_receiver_address on the UDP path. Not constrained by --bind-address,
-        // so the OS routing table selects the appropriate interface for each destination.
+        // Dedicated socket for ShredReceiverAddresses and multicast_receiver_address.
+        // Bound to 0.0.0.0:0 (not --bind-address) so the OS routing table selects the
+        // correct outbound interface per destination, regardless of which interface Turbine
+        // uses for its main broadcast traffic.
         let shred_receiver_socket =
             Arc::new(bind_to_unspecified().expect("bind shred_receiver_socket 0.0.0.0:0"));
         shred_receiver_socket
@@ -536,36 +537,6 @@ fn update_peer_stats(
     }
 }
 
-fn get_additional_external_shred_receiver_addresses(
-    shredstream_receiver_address: &Option<SocketAddr>,
-    shred_receiver_addresses: &ShredReceiverAddresses,
-    bam_shred_receiver_addresses: &ShredReceiverAddresses,
-    multicast_receiver_address: &Option<SocketAddr>,
-) -> ShredReceiverAddresses {
-    let shredstream_receiver_address = shredstream_receiver_address.as_ref();
-    let mut additional_external_addrs = ShredReceiverAddresses::new();
-    for addr in shred_receiver_addresses {
-        if Some(addr) != shredstream_receiver_address && !additional_external_addrs.contains(addr) {
-            additional_external_addrs.push(*addr);
-        }
-    }
-    for addr in bam_shred_receiver_addresses {
-        if Some(addr) != shredstream_receiver_address && !additional_external_addrs.contains(addr) {
-            additional_external_addrs.push(*addr);
-        }
-    }
-    if let Some(addr) = multicast_receiver_address
-        && Some(addr) != shredstream_receiver_address
-        && !additional_external_addrs.contains(addr)
-    {
-        additional_external_addrs.push(*addr);
-    }
-    // Always truncate to MAX_SHRED_RECEIVER_ADDRESSES at the end.
-    additional_external_addrs.truncate(MAX_SHRED_RECEIVER_ADDRESSES);
-
-    additional_external_addrs
-}
-
 #[derive(Clone, Copy)]
 pub enum BroadcastSocket<'a> {
     Udp(&'a UdpSocket),
@@ -597,61 +568,70 @@ pub fn broadcast_shreds(
         let bank_forks = bank_forks.read().unwrap();
         (bank_forks.root_bank(), bank_forks.working_bank())
     };
-    let mut all_packets: Vec<_> = shreds
-        .iter()
-        .chunk_by(|shred| shred.slot())
+    let shredstream_receiver_address = shredstream_receiver_address.as_ref();
+    let num_shred_receiver_addresses = shred_receiver_addresses
+        .len()
+        .min(MAX_SHRED_RECEIVER_ADDRESSES);
+    let external_addr_capacity = num_shred_receiver_addresses
+        .saturating_add(multicast_receiver_address.iter().len())
+        .saturating_add(usize::from(shredstream_receiver_address.is_some()))
+        .saturating_add(bam_shred_receiver_addresses.len());
+    let mut external_addrs = ShredReceiverAddresses::with_capacity(external_addr_capacity);
+    for &addr in shredstream_receiver_address
         .into_iter()
-        .flat_map(|(slot, shreds)| {
-            let cluster_nodes =
-                cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);
-            update_peer_stats(&cluster_nodes, last_datapoint_submit);
+        .chain(
+            shred_receiver_addresses
+                .iter()
+                .take(num_shred_receiver_addresses),
+        )
+        .chain(bam_shred_receiver_addresses)
+        .chain(multicast_receiver_address.iter())
+    {
+        // Shredstream, ShredReceiverAddresses, and multicast_receiver_address are external
+        // receivers that may be reachable via a different interface than --bind-address. They are
+        // collected separately so they can be sent through the right path:
+        //   - UDP path: shred_receiver_socket (0.0.0.0:0), letting the kernel pick the interface.
+        //   - XDP path: XDP sender, which uses its own Router (fed from the kernel routing table via
+        //               netlink) to resolve the correct next-hop and interface per destination.
+        if !external_addrs.contains(&addr) {
+            external_addrs.push(addr);
+        }
+    }
+    let packet_capacity = shreds.len().saturating_mul(1 + external_addrs.len());
+    let mut all_packets = Vec::with_capacity(packet_capacity);
+    for (slot, shreds) in shreds.iter().chunk_by(|shred| shred.slot()).into_iter() {
+        let cluster_nodes = cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);
+        update_peer_stats(&cluster_nodes, last_datapoint_submit);
 
-            shreds.filter_map(move |shred| {
-                let key = shred.id();
-                let addr = cluster_nodes
-                    .get_broadcast_peer(&key)?
-                    .tvu(Protocol::UDP)
-                    .filter(|addr| socket_addr_space.check(addr))?;
-
-                Some((shred.payload(), addr))
-            })
-        })
-        .collect();
+        for shred in shreds {
+            let key = shred.id();
+            if let Some(addr) = cluster_nodes
+                .get_broadcast_peer(&key)
+                .and_then(|peer| peer.tvu(Protocol::UDP))
+                .filter(|addr| socket_addr_space.check(addr))
+            {
+                all_packets.push((shred.payload(), addr));
+            }
+        }
+    }
 
     // Mirror this validator's own broadcast shreds to external receivers
-    // (`--shred-receiver-address`), avoiding duplicates when addresses overlap.
-    // Add BAM and cluster multicast addresses only when they are present and
-    // not already added.
-    if let Some(addr) = shredstream_receiver_address {
-        all_packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
-    }
-    // ShredReceiverAddresses, BAM ShredReceiverAddresses, and multicast_receiver_address are
-    // external receivers that may be reachable via a different interface than --bind-address.
-    // Keep them separate so the UDP path can use the dedicated 0.0.0.0:0 socket, while the
-    // XDP path can route them directly.
+    // (shredstream, `--shred-receiver-address`, BAM, and multicast), avoiding duplicates when
+    // addresses overlap. Add the cluster multicast address only when the route is present.
     let external_packets_start = all_packets.len();
-    all_packets.reserve(shreds.len().saturating_mul(
-        shred_receiver_addresses.len()
-            + bam_shred_receiver_addresses.len()
-            + multicast_receiver_address.iter().len(),
-    ));
-    for addr in get_additional_external_shred_receiver_addresses(
-        shredstream_receiver_address,
-        shred_receiver_addresses,
-        bam_shred_receiver_addresses,
-        multicast_receiver_address,
-    ) {
-        all_packets.extend(shreds.iter().map(|shred| (shred.payload(), addr)));
+    for &addr in external_addrs.iter() {
+        for shred in shreds {
+            all_packets.push((shred.payload(), addr));
+        }
     }
     let (main_packets, external_packets) = all_packets.split_at(external_packets_start);
 
     shred_select.stop();
     transmit_stats.shred_select += shred_select.as_us();
-    let num_udp_packets = main_packets.len() + external_packets.len();
     match socket {
         BroadcastSocket::Udp(s) => {
             let mut send_mmsg_time = Measure::start("send_mmsg");
-            // Turbine tree + shredstream: use the main socket bound to --bind-address.
+            // Turbine tree: use the main socket bound to --bind-address.
             // `.copied()` copies only `(&Payload, SocketAddr)`, not payload bytes.
             match batch_send(s, main_packets.iter().copied()) {
                 Ok(()) => (),
@@ -683,12 +663,7 @@ pub fn broadcast_shreds(
             // The XDP Router resolves the correct interface and next-hop per destination
             // from the kernel routing table.
             // `.copied()` copies only `(&Payload, SocketAddr)`; `payload.bytes.clone()` is refcount-only.
-            for (idx, (payload, addr)) in main_packets
-                .iter()
-                .copied()
-                .chain(external_packets.iter().copied())
-                .enumerate()
-            {
+            for (idx, (payload, addr)) in all_packets.iter().copied().enumerate() {
                 if let Err(e) = s.try_send(idx, addr, payload.bytes.clone()) {
                     log::warn!("xdp channel full: {e:?}");
                     transmit_stats.dropped_packets_xdp += 1;
@@ -700,7 +675,7 @@ pub fn broadcast_shreds(
         }
     }
 
-    transmit_stats.total_packets += num_udp_packets;
+    transmit_stats.total_packets += all_packets.len();
     result
 }
 impl<T> From<crossbeam_channel::SendError<T>> for Error {
@@ -726,12 +701,15 @@ pub mod test {
             get_tmp_ledger_path_auto_delete,
             shred::{ProcessShredsStats, ReedSolomonCache, Shredder, max_ticks_per_n_shreds},
         },
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         std::{
+            net::UdpSocket,
             path::Path,
             sync::{Arc, atomic::AtomicBool},
             thread::sleep,
+            time::Duration,
         },
     };
 
@@ -804,31 +782,92 @@ pub mod test {
     }
 
     #[test]
-    fn test_bam_shred_receivers_are_added_and_deduped_for_leader_broadcast() {
-        let shredstream_addr = "127.0.0.1:10".parse().unwrap();
-        let regular_addr_1 = "127.0.0.1:11".parse().unwrap();
-        let regular_addr_2 = "127.0.0.1:12".parse().unwrap();
-        let bam_addr = "127.0.0.1:13".parse().unwrap();
-        let multicast_addr = "127.0.0.1:14".parse().unwrap();
+    fn test_external_shred_receivers_are_deduped_and_configured_cap_only() {
+        let bind_receiver = || {
+            let socket = bind_to_localhost_unique().unwrap();
+            socket
+                .set_read_timeout(Some(Duration::from_millis(50)))
+                .unwrap();
+            socket
+        };
+        let recv_source = |socket: &UdpSocket| {
+            let mut buf = [0u8; 2048];
+            socket.recv_from(&mut buf).unwrap().1
+        };
+        let assert_no_packet = |socket: &UdpSocket| {
+            let mut buf = [0u8; 2048];
+            assert!(socket.recv_from(&mut buf).is_err());
+        };
 
-        let shred_receiver_addresses: ShredReceiverAddresses =
-            [regular_addr_1, regular_addr_2].into_iter().collect();
-        let bam_shred_receiver_addresses: ShredReceiverAddresses =
-            [regular_addr_2, bam_addr, shredstream_addr]
-                .into_iter()
-                .collect();
+        let main_sender = bind_to_localhost_unique().unwrap();
+        let external_sender = bind_to_localhost_unique().unwrap();
+        let shredstream_receiver = bind_receiver();
+        let configured_receivers: Vec<_> = (0..=MAX_SHRED_RECEIVER_ADDRESSES)
+            .map(|_| bind_receiver())
+            .collect();
+        let bam_receiver = bind_receiver();
+        let multicast_receiver = bind_receiver();
+        let shredstream_addr = shredstream_receiver.local_addr().unwrap();
+        let configured_addrs: ShredReceiverAddresses = configured_receivers
+            .iter()
+            .map(|socket| socket.local_addr().unwrap())
+            .collect();
+        let bam_addr = bam_receiver.local_addr().unwrap();
+        let multicast_addr = multicast_receiver.local_addr().unwrap();
+        let bam_addrs: ShredReceiverAddresses = [configured_addrs[1], bam_addr, shredstream_addr]
+            .into_iter()
+            .collect();
 
-        let additional_external_addrs = get_additional_external_shred_receiver_addresses(
+        let keypair = Arc::new(Keypair::new());
+        let node = Node::new_localhost_with_pubkey(&keypair.pubkey());
+        let cluster_info =
+            ClusterInfo::new(node.info.clone(), keypair, SocketAddrSpace::Unspecified);
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank);
+        let cluster_nodes_cache =
+            ClusterNodesCache::<BroadcastStage>::new(1, Duration::from_secs(60));
+        let mut transmit_stats = TransmitShredsStats::default();
+        let (shreds, _, _, _) = make_transmit_shreds(0, 1);
+        let shreds = vec![shreds[0].clone()];
+
+        broadcast_shreds(
+            BroadcastSocket::Udp(&main_sender),
+            &external_sender,
+            &shreds,
+            &cluster_nodes_cache,
+            &AtomicInterval::default(),
+            &mut transmit_stats,
+            &cluster_info,
+            &bank_forks,
+            &SocketAddrSpace::Unspecified,
             &Some(shredstream_addr),
-            &shred_receiver_addresses,
-            &bam_shred_receiver_addresses,
+            &configured_addrs,
+            &bam_addrs,
             &Some(multicast_addr),
-        );
+        )
+        .unwrap();
 
         assert_eq!(
-            additional_external_addrs.as_slice(),
-            &[regular_addr_1, regular_addr_2, bam_addr, multicast_addr]
+            recv_source(&shredstream_receiver),
+            external_sender.local_addr().unwrap()
         );
+        assert_no_packet(&shredstream_receiver);
+        for receiver in &configured_receivers[..MAX_SHRED_RECEIVER_ADDRESSES] {
+            assert_eq!(recv_source(receiver), external_sender.local_addr().unwrap());
+        }
+        assert_no_packet(&configured_receivers[MAX_SHRED_RECEIVER_ADDRESSES]);
+        assert_no_packet(&configured_receivers[1]);
+        assert_eq!(
+            recv_source(&bam_receiver),
+            external_sender.local_addr().unwrap()
+        );
+        assert_no_packet(&bam_receiver);
+        assert_eq!(
+            recv_source(&multicast_receiver),
+            external_sender.local_addr().unwrap()
+        );
+        assert_no_packet(&multicast_receiver);
     }
 
     #[test]

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -226,6 +226,10 @@ trait BroadcastRun {
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
+        // Dedicated socket bound to 0.0.0.0:0 used only for ShredReceiverAddresses and
+        // multicast_receiver_address on the UDP path. Kept separate from the main broadcast
+        // socket so the OS routing table (not --bind-address) selects the outbound interface
+        // per destination. The XDP path resolves routes from the kernel table directly.
         shred_receiver_socket: &UdpSocket,
     ) -> Result<()>;
     fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()>;
@@ -354,8 +358,8 @@ impl BroadcastStage {
         let mut thread_hdls = vec![thread_hdl];
 
         // Dedicated socket bound to 0.0.0.0:0 for sending shreds to ShredReceiverAddresses
-        // and multicast_receiver_address. Not constrained by --bind-address, so the OS
-        // routing table selects the appropriate interface for each destination.
+        // and multicast_receiver_address on the UDP path. Not constrained by --bind-address,
+        // so the OS routing table selects the appropriate interface for each destination.
         let shred_receiver_socket =
             Arc::new(bind_to_unspecified().expect("bind shred_receiver_socket 0.0.0.0:0"));
         shred_receiver_socket
@@ -593,7 +597,7 @@ pub fn broadcast_shreds(
         let bank_forks = bank_forks.read().unwrap();
         (bank_forks.root_bank(), bank_forks.working_bank())
     };
-    let mut packets: Vec<_> = shreds
+    let mut all_packets: Vec<_> = shreds
         .iter()
         .chunk_by(|shred| shred.slot())
         .into_iter()
@@ -619,10 +623,14 @@ pub fn broadcast_shreds(
     // Add BAM and cluster multicast addresses only when they are present and
     // not already added.
     if let Some(addr) = shredstream_receiver_address {
-        packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
+        all_packets.extend(shreds.iter().map(|shred| (shred.payload(), *addr)));
     }
-    let external_packets_start = packets.len();
-    packets.reserve(shreds.len().saturating_mul(
+    // ShredReceiverAddresses, BAM ShredReceiverAddresses, and multicast_receiver_address are
+    // external receivers that may be reachable via a different interface than --bind-address.
+    // Keep them separate so the UDP path can use the dedicated 0.0.0.0:0 socket, while the
+    // XDP path can route them directly.
+    let external_packets_start = all_packets.len();
+    all_packets.reserve(shreds.len().saturating_mul(
         shred_receiver_addresses.len()
             + bam_shred_receiver_addresses.len()
             + multicast_receiver_address.iter().len(),
@@ -633,18 +641,19 @@ pub fn broadcast_shreds(
         bam_shred_receiver_addresses,
         multicast_receiver_address,
     ) {
-        packets.extend(shreds.iter().map(|shred| (shred.payload(), addr)));
+        all_packets.extend(shreds.iter().map(|shred| (shred.payload(), addr)));
     }
-    let (packets, external_packets) = packets.split_at(external_packets_start);
+    let (main_packets, external_packets) = all_packets.split_at(external_packets_start);
 
     shred_select.stop();
     transmit_stats.shred_select += shred_select.as_us();
-    let num_udp_packets = packets.len() + external_packets.len();
+    let num_udp_packets = main_packets.len() + external_packets.len();
     match socket {
         BroadcastSocket::Udp(s) => {
             let mut send_mmsg_time = Measure::start("send_mmsg");
+            // Turbine tree + shredstream: use the main socket bound to --bind-address.
             // `.copied()` copies only `(&Payload, SocketAddr)`, not payload bytes.
-            match batch_send(s, packets.iter().copied()) {
+            match batch_send(s, main_packets.iter().copied()) {
                 Ok(()) => (),
                 Err(SendPktsError::IoError(ioerr, num_failed)) => {
                     transmit_stats.dropped_packets_udp += num_failed;
@@ -652,6 +661,8 @@ pub fn broadcast_shreds(
                 }
             }
             if !external_packets.is_empty() {
+                // External receivers: use the dedicated 0.0.0.0:0 socket so the kernel routing
+                // table picks the outbound interface independent of --bind-address.
                 // `.copied()` copies only `(&Payload, SocketAddr)`, not payload bytes.
                 match batch_send(shred_receiver_socket, external_packets.iter().copied()) {
                     Ok(()) => (),
@@ -668,8 +679,16 @@ pub fn broadcast_shreds(
         }
         BroadcastSocket::Xdp(s) => {
             let mut send_xdp_time = Measure::start("send_xdp");
+            // Turbine tree, shredstream, and external receivers all go through XDP.
+            // The XDP Router resolves the correct interface and next-hop per destination
+            // from the kernel routing table.
             // `.copied()` copies only `(&Payload, SocketAddr)`; `payload.bytes.clone()` is refcount-only.
-            for (idx, (payload, addr)) in packets.iter().copied().enumerate() {
+            for (idx, (payload, addr)) in main_packets
+                .iter()
+                .copied()
+                .chain(external_packets.iter().copied())
+                .enumerate()
+            {
                 if let Err(e) = s.try_send(idx, addr, payload.bytes.clone()) {
                     log::warn!("xdp channel full: {e:?}");
                     transmit_stats.dropped_packets_xdp += 1;
@@ -678,26 +697,6 @@ pub fn broadcast_shreds(
             }
             send_xdp_time.stop();
             transmit_stats.send_xdp_elapsed += send_xdp_time.as_us();
-            // External receivers (ShredReceiverAddresses + multicast) must be sent via
-            // the dedicated UDP socket bound to 0.0.0.0, even when XDP is active.
-            // XDP bypasses the kernel network stack and is attached to the specific NIC
-            // that corresponds to --bind-address. It has no visibility into the routing
-            // table, so packets destined for an address reachable only through a different
-            // interface will be dropped by the NIC driver or never reach the destination.
-            // The dedicated 0.0.0.0 socket goes through the normal kernel IP stack, which
-            // uses the routing table to select the correct outbound interface per destination.
-            if !external_packets.is_empty() {
-                // `.copied()` copies only `(&Payload, SocketAddr)`, not payload bytes.
-                match batch_send(shred_receiver_socket, external_packets.iter().copied()) {
-                    Ok(()) => (),
-                    Err(SendPktsError::IoError(ioerr, num_failed)) => {
-                        transmit_stats.dropped_packets_udp += num_failed;
-                        if result.is_ok() {
-                            result = Err(Error::Io(ioerr));
-                        }
-                    }
-                }
-            }
         }
     }
 

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -337,6 +337,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         bank_forks: &RwLock<BankForks>,
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        _bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -159,6 +159,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         _bank_forks: &RwLock<BankForks>,
         _shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        _bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         _multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         _shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {

--- a/turbine/src/broadcast_stage/broadcast_metrics.rs
+++ b/turbine/src/broadcast_stage/broadcast_metrics.rs
@@ -1,4 +1,4 @@
-use super::*;
+use {super::*, std::collections::HashMap};
 
 pub(crate) trait BroadcastStats {
     fn update(&mut self, new_stats: &Self);

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -186,6 +186,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
@@ -202,6 +203,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             cluster_info.socket_addr_space(),
             &shredstream_receiver_address.load(),
             &shred_receiver_addresses.load(),
+            &bam_shred_receiver_addresses.load(),
             &multicast_receiver_address.load(),
         )
     }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -190,6 +190,7 @@ impl StandardBroadcastRun {
             &ArcSwap::default(),
             &ArcSwap::default(),
             &ArcSwap::default(),
+            &ArcSwap::default(),
             &shred_receiver_socket,
         );
         let _ = self.record(&brecv, blockstore);
@@ -404,6 +405,7 @@ impl StandardBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &Option<SocketAddr>,
         shred_receiver_addresses: &ShredReceiverAddresses,
+        bam_shred_receiver_addresses: &ShredReceiverAddresses,
         multicast_receiver_address: &Option<SocketAddr>,
     ) -> Result<()> {
         trace!("Broadcasting {:?} shreds", shreds.len());
@@ -428,6 +430,7 @@ impl StandardBroadcastRun {
             cluster_info.socket_addr_space(),
             shredstream_receiver_address,
             shred_receiver_addresses,
+            bam_shred_receiver_addresses,
             multicast_receiver_address,
         )?;
         transmit_time.stop();
@@ -497,6 +500,7 @@ impl BroadcastRun for StandardBroadcastRun {
         bank_forks: &RwLock<BankForks>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+        bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
         multicast_receiver_address: &ArcSwap<Option<SocketAddr>>,
         shred_receiver_socket: &UdpSocket,
     ) -> Result<()> {
@@ -510,6 +514,7 @@ impl BroadcastRun for StandardBroadcastRun {
             bank_forks,
             &shredstream_receiver_address.load(),
             &shred_receiver_addresses.load(),
+            &bam_shred_receiver_addresses.load(),
             &multicast_receiver_address.load(),
         )
     }

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -23,7 +23,7 @@ use {
         shred::{self, ShredFlags, ShredId, ShredType},
     },
     solana_measure::measure::Measure,
-    solana_net_utils::SocketAddrSpace,
+    solana_net_utils::{SocketAddrSpace, bind_to_unspecified},
     solana_perf::deduper::Deduper,
     solana_pubkey::Pubkey,
     solana_rpc::{
@@ -294,6 +294,7 @@ fn retransmit(
     cluster_info: &ClusterInfo,
     retransmit_receiver: &Receiver<Vec<shred::Payload>>,
     retransmit_sockets: &[UdpSocket],
+    external_sender_socket: &UdpSocket,
     xdp_sender: Option<&XdpSender>,
     stats: &mut RetransmitStats,
     cluster_nodes_cache: &ClusterNodesCache<RetransmitStage>,
@@ -306,6 +307,7 @@ fn retransmit(
     votor_event_sender: &Sender<VotorEvent>,
     migration_status: &MigrationStatus,
     shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+    bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
 ) -> Result<(), ()> {
     // Try to receive shreds from the channel without blocking. If the channel
     // is empty precompute turbine trees speculatively. If no cache updates are
@@ -361,12 +363,20 @@ fn retransmit(
     );
     epoch_cache_update.stop();
     stats.epoch_cache_update += epoch_cache_update.as_us();
-    // Lookup slot leader and cluster nodes for each slot.
-    let cache: HashMap<Slot, _> = shred_buf
+    let shred_slots: HashSet<Slot> = shred_buf
         .iter()
         .flatten()
         .filter_map(|shred| shred::layout::get_slot(shred))
-        .collect::<HashSet<Slot>>()
+        .collect();
+    let bam_forward_slots = get_bam_forward_slots(
+        &shred_slots,
+        leader_schedule_cache,
+        &cluster_info.id(),
+        &working_bank,
+    );
+
+    // Lookup slot leader and cluster nodes for each slot.
+    let cache: HashMap<Slot, _> = shred_slots
         .into_iter()
         .filter_map(|slot: Slot| {
             max_slots.retransmit.fetch_max(slot, Ordering::Relaxed);
@@ -393,6 +403,7 @@ fn retransmit(
         stats
     };
     let shred_receiver_addresses_local = shred_receiver_addresses.load();
+    let bam_shred_receiver_addresses_local = bam_shred_receiver_addresses.load();
     let retransmit_shred = |shred, socket, stats| {
         retransmit_shred(
             shred,
@@ -402,8 +413,11 @@ fn retransmit(
             addr_cache,
             socket_addr_space,
             socket,
+            external_sender_socket,
             stats,
             &shred_receiver_addresses_local,
+            &bam_forward_slots,
+            &bam_shred_receiver_addresses_local,
         )
     };
 
@@ -456,6 +470,46 @@ fn retransmit(
     Ok(())
 }
 
+fn should_forward_to_bam_for_slot(
+    slot: Slot,
+    leader_schedule_cache: &LeaderScheduleCache,
+    my_pubkey: &Pubkey,
+    working_bank: &Bank,
+) -> bool {
+    should_forward_to_bam_for_slot_with_leader_lookup(slot, my_pubkey, |slot| {
+        leader_schedule_cache
+            .slot_leader_at(slot, Some(working_bank))
+            .map(|leader| leader.id)
+    })
+}
+
+fn should_forward_to_bam_for_slot_with_leader_lookup(
+    slot: Slot,
+    my_pubkey: &Pubkey,
+    mut leader_at_slot: impl FnMut(Slot) -> Option<Pubkey>,
+) -> bool {
+    (0..3).any(|offset| {
+        slot.checked_add(offset)
+            .and_then(&mut leader_at_slot)
+            .is_some_and(|leader| leader == *my_pubkey)
+    })
+}
+
+fn get_bam_forward_slots(
+    shred_slots: &HashSet<Slot>,
+    leader_schedule_cache: &LeaderScheduleCache,
+    my_pubkey: &Pubkey,
+    working_bank: &Bank,
+) -> HashSet<Slot> {
+    shred_slots
+        .iter()
+        .copied()
+        .filter(|slot| {
+            should_forward_to_bam_for_slot(*slot, leader_schedule_cache, my_pubkey, working_bank)
+        })
+        .collect()
+}
+
 // Retransmit a single shred to all downstream nodes
 #[allow(clippy::too_many_arguments)]
 fn retransmit_shred(
@@ -466,8 +520,11 @@ fn retransmit_shred(
     addr_cache: &AddrCache,
     socket_addr_space: &SocketAddrSpace,
     socket: RetransmitSocket<'_>,
+    external_sender_socket: &UdpSocket,
     stats: &RetransmitStats,
     shred_receiver_addresses: &ShredReceiverAddresses,
+    bam_forward_slots: &HashSet<Slot>,
+    bam_shred_receiver_addresses: &ShredReceiverAddresses,
 ) -> Option<RetransmitShredOutput> {
     let key = shred::layout::get_shred_id(shred.as_ref())?;
     if key.slot() < root_bank.slot()
@@ -487,19 +544,40 @@ fn retransmit_shred(
         .map(|flags| flags.contains(ShredFlags::LAST_SHRED_IN_SLOT))
         .unwrap_or_default();
     let mut retransmit_time = Measure::start("retransmit_to");
-    let num_addrs = addrs.len();
+    let include_bam_shred_receivers = bam_forward_slots.contains(&key.slot());
+    let mut turbine_addrs = Vec::with_capacity(addrs.len());
+    for addr in addrs.iter() {
+        if !turbine_addrs.contains(addr) {
+            turbine_addrs.push(*addr);
+        }
+    }
+    let mut external_addrs = Vec::with_capacity(shred_receiver_addresses.len().saturating_add(
+        if include_bam_shred_receivers {
+            bam_shred_receiver_addresses.len()
+        } else {
+            0
+        },
+    ));
+    for addr in shred_receiver_addresses.iter() {
+        if !turbine_addrs.contains(addr) && !external_addrs.contains(addr) {
+            external_addrs.push(*addr);
+        }
+    }
+    if include_bam_shred_receivers {
+        for addr in bam_shred_receiver_addresses.iter() {
+            if !turbine_addrs.contains(addr) && !external_addrs.contains(addr) {
+                external_addrs.push(*addr);
+            }
+        }
+    }
+    let num_addrs = turbine_addrs.len();
     let num_nodes = match socket {
         RetransmitSocket::Xdp(sender) => {
             let mut sent = num_addrs;
-            let mut send_addrs =
-                Vec::with_capacity(num_addrs.saturating_add(shred_receiver_addresses.len()));
-            send_addrs.extend(addrs.iter().copied());
-            send_addrs.extend(shred_receiver_addresses.iter().copied());
-            if !send_addrs.is_empty()
-                && let Err(e) = sender.try_send(key.index() as usize, send_addrs, shred.bytes)
+            if !turbine_addrs.is_empty()
+                && let Err(e) =
+                    sender.try_send(key.index() as usize, turbine_addrs, shred.bytes.clone())
             {
-                // External retransmit receivers (`--shred-retransmit-receiver-address`) are
-                // intentionally not included in retransmit stats.
                 log::warn!("xdp channel full: {e:?}");
                 stats
                     .num_shreds_dropped_xdp_full
@@ -510,14 +588,10 @@ fn retransmit_shred(
         }
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();
-            let mut send_addrs =
-                Vec::with_capacity(num_addrs.saturating_add(shred_receiver_addresses.len()));
-            send_addrs.extend(addrs.iter().copied());
-            send_addrs.extend(shred_receiver_addresses.iter().copied());
-            if send_addrs.is_empty() {
+            if turbine_addrs.is_empty() {
                 0
             } else {
-                match multi_target_send(socket, shred, &send_addrs) {
+                match multi_target_send(socket, &shred, &turbine_addrs) {
                     Ok(()) => num_addrs,
                     Err(SendPktsError::IoError(ioerr, num_failed)) => {
                         let num_failed = num_failed.min(num_addrs);
@@ -531,6 +605,16 @@ fn retransmit_shred(
             }
         }
     };
+    if !external_addrs.is_empty()
+        && let Err(SendPktsError::IoError(ioerr, num_failed)) =
+            multi_target_send(external_sender_socket, &shred, &external_addrs)
+    {
+        warn!(
+            "retransmit_to external multi_target_send error: {ioerr:?}, {num_failed}/{} packets \
+             failed",
+            external_addrs.len()
+        );
+    }
     retransmit_time.stop();
     stats
         .num_addrs_failed
@@ -666,6 +750,7 @@ impl RetransmitStage {
         xdp_sender: Option<XdpSender>,
         votor_event_sender: Sender<VotorEvent>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
     ) -> Self {
         let migration_status = bank_forks.read().unwrap().migration_status();
         let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
@@ -689,6 +774,10 @@ impl RetransmitStage {
         let retransmit_thread_handle = Builder::new()
             .name("solRetransmittr".to_string())
             .spawn({
+                let external_sender_socket = Arc::new(
+                    bind_to_unspecified()
+                        .expect("bind retransmit external_sender_socket 0.0.0.0:0"),
+                );
                 move || {
                     let mut shred_buf = Vec::with_capacity(RETRANSMIT_BATCH_SIZE);
                     while retransmit(
@@ -698,6 +787,7 @@ impl RetransmitStage {
                         &cluster_info,
                         &retransmit_receiver,
                         &retransmit_sockets,
+                        &external_sender_socket,
                         xdp_sender.as_ref(),
                         &mut stats,
                         &cluster_nodes_cache,
@@ -710,6 +800,7 @@ impl RetransmitStage {
                         &votor_event_sender,
                         &migration_status,
                         &shred_receiver_addresses,
+                        &bam_shred_receiver_addresses,
                     )
                     .is_ok()
                     {}
@@ -957,6 +1048,51 @@ mod tests {
             .map(Keypair::try_from)
             .unwrap()
             .unwrap()
+    }
+
+    #[test]
+    fn test_should_forward_to_bam_for_slot_near_leader_window() {
+        let my_pubkey = Pubkey::new_unique();
+        let other_pubkey = Pubkey::new_unique();
+        let leader_window = 10..=13;
+        let leader_at_slot = |slot| {
+            Some(if leader_window.contains(&slot) {
+                my_pubkey
+            } else {
+                other_pubkey
+            })
+        };
+
+        assert!(!should_forward_to_bam_for_slot_with_leader_lookup(
+            7,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            8,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            9,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            10,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
+            13,
+            &my_pubkey,
+            leader_at_slot
+        ));
+        assert!(!should_forward_to_bam_for_slot_with_leader_lookup(
+            14,
+            &my_pubkey,
+            leader_at_slot
+        ));
     }
 
     #[test]

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        ShredReceiverAddresses,
+        MAX_SHRED_RECEIVER_ADDRESSES, ShredReceiverAddresses,
         addr_cache::AddrCache,
         cluster_nodes::{
             ClusterNodes, ClusterNodesCache, DATA_PLANE_FANOUT, Error, MAX_NUM_TURBINE_HOPS,
@@ -368,12 +368,29 @@ fn retransmit(
         .flatten()
         .filter_map(|shred| shred::layout::get_slot(shred))
         .collect();
-    let bam_forward_slots = get_bam_forward_slots(
-        &shred_slots,
-        leader_schedule_cache,
-        &cluster_info.id(),
-        &working_bank,
-    );
+    let shred_receiver_addresses_local = shred_receiver_addresses.load();
+    let bam_shred_receiver_addresses_local = bam_shred_receiver_addresses.load();
+    let my_pubkey = cluster_info.id();
+    let mut leader_schedule_epoch = None;
+    let mut leader_schedule = None;
+    let mut leader_at_slot = |slot| {
+        let (epoch, slot_index) = working_bank.get_epoch_and_slot_index(slot);
+        let mut computed_slot_leader = None;
+        if leader_schedule_epoch != Some(epoch) {
+            leader_schedule = leader_schedule_cache.get_epoch_leader_schedule(epoch);
+            if leader_schedule.is_none() {
+                computed_slot_leader =
+                    leader_schedule_cache.slot_leader_at(slot, Some(&working_bank));
+                leader_schedule = leader_schedule_cache.get_epoch_leader_schedule(epoch);
+            }
+            leader_schedule_epoch = Some(epoch);
+        }
+        leader_schedule
+            .as_ref()
+            .map(|leader_schedule| leader_schedule[slot_index])
+            .or(computed_slot_leader)
+            .or_else(|| leader_schedule_cache.slot_leader_at(slot, Some(&working_bank)))
+    };
 
     // Lookup slot leader and cluster nodes for each slot.
     let cache: HashMap<Slot, _> = shred_slots
@@ -385,14 +402,23 @@ fn retransmit(
             // and if the leader is unknown they should fail signature check.
             // So here we should expect to know the slot leader and otherwise
             // skip the shred.
-            let Some(slot_leader) = leader_schedule_cache.slot_leader_at(slot, Some(&working_bank))
-            else {
+            let Some(slot_leader) = leader_at_slot(slot) else {
                 stats.unknown_shred_slot_leader += num_shreds;
                 return None;
             };
+            let include_bam_shred_receivers = !bam_shred_receiver_addresses_local.is_empty()
+                && slot_leader.id != my_pubkey
+                && (1..=2).any(|offset| {
+                    slot.checked_add(offset)
+                        .and_then(&mut leader_at_slot)
+                        .is_some_and(|leader| leader.id == my_pubkey)
+                });
             let cluster_nodes =
                 cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);
-            Some((slot, (slot_leader.id, cluster_nodes)))
+            Some((
+                slot,
+                (slot_leader.id, cluster_nodes, include_bam_shred_receivers),
+            ))
         })
         .collect();
     let socket_addr_space = cluster_info.socket_addr_space();
@@ -402,8 +428,6 @@ fn retransmit(
         entry.record(now, out);
         stats
     };
-    let shred_receiver_addresses_local = shred_receiver_addresses.load();
-    let bam_shred_receiver_addresses_local = bam_shred_receiver_addresses.load();
     let retransmit_shred = |shred, socket, stats| {
         retransmit_shred(
             shred,
@@ -416,7 +440,6 @@ fn retransmit(
             external_sender_socket,
             stats,
             &shred_receiver_addresses_local,
-            &bam_forward_slots,
             &bam_shred_receiver_addresses_local,
         )
     };
@@ -470,60 +493,26 @@ fn retransmit(
     Ok(())
 }
 
-fn should_forward_to_bam_for_slot(
-    slot: Slot,
-    leader_schedule_cache: &LeaderScheduleCache,
-    my_pubkey: &Pubkey,
-    working_bank: &Bank,
-) -> bool {
-    should_forward_to_bam_for_slot_with_leader_lookup(slot, my_pubkey, |slot| {
-        leader_schedule_cache
-            .slot_leader_at(slot, Some(working_bank))
-            .map(|leader| leader.id)
-    })
-}
-
-fn should_forward_to_bam_for_slot_with_leader_lookup(
-    slot: Slot,
-    my_pubkey: &Pubkey,
-    mut leader_at_slot: impl FnMut(Slot) -> Option<Pubkey>,
-) -> bool {
-    (0..3).any(|offset| {
-        slot.checked_add(offset)
-            .and_then(&mut leader_at_slot)
-            .is_some_and(|leader| leader == *my_pubkey)
-    })
-}
-
-fn get_bam_forward_slots(
-    shred_slots: &HashSet<Slot>,
-    leader_schedule_cache: &LeaderScheduleCache,
-    my_pubkey: &Pubkey,
-    working_bank: &Bank,
-) -> HashSet<Slot> {
-    shred_slots
-        .iter()
-        .copied()
-        .filter(|slot| {
-            should_forward_to_bam_for_slot(*slot, leader_schedule_cache, my_pubkey, working_bank)
-        })
-        .collect()
-}
-
 // Retransmit a single shred to all downstream nodes
 #[allow(clippy::too_many_arguments)]
 fn retransmit_shred(
     shred: shred::Payload,
     root_bank: &Bank,
     shred_deduper: &ShredDeduper,
-    cache: &HashMap<Slot, (/*leader:*/ Pubkey, Arc<ClusterNodes<RetransmitStage>>)>,
+    cache: &HashMap<
+        Slot,
+        (
+            /*leader:*/ Pubkey,
+            Arc<ClusterNodes<RetransmitStage>>,
+            /*include_bam_shred_receivers:*/ bool,
+        ),
+    >,
     addr_cache: &AddrCache,
     socket_addr_space: &SocketAddrSpace,
     socket: RetransmitSocket<'_>,
     external_sender_socket: &UdpSocket,
     stats: &RetransmitStats,
     shred_receiver_addresses: &ShredReceiverAddresses,
-    bam_forward_slots: &HashSet<Slot>,
     bam_shred_receiver_addresses: &ShredReceiverAddresses,
 ) -> Option<RetransmitShredOutput> {
     let key = shred::layout::get_shred_id(shred.as_ref())?;
@@ -534,7 +523,7 @@ fn retransmit_shred(
         return None;
     }
     let mut compute_turbine_peers = Measure::start("turbine_start");
-    let (root_distance, addrs) =
+    let (root_distance, addrs, include_bam_shred_receivers) =
         get_retransmit_addrs(&key, cache, addr_cache, socket_addr_space, stats)?;
     compute_turbine_peers.stop();
     stats
@@ -544,40 +533,49 @@ fn retransmit_shred(
         .map(|flags| flags.contains(ShredFlags::LAST_SHRED_IN_SLOT))
         .unwrap_or_default();
     let mut retransmit_time = Measure::start("retransmit_to");
-    let include_bam_shred_receivers = bam_forward_slots.contains(&key.slot());
     let mut turbine_addrs = Vec::with_capacity(addrs.len());
     for addr in addrs.iter() {
         if !turbine_addrs.contains(addr) {
             turbine_addrs.push(*addr);
         }
     }
-    let mut external_addrs = Vec::with_capacity(shred_receiver_addresses.len().saturating_add(
-        if include_bam_shred_receivers {
+    let num_shred_receiver_addresses = shred_receiver_addresses
+        .len()
+        .min(MAX_SHRED_RECEIVER_ADDRESSES);
+    let external_addr_capacity =
+        num_shred_receiver_addresses.saturating_add(if include_bam_shred_receivers {
             bam_shred_receiver_addresses.len()
         } else {
             0
-        },
-    ));
-    for addr in shred_receiver_addresses.iter() {
-        if !turbine_addrs.contains(addr) && !external_addrs.contains(addr) {
-            external_addrs.push(*addr);
-        }
-    }
-    if include_bam_shred_receivers {
-        for addr in bam_shred_receiver_addresses.iter() {
-            if !turbine_addrs.contains(addr) && !external_addrs.contains(addr) {
-                external_addrs.push(*addr);
-            }
+        });
+    let mut external_addrs = ShredReceiverAddresses::with_capacity(external_addr_capacity);
+    for &addr in shred_receiver_addresses
+        .iter()
+        .take(num_shred_receiver_addresses)
+        .chain(
+            include_bam_shred_receivers
+                .then_some(bam_shred_receiver_addresses)
+                .into_iter()
+                .flatten(),
+        )
+    {
+        if !turbine_addrs.contains(&addr) && !external_addrs.contains(&addr) {
+            external_addrs.push(addr);
         }
     }
     let num_addrs = turbine_addrs.len();
     let num_nodes = match socket {
         RetransmitSocket::Xdp(sender) => {
             let mut sent = num_addrs;
-            if !turbine_addrs.is_empty()
+            let mut send_addrs =
+                Vec::with_capacity(turbine_addrs.len().saturating_add(external_addrs.len()));
+            send_addrs.extend(turbine_addrs.iter().copied());
+            send_addrs.extend(external_addrs.iter().copied());
+            if !send_addrs.is_empty()
                 && let Err(e) =
-                    sender.try_send(key.index() as usize, turbine_addrs, shred.bytes.clone())
+                    sender.try_send(key.index() as usize, send_addrs, shred.bytes.clone())
             {
+                // External shred receivers are intentionally not included in retransmit stats.
                 log::warn!("xdp channel full: {e:?}");
                 stats
                     .num_shreds_dropped_xdp_full
@@ -588,8 +586,8 @@ fn retransmit_shred(
         }
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();
-            if turbine_addrs.is_empty() {
-                0
+            let sent = if turbine_addrs.is_empty() {
+                0usize
             } else {
                 match multi_target_send(socket, &shred, &turbine_addrs) {
                     Ok(()) => num_addrs,
@@ -602,19 +600,20 @@ fn retransmit_shred(
                         num_addrs - num_failed
                     }
                 }
+            };
+            if !external_addrs.is_empty()
+                && let Err(SendPktsError::IoError(ioerr, num_failed)) =
+                    multi_target_send(external_sender_socket, &shred, &external_addrs)
+            {
+                warn!(
+                    "retransmit_to external multi_target_send error: {ioerr:?}, {num_failed}/{} \
+                     packets failed",
+                    external_addrs.len()
+                );
             }
+            sent
         }
     };
-    if !external_addrs.is_empty()
-        && let Err(SendPktsError::IoError(ioerr, num_failed)) =
-            multi_target_send(external_sender_socket, &shred, &external_addrs)
-    {
-        warn!(
-            "retransmit_to external multi_target_send error: {ioerr:?}, {num_failed}/{} packets \
-             failed",
-            external_addrs.len()
-        );
-    }
     retransmit_time.stop();
     stats
         .num_addrs_failed
@@ -637,16 +636,35 @@ fn retransmit_shred(
 
 fn get_retransmit_addrs<'a>(
     shred: &ShredId,
-    cache: &HashMap<Slot, (/*leader:*/ Pubkey, Arc<ClusterNodes<RetransmitStage>>)>,
+    cache: &HashMap<
+        Slot,
+        (
+            /*leader:*/ Pubkey,
+            Arc<ClusterNodes<RetransmitStage>>,
+            /*include_bam_shred_receivers:*/ bool,
+        ),
+    >,
     addr_cache: &'a AddrCache,
     socket_addr_space: &SocketAddrSpace,
     stats: &RetransmitStats,
-) -> Option<(/*root_distance:*/ u8, Cow<'a, [SocketAddr]>)> {
+) -> Option<(
+    /*root_distance:*/ u8,
+    Cow<'a, [SocketAddr]>,
+    /*include_bam_shred_receivers:*/ bool,
+)> {
+    let cache_entry = cache.get(&shred.slot());
+    let include_bam_shred_receivers = cache_entry
+        .map(|(_, _, include_bam_shred_receivers)| *include_bam_shred_receivers)
+        .unwrap_or_default();
     if let Some((root_distance, addrs)) = addr_cache.get(shred) {
         stats.addr_cache_hit.fetch_add(1, Ordering::Relaxed);
-        return Some((root_distance, Cow::Borrowed(addrs)));
+        return Some((
+            root_distance,
+            Cow::Borrowed(addrs),
+            include_bam_shred_receivers,
+        ));
     }
-    let (slot_leader, cluster_nodes) = cache.get(&shred.slot())?;
+    let (slot_leader, cluster_nodes, _) = cache_entry?;
     let (root_distance, addrs) = cluster_nodes
         .get_retransmit_addrs(slot_leader, shred, DATA_PLANE_FANOUT, socket_addr_space)
         .inspect_err(|err| match err {
@@ -656,7 +674,11 @@ fn get_retransmit_addrs<'a>(
         })
         .ok()?;
     stats.addr_cache_miss.fetch_add(1, Ordering::Relaxed);
-    Some((root_distance, Cow::Owned(addrs)))
+    Some((
+        root_distance,
+        Cow::Owned(addrs),
+        include_bam_shred_receivers,
+    ))
 }
 
 // Speculatively precomputes turbine tree and caches retranmsit addresses.
@@ -1033,10 +1055,19 @@ mod tests {
         super::*,
         rand::SeedableRng,
         rand_chacha::ChaChaRng,
+        solana_cluster_type::ClusterType,
         solana_entry::entry::create_ticks,
+        solana_gossip::{cluster_info::ClusterInfo, node::Node},
         solana_hash::Hash,
         solana_keypair::Keypair,
-        solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+        solana_ledger::{
+            genesis_utils::create_genesis_config,
+            shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+        },
+        solana_net_utils::sockets::bind_to_localhost_unique,
+        solana_runtime::bank::Bank,
+        solana_signer::Signer,
+        std::{net::UdpSocket, time::Duration},
     };
 
     fn get_keypair() -> Keypair {
@@ -1051,48 +1082,125 @@ mod tests {
     }
 
     #[test]
-    fn test_should_forward_to_bam_for_slot_near_leader_window() {
-        let my_pubkey = Pubkey::new_unique();
-        let other_pubkey = Pubkey::new_unique();
-        let leader_window = 10..=13;
-        let leader_at_slot = |slot| {
-            Some(if leader_window.contains(&slot) {
-                my_pubkey
-            } else {
-                other_pubkey
-            })
+    fn test_retransmit_external_receivers_are_deduped_and_bam_gated() {
+        let bind_receiver = || {
+            let socket = bind_to_localhost_unique().unwrap();
+            socket
+                .set_read_timeout(Some(Duration::from_millis(200)))
+                .unwrap();
+            socket
+        };
+        let recv_one = |socket: &UdpSocket| {
+            let mut buf = [0u8; 2048];
+            socket.recv_from(&mut buf).is_ok()
+        };
+        let assert_no_packet = |socket: &UdpSocket| {
+            let mut buf = [0u8; 2048];
+            assert!(socket.recv_from(&mut buf).is_err());
         };
 
-        assert!(!should_forward_to_bam_for_slot_with_leader_lookup(
-            7,
-            &my_pubkey,
-            leader_at_slot
+        let turbine_receiver = bind_receiver();
+        let duplicate_configured_receiver = bind_receiver();
+        let configured_receiver = bind_receiver();
+        let bam_receiver = bind_receiver();
+        let turbine_addr = turbine_receiver.local_addr().unwrap();
+        let duplicate_configured_addr = duplicate_configured_receiver.local_addr().unwrap();
+        let configured_addr = configured_receiver.local_addr().unwrap();
+        let bam_addr = bam_receiver.local_addr().unwrap();
+        let retransmit_socket = bind_to_localhost_unique().unwrap();
+        let external_sender_socket = bind_to_localhost_unique().unwrap();
+
+        let keypair = get_keypair();
+        let entries = create_ticks(1, 1, Hash::new_unique());
+        let shredder = Shredder::new(5, 4, 1, 0).unwrap();
+        let (data_shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+            &keypair,
+            &entries,
+            true,
+            Hash::new_from_array(rand::rng().random()),
+            0,
+            0,
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
+        let shred = data_shreds[0].payload().clone();
+        let key = shred::layout::get_shred_id(shred.as_ref()).unwrap();
+
+        let genesis_config = create_genesis_config(10_000).genesis_config;
+        let root_bank = Bank::new_for_tests(&genesis_config);
+        let cluster_info = ClusterInfo::new(
+            Node::new_localhost_with_pubkey(&keypair.pubkey()).info,
+            Arc::new(keypair),
+            SocketAddrSpace::Unspecified,
+        );
+        let cluster_nodes = Arc::new(crate::cluster_nodes::new_cluster_nodes::<RetransmitStage>(
+            &cluster_info,
+            ClusterType::Development,
+            &HashMap::new(),
+            false,
         ));
-        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
-            8,
-            &my_pubkey,
-            leader_at_slot
-        ));
-        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
-            9,
-            &my_pubkey,
-            leader_at_slot
-        ));
-        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
-            10,
-            &my_pubkey,
-            leader_at_slot
-        ));
-        assert!(should_forward_to_bam_for_slot_with_leader_lookup(
-            13,
-            &my_pubkey,
-            leader_at_slot
-        ));
-        assert!(!should_forward_to_bam_for_slot_with_leader_lookup(
-            14,
-            &my_pubkey,
-            leader_at_slot
-        ));
+        let shred_receiver_addresses: ShredReceiverAddresses =
+            [duplicate_configured_addr, configured_addr]
+                .into_iter()
+                .collect();
+        let bam_shred_receiver_addresses: ShredReceiverAddresses =
+            [configured_addr, bam_addr, turbine_addr]
+                .into_iter()
+                .collect();
+
+        let retransmit_once = |include_bam_shred_receivers| {
+            let mut cache = HashMap::new();
+            cache.insert(
+                key.slot(),
+                (
+                    Pubkey::new_unique(),
+                    cluster_nodes.clone(),
+                    include_bam_shred_receivers,
+                ),
+            );
+            let mut addr_cache = AddrCache::with_capacity(1);
+            addr_cache.put(
+                &key,
+                (0, Box::new([turbine_addr, duplicate_configured_addr])),
+            );
+            let mut rng = ChaChaRng::from_seed([0xa5; 32]);
+            let shred_deduper = ShredDeduper::<2>::new(&mut rng, /*num_bits:*/ 640_007);
+            retransmit_shred(
+                shred.clone(),
+                &root_bank,
+                &shred_deduper,
+                &cache,
+                &addr_cache,
+                &SocketAddrSpace::Unspecified,
+                RetransmitSocket::Socket(&retransmit_socket),
+                &external_sender_socket,
+                &RetransmitStats::new(Instant::now()),
+                &shred_receiver_addresses,
+                &bam_shred_receiver_addresses,
+            )
+            .unwrap()
+        };
+
+        let out = retransmit_once(false);
+        assert_eq!(out.num_nodes, 2);
+        assert!(recv_one(&turbine_receiver));
+        assert!(recv_one(&duplicate_configured_receiver));
+        assert!(recv_one(&configured_receiver));
+        assert_no_packet(&turbine_receiver);
+        assert_no_packet(&duplicate_configured_receiver);
+        assert_no_packet(&configured_receiver);
+        assert_no_packet(&bam_receiver);
+
+        let out = retransmit_once(true);
+        assert_eq!(out.num_nodes, 2);
+        assert!(recv_one(&turbine_receiver));
+        assert!(recv_one(&duplicate_configured_receiver));
+        assert!(recv_one(&configured_receiver));
+        assert!(recv_one(&bam_receiver));
+        assert_no_packet(&turbine_receiver);
+        assert_no_packet(&duplicate_configured_receiver);
+        assert_no_packet(&configured_receiver);
+        assert_no_packet(&bam_receiver);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Forward BAM-provided shred receiver sockets through broadcast and retransmit paths.
- Gate BAM retransmit forwarding to slots just before this validator’s leader window, with de-duping and receiver caps.
- Wire BAM shred receiver state through TPU/TVU and clear it on BAM disconnect.
- Add focused tests for external receiver de-duping, caps, and BAM gating.