### PR TITLE
Enable TLS Connections to BAM Node

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -186,7 +186,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
-tonic = { workspace = true }
+tonic = { workspace = true, features = ["tls-ring", "tls-native-roots", "tls-webpki-roots"] }
 trees = { workspace = true }
 wincode = { workspace = true }
 

--- a/core/src/bam_connection.rs
+++ b/core/src/bam_connection.rs
@@ -23,12 +23,12 @@ use {
         time::{Duration, Instant, SystemTime},
     },
     thiserror::Error,
-    tonic::transport::{ClientTlsConfig, Endpoint},
     tokio::{
         sync::mpsc,
         time::{interval, timeout},
     },
     tokio_stream::wrappers::ReceiverStream,
+    tonic::transport::{ClientTlsConfig, Endpoint},
 };
 
 pub struct BamConnection {
@@ -467,11 +467,10 @@ impl BamConnection {
     }
 
     fn endpoint_from_url(url: &str) -> Result<Endpoint, TryInitError> {
-        let mut endpoint = Endpoint::from_shared(url.to_owned())?.tcp_keepalive(Some(Duration::from_secs(60)));
+        let mut endpoint =
+            Endpoint::from_shared(url.to_owned())?.tcp_keepalive(Some(Duration::from_secs(60)));
         if url.starts_with("https") {
-            endpoint = endpoint.tls_config(
-                ClientTlsConfig::new().with_enabled_roots(),
-            )?;
+            endpoint = endpoint.tls_config(ClientTlsConfig::new().with_enabled_roots())?;
         }
         Ok(endpoint)
     }

--- a/core/src/bam_connection.rs
+++ b/core/src/bam_connection.rs
@@ -469,7 +469,9 @@ impl BamConnection {
     fn endpoint_from_url(url: &str) -> Result<Endpoint, TryInitError> {
         let mut endpoint = Endpoint::from_shared(url.to_owned())?.tcp_keepalive(Some(Duration::from_secs(60)));
         if url.starts_with("https") {
-            endpoint = endpoint.tls_config(ClientTlsConfig::new())?;
+            endpoint = endpoint.tls_config(
+                ClientTlsConfig::new().with_enabled_roots(),
+            )?;
         }
         Ok(endpoint)
     }

--- a/core/src/bam_connection.rs
+++ b/core/src/bam_connection.rs
@@ -23,6 +23,7 @@ use {
         time::{Duration, Instant, SystemTime},
     },
     thiserror::Error,
+    tonic::transport::{ClientTlsConfig, Endpoint},
     tokio::{
         sync::mpsc,
         time::{interval, timeout},
@@ -62,7 +63,7 @@ impl BamConnection {
         outbound_receiver: crossbeam_channel::Receiver<BamOutboundMessage>,
     ) -> Result<Self, TryInitError> {
         // Create connection and inbound and outbound streams
-        let backend_endpoint = tonic::transport::Endpoint::from_shared(url.clone())?
+        let backend_endpoint = Self::endpoint_from_url(&url)?
             .connect_timeout(CONNECTION_TIMEOUT)
             .timeout(NETWORK_REQUEST_TIMEOUT);
         let channel = timeout(CONNECTION_TIMEOUT, backend_endpoint.connect()).await??;
@@ -463,6 +464,14 @@ impl BamConnection {
             validator_pubkey: cluster_info.keypair().pubkey().to_string(),
             signature,
         })
+    }
+
+    fn endpoint_from_url(url: &str) -> Result<Endpoint, TryInitError> {
+        let mut endpoint = Endpoint::from_shared(url.to_owned())?.tcp_keepalive(Some(Duration::from_secs(60)));
+        if url.starts_with("https") {
+            endpoint = endpoint.tls_config(ClientTlsConfig::new())?;
+        }
+        Ok(endpoint)
     }
 }
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -10832,6 +10832,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding 2.3.2",
  "pin-project",
+ "rustls-native-certs",
  "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
@@ -10841,6 +10842,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/validator/src/commands/bam/mod.rs
+++ b/validator/src/commands/bam/mod.rs
@@ -31,7 +31,7 @@ const DEFAULT_BAM_HTTPS_PORT: u16 = 50056;
 /// - Missing scheme defaults to HTTP
 ///
 /// HTTPS is now the default scheme and port.
-/// 
+///
 /// # Errors
 /// Returns an error if the URL is invalid or uses an unsupported scheme.
 fn normalize_bam_url(url_str: &str) -> Result<String, BamUrlError> {

--- a/validator/src/commands/bam/mod.rs
+++ b/validator/src/commands/bam/mod.rs
@@ -16,7 +16,7 @@ pub enum BamUrlError {
     PortSetFailed { url: String },
 }
 
-const DEFAULT_BAM_URL_SCHEME: &str = "http";
+const DEFAULT_BAM_URL_SCHEME: &str = "https";
 const DEFAULT_BAM_HTTP_PORT: u16 = 50055;
 const DEFAULT_BAM_HTTPS_PORT: u16 = 50056;
 
@@ -30,6 +30,8 @@ const DEFAULT_BAM_HTTPS_PORT: u16 = 50056;
 /// - HTTPS URLs default to port 50056
 /// - Missing scheme defaults to HTTP
 ///
+/// HTTPS is now the default scheme and port.
+/// 
 /// # Errors
 /// Returns an error if the URL is invalid or uses an unsupported scheme.
 fn normalize_bam_url(url_str: &str) -> Result<String, BamUrlError> {
@@ -183,20 +185,20 @@ mod tests {
     #[test_case("https://bam:8081/badam", "https://bam:8081/badam" ; "https with port and path")]
     #[test_case("https://192.168.100.42:8081/ba/da/m", "https://192.168.100.42:8081/ba/da/m" ; "https ipv4 with port and path")]
     #[test_case("https://[fe80::1]:8081/ba/da/m", "https://[fe80::1]:8081/ba/da/m" ; "https ipv6 with port and path")]
-    // No scheme with port (should default to http)
-    #[test_case("localhost:8080", "http://localhost:8080" ; "localhost with port defaults to http")]
-    #[test_case("your-bam.host.wtf:8080", "http://your-bam.host.wtf:8080" ; "domain with port defaults to http")]
-    #[test_case("oh.bam:8080", "http://oh.bam:8080" ; "short domain with port defaults to http")]
-    #[test_case("bam:8080/badam", "http://bam:8080/badam" ; "host with port and path defaults to http")]
-    #[test_case("192.168.100.42:8080/ba/da/m", "http://192.168.100.42:8080/ba/da/m" ; "ipv4 with port and path defaults to http")]
-    #[test_case("[fe80::1]:8080/ba/da/m", "http://[fe80::1]:8080/ba/da/m" ; "ipv6 with port and path defaults to http")]
-    // No scheme without port (should default to http with default port 50055)
-    #[test_case("localhost", "http://localhost:50055" ; "localhost defaults to http with default port")]
-    #[test_case("your-bam.host.wtf", "http://your-bam.host.wtf:50055" ; "domain defaults to http with default port")]
-    #[test_case("oh.bam", "http://oh.bam:50055" ; "short domain defaults to http with default port")]
-    #[test_case("bam/badam", "http://bam:50055/badam" ; "host with path defaults to http with default port")]
-    #[test_case("192.168.100.42/ba/da/m", "http://192.168.100.42:50055/ba/da/m" ; "ipv4 with path defaults to http with default port")]
-    #[test_case("[fe80::1]/ba/da/m", "http://[fe80::1]:50055/ba/da/m" ; "ipv6 with path defaults to http with default port")]
+    // No scheme with port (should default to https)
+    #[test_case("localhost:8080", "https://localhost:8080" ; "localhost with port defaults to https")]
+    #[test_case("your-bam.host.wtf:8080", "https://your-bam.host.wtf:8080" ; "domain with port defaults to https")]
+    #[test_case("oh.bam:8080", "https://oh.bam:8080" ; "short domain with port defaults to https")]
+    #[test_case("bam:8080/badam", "https://bam:8080/badam" ; "host with port and path defaults to https")]
+    #[test_case("192.168.100.42:8080/ba/da/m", "https://192.168.100.42:8080/ba/da/m" ; "ipv4 with port and path defaults to https")]
+    #[test_case("[fe80::1]:8080/ba/da/m", "https://[fe80::1]:8080/ba/da/m" ; "ipv6 with port and path defaults to https")]
+    // No scheme without port (should default to https with default port 50056)
+    #[test_case("localhost", "https://localhost:50056" ; "localhost defaults to https with default port")]
+    #[test_case("your-bam.host.wtf", "https://your-bam.host.wtf:50056" ; "domain defaults to https with default port")]
+    #[test_case("oh.bam", "https://oh.bam:50056" ; "short domain defaults to https with default port")]
+    #[test_case("bam/badam", "https://bam:50056/badam" ; "host with path defaults to https with default port")]
+    #[test_case("192.168.100.42/ba/da/m", "https://192.168.100.42:50056/ba/da/m" ; "ipv4 with path defaults to https with default port")]
+    #[test_case("[fe80::1]/ba/da/m", "https://[fe80::1]:50056/ba/da/m" ; "ipv6 with path defaults to https with default port")]
     fn test_extract_bam_url_success(input: &str, expected: &str) {
         assert_eq_extract_bam_url(input, expected);
     }

--- a/validator/src/commands/bam/mod.rs
+++ b/validator/src/commands/bam/mod.rs
@@ -16,7 +16,7 @@ pub enum BamUrlError {
     PortSetFailed { url: String },
 }
 
-const DEFAULT_BAM_URL_SCHEME: &str = "https";
+const DEFAULT_BAM_URL_SCHEME: &str = "http";
 const DEFAULT_BAM_HTTP_PORT: u16 = 50055;
 const DEFAULT_BAM_HTTPS_PORT: u16 = 50056;
 
@@ -185,20 +185,20 @@ mod tests {
     #[test_case("https://bam:8081/badam", "https://bam:8081/badam" ; "https with port and path")]
     #[test_case("https://192.168.100.42:8081/ba/da/m", "https://192.168.100.42:8081/ba/da/m" ; "https ipv4 with port and path")]
     #[test_case("https://[fe80::1]:8081/ba/da/m", "https://[fe80::1]:8081/ba/da/m" ; "https ipv6 with port and path")]
-    // No scheme with port (should default to https)
-    #[test_case("localhost:8080", "https://localhost:8080" ; "localhost with port defaults to https")]
-    #[test_case("your-bam.host.wtf:8080", "https://your-bam.host.wtf:8080" ; "domain with port defaults to https")]
-    #[test_case("oh.bam:8080", "https://oh.bam:8080" ; "short domain with port defaults to https")]
-    #[test_case("bam:8080/badam", "https://bam:8080/badam" ; "host with port and path defaults to https")]
-    #[test_case("192.168.100.42:8080/ba/da/m", "https://192.168.100.42:8080/ba/da/m" ; "ipv4 with port and path defaults to https")]
-    #[test_case("[fe80::1]:8080/ba/da/m", "https://[fe80::1]:8080/ba/da/m" ; "ipv6 with port and path defaults to https")]
-    // No scheme without port (should default to https with default port 50056)
-    #[test_case("localhost", "https://localhost:50056" ; "localhost defaults to https with default port")]
-    #[test_case("your-bam.host.wtf", "https://your-bam.host.wtf:50056" ; "domain defaults to https with default port")]
-    #[test_case("oh.bam", "https://oh.bam:50056" ; "short domain defaults to https with default port")]
-    #[test_case("bam/badam", "https://bam:50056/badam" ; "host with path defaults to https with default port")]
-    #[test_case("192.168.100.42/ba/da/m", "https://192.168.100.42:50056/ba/da/m" ; "ipv4 with path defaults to https with default port")]
-    #[test_case("[fe80::1]/ba/da/m", "https://[fe80::1]:50056/ba/da/m" ; "ipv6 with path defaults to https with default port")]
+    // No scheme with port (should default to http)
+    #[test_case("localhost:8080", "http://localhost:8080" ; "localhost with port defaults to http")]
+    #[test_case("your-bam.host.wtf:8080", "http://your-bam.host.wtf:8080" ; "domain with port defaults to http")]
+    #[test_case("oh.bam:8080", "http://oh.bam:8080" ; "short domain with port defaults to http")]
+    #[test_case("bam:8080/badam", "http://bam:8080/badam" ; "host with port and path defaults to http")]
+    #[test_case("192.168.100.42:8080/ba/da/m", "http://192.168.100.42:8080/ba/da/m" ; "ipv4 with port and path defaults to http")]
+    #[test_case("[fe80::1]:8080/ba/da/m", "http://[fe80::1]:8080/ba/da/m" ; "ipv6 with port and path defaults to http")]
+    // No scheme without port (should default to http with default port 50055)
+    #[test_case("localhost", "http://localhost:50055" ; "localhost defaults to http with default port")]
+    #[test_case("your-bam.host.wtf", "http://your-bam.host.wtf:50055" ; "domain defaults to http with default port")]
+    #[test_case("oh.bam", "http://oh.bam:50055" ; "short domain defaults to http with default port")]
+    #[test_case("bam/badam", "http://bam:50055/badam" ; "host with path defaults to http with default port")]
+    #[test_case("192.168.100.42/ba/da/m", "http://192.168.100.42:50055/ba/da/m" ; "ipv4 with path defaults to http with default port")]
+    #[test_case("[fe80::1]/ba/da/m", "http://[fe80::1]:50055/ba/da/m" ; "ipv6 with path defaults to http with default port")]
     fn test_extract_bam_url_success(input: &str, expected: &str) {
         assert_eq_extract_bam_url(input, expected);
     }


### PR DESCRIPTION
This change enables validators to connect to the a BAM node over HTTPS, and changes the default scheme from HTTP -> HTTPS. This is done by borrowing the same technique used to connect to BE/relayer proxies based off of whether the URL contains `https` or `http`. HTTP is still supported but if left unspecified, HTTPS is used. To switch a validator over from HTTP, one can either change their BAM url in their config and restart, or use the `set-bam-config --bam-url` command to change it.