### PR TITLE
fix(ci): adding v4.1 to autorebase CI

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -38,6 +38,12 @@ jobs:
           - branch: v3.0
             upstream_branch: v3.0
             upstream_repo: https://github.com/anza-xyz/agave.git
+          - branch: v4.0
+            upstream_branch: v4.0
+            upstream_repo: https://github.com/anza-xyz/agave.git
+          - branch: v4.1
+            upstream_branch: v4.1
+            upstream_repo: https://github.com/anza-xyz/agave.git
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
#### Problem
jito-solana is a git fork of anza-xyz/agave. Agave updates are pulled in via git rebase, not Cargo dependencies. The jito patches sit on top of the agave commits on each branch.

  The automation: There's a nightly GitHub Actions workflow (rebase.yaml) that runs weekdays at 19:00 UTC. It:
  1. Creates a temp branch, rebases it onto upstream/anza-xyz/agave
  2. Waits for Buildkite CI to pass
  3. Force-pushes back to the tracked branch

  The problem for v4.1: The matrix in rebase.yaml (lines 31–40) only covers:
  - master → agave:master
  - v3.1 → agave:v3.1
  - v3.0 → agave:v3.0

  v4.1 is not in the matrix, so it gets no automated rebases. Whoever set up the v4.1 branch did so manually (following the process documented in the workflow comments at
  the top of the file), and any future agave v4.1 updates would need to be manually rebased in unless v4.1 is added to the matrix.

#### Summary of Changes

1. Added v4.1 -> agave:v4.1 to the matrix
