### PR TITLE
[master] Allow local cluster startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,6 +1354,7 @@ dependencies = [
  "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-genesis-config",
+ "solana-genesis-utils",
  "solana-keypair",
  "solana-ledger",
  "solana-local-cluster",

--- a/bam-local-cluster/Cargo.toml
+++ b/bam-local-cluster/Cargo.toml
@@ -30,6 +30,7 @@ solana-faucet = { workspace = true }
 solana-feature-gate-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-genesis-config = { workspace = true }
+solana-genesis-utils = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
 solana-local-cluster = { workspace = true }

--- a/bam-local-cluster/src/cluster_manager.rs
+++ b/bam-local-cluster/src/cluster_manager.rs
@@ -10,6 +10,7 @@ use {
     solana_feature_gate_interface as feature,
     solana_fee_calculator::FeeRateGovernor,
     solana_genesis_config::GenesisConfig,
+    solana_genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     solana_keypair::{Keypair, read_keypair_file},
     solana_ledger::{
         blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions,
@@ -110,6 +111,10 @@ impl BamValidator {
         .arg("--full-rpc-api")
         .arg("--enable-rpc-transaction-history")
         .arg("--enable-extended-tx-metadata-storage")
+        // Keep snapshots frequent so restarted or non-bootstrap local validators
+        // can quickly download a usable bootstrap snapshot during short runs.
+        .arg("--snapshot-interval-slots")
+        .arg("25")
         .arg("--expected-shred-version")
         .arg(compute_shred_version(&genesis_config.hash(), None).to_string())
         .arg("--bam-url")
@@ -426,13 +431,21 @@ impl BamLocalCluster {
                 .into());
             }
 
+            if !is_bootstrap {
+                create_new_ledger(
+                    &ledger_path,
+                    &genesis_config_info.genesis_config,
+                    MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+                    LedgerColumnOptions::default(),
+                )?;
+            }
             // Create ledger and snapshot if bootstrap; other validators need to have snapshot
             // to download from the bootstrap validator to start
             if is_bootstrap {
                 create_new_ledger(
                     &ledger_path,
                     &genesis_config_info.genesis_config,
-                    10737418240,
+                    MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
                     LedgerColumnOptions::default(),
                 )?;
                 BamValidator::create_snapshot(&ledger_path, &config.ledger_tool_build_path)?;

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -804,6 +804,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("advertised_ip")
+            .long("gossip-host")
+            .alias("advertised-ip")
+            .takes_value(true)
+            .hidden(hidden_unless_forced()),
+    )
+    .arg(
         Arg::with_name("rpc_bind_address")
             .long("rpc-bind-address")
             .value_name("HOST")


### PR DESCRIPTION
## Summary
- Create ledgers for non-bootstrap BAM local cluster validators before startup.
- Set a short snapshot interval for local cluster validator processes.
- Restore hidden `--gossip-host` / `--advertised-ip` argument support for validator startup.
- Use the standard genesis archive unpack limit when creating local cluster ledgers.

## Why
Local cluster startup can fail when non-bootstrap validators launch without initialized ledgers, and validator startup rejects the gossip host flag passed by the cluster manager.