### PR TITLE
[Master] More efficient retransmit for BAM

### DIFF
--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -16,7 +16,7 @@ use {
     lru::LruCache,
     rand::Rng,
     rayon::{ThreadPool, ThreadPoolBuilder, prelude::*},
-    solana_clock::Slot,
+    solana_clock::{NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         leader_schedule_cache::LeaderScheduleCache,
@@ -409,9 +409,12 @@ fn retransmit(
             let include_bam_shred_receivers = !bam_shred_receiver_addresses_local.is_empty()
                 && slot_leader.id != my_pubkey
                 && (1..=2).any(|offset| {
-                    slot.checked_add(offset)
-                        .and_then(&mut leader_at_slot)
-                        .is_some_and(|leader| leader.id == my_pubkey)
+                    slot.checked_add(offset).is_some_and(|lookahead_slot| {
+                        lookahead_slot % NUM_CONSECUTIVE_LEADER_SLOTS == 0
+                            && lookahead_slot > working_bank.slot()
+                            && leader_at_slot(lookahead_slot)
+                                .is_some_and(|leader| leader.id == my_pubkey)
+                    })
                 });
             let cluster_nodes =
                 cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);


### PR DESCRIPTION
## Summary
Clean up retransmit to be more efficient. Gates BAM shred receiver inclusion to upcoming consecutive leader-window starts that are still ahead of the working bank slot.

## Behavior Matrix

Assume this validator's leader window is `L..L+3`, where `L` is the first slot of the consecutive leader window.

Legend:

- `Y` = this `(shred slot, lookahead slot)` can make `include_bam_shred_receivers = true`
- `-` = not considered or does not qualify
- Common conditions omitted: BAM addresses non-empty, current shred leader is not this node
- After also requires `lookahead_slot > working_bank.slot()`

### Before

| Shred Slot \ Lookahead Slot | `L` | `L+1` | `L+2` | `L+3` |
|---|---:|---:|---:|---:|
| `L-2` | Y | - | - | - |
| `L-1` | Y | Y | - | - |
| `L` | - | Y | Y | - |
| `L+1` | - | - | Y | Y |
| `L+2` | - | - | - | Y |
| `L+3` | - | - | - | - |

### After

| Shred Slot \ Lookahead Slot | `L` | `L+1` | `L+2` | `L+3` |
|---|---:|---:|---:|---:|
| `L-2` | Y | - | - | - |
| `L-1` | Y | - | - | - |
| `L` | - | - | - | - |
| `L+1` | - | - | - | - |
| `L+2` | - | - | - | - |
| `L+3` | - | - | - | - |

The old code could trigger from any of this node's next two leader slots. The new code only triggers when the lookahead slot is exactly `L`, the first slot of the leader window.
