### PR TITLE
[v4.0] Shred retransmit optimizations

### DIFF
--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -16,7 +16,7 @@ use {
     lru::LruCache,
     rand::Rng,
     rayon::{ThreadPool, ThreadPoolBuilder, prelude::*},
-    solana_clock::Slot,
+    solana_clock::{NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         leader_schedule_cache::LeaderScheduleCache,
@@ -409,9 +409,12 @@ fn retransmit(
             let include_bam_shred_receivers = !bam_shred_receiver_addresses_local.is_empty()
                 && slot_leader.id != my_pubkey
                 && (1..=2).any(|offset| {
-                    slot.checked_add(offset)
-                        .and_then(&mut leader_at_slot)
-                        .is_some_and(|leader| leader.id == my_pubkey)
+                    slot.checked_add(offset).is_some_and(|lookahead_slot| {
+                        lookahead_slot % NUM_CONSECUTIVE_LEADER_SLOTS == 0
+                            && lookahead_slot > working_bank.slot()
+                            && leader_at_slot(lookahead_slot)
+                                .is_some_and(|leader| leader.id == my_pubkey)
+                    })
                 });
             let cluster_nodes =
                 cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);


### PR DESCRIPTION
Backport of https://github.com/jito-foundation/jito-solana/pull/1434

Pcap dump results
```
  slot       total  data  code
  417234468      4     3     1
  417234469      1     0     1
  417234470      2     1     1
  417234471      2     1     1
  417234472      2     0     2
  417234473      1     0     1
  417234475      2     0     2
  417234477      1     1     0
  417234478   1024   512   512
  417234479   1152   576   576
  417234480   1344   672   672
  417234481   1088   544   544
  417234482   1216   608   608
  417234483   1024   512   512
  417234484      1     0     1
  417234485      1     1     0
  417234486      2     1     1
  417234487      1     0     1
  417234488      1     0     1
  417234489      1     0     1
  417234491      1     1     0
  417234492      2     0     2
  417234493      3     1     2
  417234494      1     0     1
  ```

  Source port split:
      - 49322: retransmit external, 2,172 shreds, slots 417234478..417234479.
      - 59075: broadcast external, 4,672 shreds, slots 417234480..417234483.
      - 8006: normal low-volume turbine path, 100 shreds across many slots.

100ms bins for the relevant external shred traffic:
```
  slot       mod4  path                    time bin      total  data  code
  417234478  2     retransmit-external      20:49:04.000      5     2     3
  417234478  2     retransmit-external      20:49:04.100    134    69    65
  417234478  2     retransmit-external      20:49:04.200    136    65    71
  417234478  2     retransmit-external      20:49:04.300    571   288   283
  417234478  2     retransmit-external      20:49:04.400    177    87    90
  417234479  3     retransmit-external      20:49:04.400     17     9     8
  417234479  3     retransmit-external      20:49:04.500    204   101   103
  417234479  3     retransmit-external      20:49:04.600    563   283   280
  417234479  3     retransmit-external      20:49:04.700    325   161   164
  417234479  3     retransmit-external      20:49:04.800     40    22    18

  417234480  0     broadcast-external       20:49:04.800    704   352   352
  417234480  0     broadcast-external       20:49:04.900    320   160   160
  417234480  0     broadcast-external       20:49:05.000    192    96    96
  417234480  0     broadcast-external       20:49:05.100    128    64    64
  417234481  1     broadcast-external       20:49:05.200    256   128   128
  417234481  1     broadcast-external       20:49:05.300    512   256   256
  417234481  1     broadcast-external       20:49:05.400    256   128   128
  417234481  1     broadcast-external       20:49:05.500     64    32    32
  417234482  2     broadcast-external       20:49:05.500    128    64    64
  417234482  2     broadcast-external       20:49:05.600    576   288   288
  417234482  2     broadcast-external       20:49:05.700    256   128   128
  417234482  2     broadcast-external       20:49:05.800    256   128   128
  417234483  3     broadcast-external       20:49:05.900    192    96    96
  417234483  3     broadcast-external       20:49:06.000    512   256   256
  417234483  3     broadcast-external       20:49:06.100    256   128   128
  417234483  3     broadcast-external       20:49:06.200     64    32    32
  ```
