### PR TITLE
[v4.1] Fix local cluster startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,6 +1354,7 @@ dependencies = [
  "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-genesis-config",
+ "solana-genesis-utils",
  "solana-keypair",
  "solana-ledger",
  "solana-local-cluster",

--- a/bam-local-cluster/Cargo.toml
+++ b/bam-local-cluster/Cargo.toml
@@ -30,6 +30,7 @@ solana-faucet = { workspace = true }
 solana-feature-gate-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-genesis-config = { workspace = true }
+solana-genesis-utils = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
 solana-local-cluster = { workspace = true }

--- a/bam-local-cluster/src/cluster_manager.rs
+++ b/bam-local-cluster/src/cluster_manager.rs
@@ -10,6 +10,7 @@ use {
     solana_feature_gate_interface as feature,
     solana_fee_calculator::FeeRateGovernor,
     solana_genesis_config::GenesisConfig,
+    solana_genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     solana_keypair::{Keypair, read_keypair_file},
     solana_ledger::{
         blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions,
@@ -42,11 +43,6 @@ use {
     },
     tokio::{runtime::Runtime, signal},
 };
-
-// create_new_ledger verifies the generated genesis archive can be unpacked.
-// BAM local-cluster genesis archives can exceed the standard 10 MiB default, so
-// allow up to 10 GiB for local cluster ledger creation.
-const MAX_BAM_LOCAL_CLUSTER_GENESIS_ARCHIVE_UNPACKED_SIZE: u64 = 10 * 1024 * 1024 * 1024;
 
 pub struct BamValidator {
     process: Child,
@@ -439,7 +435,7 @@ impl BamLocalCluster {
                 create_new_ledger(
                     &ledger_path,
                     &genesis_config_info.genesis_config,
-                    MAX_BAM_LOCAL_CLUSTER_GENESIS_ARCHIVE_UNPACKED_SIZE,
+                    MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
                     LedgerColumnOptions::default(),
                 )?;
             }
@@ -449,7 +445,7 @@ impl BamLocalCluster {
                 create_new_ledger(
                     &ledger_path,
                     &genesis_config_info.genesis_config,
-                    MAX_BAM_LOCAL_CLUSTER_GENESIS_ARCHIVE_UNPACKED_SIZE,
+                    MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
                     LedgerColumnOptions::default(),
                 )?;
                 BamValidator::create_snapshot(&ledger_path, &config.ledger_tool_build_path)?;

--- a/bam-local-cluster/src/cluster_manager.rs
+++ b/bam-local-cluster/src/cluster_manager.rs
@@ -110,6 +110,8 @@ impl BamValidator {
         .arg("--full-rpc-api")
         .arg("--enable-rpc-transaction-history")
         .arg("--enable-extended-tx-metadata-storage")
+        .arg("--snapshot-interval-slots")
+        .arg("25")
         .arg("--expected-shred-version")
         .arg(compute_shred_version(&genesis_config.hash(), None).to_string())
         .arg("--bam-url")
@@ -426,6 +428,14 @@ impl BamLocalCluster {
                 .into());
             }
 
+            if !is_bootstrap {
+                create_new_ledger(
+                    &ledger_path,
+                    &genesis_config_info.genesis_config,
+                    10737418240,
+                    LedgerColumnOptions::default(),
+                )?;
+            }
             // Create ledger and snapshot if bootstrap; other validators need to have snapshot
             // to download from the bootstrap validator to start
             if is_bootstrap {

--- a/bam-local-cluster/src/cluster_manager.rs
+++ b/bam-local-cluster/src/cluster_manager.rs
@@ -43,6 +43,11 @@ use {
     tokio::{runtime::Runtime, signal},
 };
 
+// create_new_ledger verifies the generated genesis archive can be unpacked.
+// BAM local-cluster genesis archives can exceed the standard 10 MiB default, so
+// allow up to 10 GiB for local cluster ledger creation.
+const MAX_BAM_LOCAL_CLUSTER_GENESIS_ARCHIVE_UNPACKED_SIZE: u64 = 10 * 1024 * 1024 * 1024;
+
 pub struct BamValidator {
     process: Child,
     node_name: String,
@@ -110,6 +115,8 @@ impl BamValidator {
         .arg("--full-rpc-api")
         .arg("--enable-rpc-transaction-history")
         .arg("--enable-extended-tx-metadata-storage")
+        // Keep snapshots frequent so restarted or non-bootstrap local validators
+        // can quickly download a usable bootstrap snapshot during short runs.
         .arg("--snapshot-interval-slots")
         .arg("25")
         .arg("--expected-shred-version")
@@ -432,7 +439,7 @@ impl BamLocalCluster {
                 create_new_ledger(
                     &ledger_path,
                     &genesis_config_info.genesis_config,
-                    10737418240,
+                    MAX_BAM_LOCAL_CLUSTER_GENESIS_ARCHIVE_UNPACKED_SIZE,
                     LedgerColumnOptions::default(),
                 )?;
             }
@@ -442,7 +449,7 @@ impl BamLocalCluster {
                 create_new_ledger(
                     &ledger_path,
                     &genesis_config_info.genesis_config,
-                    10737418240,
+                    MAX_BAM_LOCAL_CLUSTER_GENESIS_ARCHIVE_UNPACKED_SIZE,
                     LedgerColumnOptions::default(),
                 )?;
                 BamValidator::create_snapshot(&ledger_path, &config.ledger_tool_build_path)?;

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -804,6 +804,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("advertised_ip")
+            .long("gossip-host")
+            .alias("advertised-ip")
+            .takes_value(true)
+            .hidden(hidden_unless_forced()),
+    )
+    .arg(
         Arg::with_name("rpc_bind_address")
             .long("rpc-bind-address")
             .value_name("HOST")


### PR DESCRIPTION
## Summary
- Create ledgers for non-bootstrap BAM local cluster validators before startup.
- Set a short snapshot interval for local cluster validator processes.
- Restore hidden `--gossip-host` / `--advertised-ip` argument support for validator startup.

## Why
Local cluster startup fail when non-bootstrap validators launch without initialized ledgers, and validator startup rejects the gossip host flag passed by the cluster manager.