### PR TITLE
[Master] Fix prio graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5498,9 +5498,12 @@ dependencies = [
 
 [[package]]
 name = "prio-graph"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dd2fa9ca0901b4d0dbf51d9862d7e3fb004605e4f4b4132472c3d08e7d901b"
+checksum = "2f28921629370a46cf564f6ba1828bd8d1c97f7fad4ee9d1c6438f92feed6b8d"
+dependencies = [
+ "ahash 0.8.12",
+]
 
 [[package]]
 name = "proc-macro-crate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,7 +317,7 @@ pickledb = { version = "0.5.1", default-features = false }
 predicates = "3.1"
 pretty-hex = "0.4.2"
 pretty_assertions = "1.4.1"
-prio-graph = "=0.1.0"
+prio-graph = "0.3.0"
 proptest = "1.11"
 prost = "0.14.3"
 prost-types = "0.14.3"

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -121,7 +121,6 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         }
     }
 
-    /// Gets accessed accounts (resources) for use in `PrioGraph`.
     fn get_transactions_account_access<'a>(
         transactions: impl Iterator<Item = &'a (impl SVMMessage + 'a)> + 'a,
     ) -> impl Iterator<Item = (Pubkey, AccessKind)> + 'a {
@@ -542,7 +541,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             }
         }
         let now = Instant::now();
-        while let Some(next_batch_id) = self.prio_graph.pop_and_unblock() {
+        while let Some((next_batch_id, _)) = self.prio_graph.pop_and_unblock() {
             if let Some(insertion_time) = self
                 .insertion_to_prio_graph_time
                 .remove(&priority_to_seq_id(next_batch_id.priority))
@@ -557,7 +556,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             container.remove_by_id(next_batch_id.id);
         }
 
-        self.prio_graph = PrioGraph::new(passthrough_priority);
+        self.prio_graph.clear();
         self.insertion_to_prio_graph_time.clear();
 
         // Only report timing metrics when slot has ended
@@ -1334,5 +1333,65 @@ mod tests {
         if let Some(first_id) = stored_txn_ids.first() {
             scheduler.prio_graph.unblock(first_id);
         }
+    }
+
+    /// Regression test for the `solBamSched` "blocking node must exist" panic.
+    ///
+    /// A bundle is inserted as one `PrioGraph` node, so two transactions sharing
+    /// a writable account (the common fee payer here) make the node reference
+    /// the same resource twice. prio-graph 0.3.0 tolerates this (its
+    /// `insert_transaction` skips a blocker equal to the node itself); 0.1.0
+    /// lacked that guard and panicked. Guards against regressing to a version
+    /// without it.
+    #[test]
+    fn test_pull_bundle_with_shared_writable_account_does_not_panic() {
+        let (bank_forks, _) = test_bank_forks();
+        let TestScheduler { mut scheduler, .. } = create_test_scheduler(4, &bank_forks);
+        scheduler.extra_checks_enabled = false;
+
+        let bank = bank_forks.read().unwrap().working_bank();
+
+        // Set the scheduler's slot via a Consume decision.
+        let mut slot_container = create_container(vec![(
+            &Keypair::new(),
+            vec![Pubkey::new_unique()],
+            1000,
+            seq_id_to_priority(0),
+            u64::MAX,
+        )]);
+        scheduler
+            .receive_completed(
+                &mut slot_container,
+                &BufferedPacketsDecision::Consume(bank.clone()),
+            )
+            .unwrap();
+        assert_eq!(scheduler.slot, Some(bank.slot()));
+
+        // One batch, two transactions sharing a writable account: both are
+        // signed by `keypair_a`, so both write its fee-payer account (index 0).
+        let keypair_a = Keypair::new();
+        let priority = seq_id_to_priority(0);
+        let mut txns_max_age: SmallVec<
+            [(RuntimeTransaction<SanitizedTransaction>, MaxAge); MAX_PACKETS_PER_BUNDLE],
+        > = SmallVec::new();
+        txns_max_age.push((
+            prioritized_tranfers(&keypair_a, vec![Pubkey::new_unique()], 1000, priority),
+            MaxAge::MAX,
+        ));
+        txns_max_age.push((
+            prioritized_tranfers(&keypair_a, vec![Pubkey::new_unique()], 2000, priority),
+            MaxAge::MAX,
+        ));
+
+        let mut container = TransactionStateContainer::with_capacity(10 * 1024);
+        container.insert_new_batch(txns_max_age, priority, 5000, false, u64::MAX);
+
+        // Must not panic; the bundle becomes a single schedulable node.
+        scheduler.pull_into_prio_graph(&mut container);
+
+        assert!(
+            !scheduler.prio_graph.is_empty(),
+            "bundle sharing a writable account should be inserted and schedulable"
+        );
     }
 }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -4777,9 +4777,12 @@ dependencies = [
 
 [[package]]
 name = "prio-graph"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dd2fa9ca0901b4d0dbf51d9862d7e3fb004605e4f4b4132472c3d08e7d901b"
+checksum = "2f28921629370a46cf564f6ba1828bd8d1c97f7fad4ee9d1c6438f92feed6b8d"
+dependencies = [
+ "ahash 0.8.12",
+]
 
 [[package]]
 name = "proc-macro-crate"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4618,9 +4618,12 @@ dependencies = [
 
 [[package]]
 name = "prio-graph"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dd2fa9ca0901b4d0dbf51d9862d7e3fb004605e4f4b4132472c3d08e7d901b"
+checksum = "2f28921629370a46cf564f6ba1828bd8d1c97f7fad4ee9d1c6438f92feed6b8d"
+dependencies = [
+ "ahash 0.8.12",
+]
 
 [[package]]
 name = "proc-macro-crate"


### PR DESCRIPTION
#### Problem

The `solBamSched` thread panics with `blocking node must exist` in prio-graph's `insert_transaction`, aborting the scheduler and taking down the validator.

`BamScheduler` inserts a whole bundle as a single `PrioGraph` node. When two transactions in the bundle share a writable account (e.g. a common fee payer), the node references the same resource twice. prio-graph `0.1.0` has no guard for a blocker equal to the node itself, so it looks up a node that has not been inserted yet and panics.

#### Summary of Changes

- Upgrade `prio-graph` `0.1.0` → `0.3.0`, whose `insert_transaction` ignores a blocker equal to the node itself (`if blocking_id == id { return; }`).
- Add a regression test that builds a bundle sharing a writable account and asserts it schedules without panicking (fails on 0.1.0, passes on 0.3.0).
