### PR TITLE
Limit the number of jobs to avoid port overflows on high core count machines

### DIFF
--- a/ci/common/limit-threads.sh
+++ b/ci/common/limit-threads.sh
@@ -13,5 +13,8 @@ NPROC=$(nproc)
 SYS_JOBS=$((SYS_JOBS > NPROC ? NPROC : SYS_JOBS))
 : "${JOBS:=$SYS_JOBS}"
 
+# Jito override
+JOBS=48
+
 export NPROC
 export JOBS

--- a/ci/common/limit-threads.sh
+++ b/ci/common/limit-threads.sh
@@ -13,7 +13,7 @@ NPROC=$(nproc)
 SYS_JOBS=$((SYS_JOBS > NPROC ? NPROC : SYS_JOBS))
 : "${JOBS:=$SYS_JOBS}"
 
-# Jito override
+# Jito override to avoid overflow in unique_port_range_for_tests from NEXTEST_TEST_GLOBAL_SLOT being too high.
 JOBS=48
 
 export NPROC


### PR DESCRIPTION
#### Problem
CI jobs fail at unique_port_range_for_tests when NEXTEST_TEST_GLOBAL_SLOT is too high. 

The function below requires NEXTEST_TEST_GLOBAL_SLOT < ~65 jobs. 

```rs
pub fn unique_port_range_for_tests(size: u16) -> Range<u16> {
    static SLICE: AtomicU16 = AtomicU16::new(0);
    let offset = SLICE.fetch_add(size, Ordering::SeqCst);
    let start = offset
        + match std::env::var("NEXTEST_TEST_GLOBAL_SLOT") {
            Ok(slot) => {
                let slot: u16 = slot.parse().unwrap();
                assert!(
                    offset < SLICE_PER_PROCESS,
                    "Overrunning into the port range of another test! Consider using fewer ports \
                     per test."
                );
                UNIQUE_ALLOC_BASE_PORT + slot * SLICE_PER_PROCESS
            }
            Err(_) => UNIQUE_ALLOC_BASE_PORT,
        };
    assert!(start < u16::MAX - size, "Ran out of port numbers!");
    start..start + size
}
```

#### Summary of Changes
We'll limit the number of parallel testing jobs to avoid NEXTEST_TEST_GLOBAL_SLOT increasing too much.