### PR TITLE
Increase BAM shred retransmit lookahead

### DIFF
--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -407,7 +407,7 @@ fn retransmit(
             };
             let include_bam_shred_receivers = !bam_shred_receiver_addresses_local.is_empty()
                 && slot_leader.id != my_pubkey
-                && (1..=2).any(|offset| {
+                && (1..=4).any(|offset| {
                     slot.checked_add(offset).is_some_and(|lookahead_slot| {
                         lookahead_slot % NUM_CONSECUTIVE_LEADER_SLOTS == 0
                             && lookahead_slot > working_bank.slot()


### PR DESCRIPTION
## Summary
- Increase BAM shred retransmit leader lookahead from 2 slots to 4