### PR TITLE
[master] Add Multicast root receiver

### DIFF
--- a/core/src/multicast_shred_check_service.rs
+++ b/core/src/multicast_shred_check_service.rs
@@ -21,6 +21,30 @@ pub const MULTICAST_SHRED_ADDR_MAINNET: SocketAddr =
 pub const MULTICAST_SHRED_ADDR_TESTNET: SocketAddr =
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(233, 84, 178, 10)), 7733);
 
+pub const MULTICAST_ROOT_SHRED_ADDR_MAINNET: SocketAddr =
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(233, 84, 178, 16)), 7733);
+
+pub const MULTICAST_ROOT_SHRED_ADDR_TESTNET: SocketAddr =
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(233, 84, 178, 12)), 7733);
+
+/// Returns the `(leader_broadcast, turbine_root)` multicast destinations for a
+/// cluster, or `None` when the cluster has no multicast group.
+pub fn multicast_shred_addresses_for_cluster(
+    cluster_type: ClusterType,
+) -> Option<(SocketAddr, SocketAddr)> {
+    match cluster_type {
+        ClusterType::MainnetBeta => Some((
+            MULTICAST_SHRED_ADDR_MAINNET,
+            MULTICAST_ROOT_SHRED_ADDR_MAINNET,
+        )),
+        ClusterType::Testnet => Some((
+            MULTICAST_SHRED_ADDR_TESTNET,
+            MULTICAST_ROOT_SHRED_ADDR_TESTNET,
+        )),
+        _ => None,
+    }
+}
+
 /// How often to run the multicast check.
 const CHECK_INTERVAL: Duration = Duration::from_secs(60);
 
@@ -44,13 +68,9 @@ impl MulticastShredCheckService {
     pub fn new(
         exit: Arc<AtomicBool>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
-        cluster_type: ClusterType,
+        multicast_addr: SocketAddr,
     ) -> Self {
-        let multicast_addr = match cluster_type {
-            ClusterType::Testnet => MULTICAST_SHRED_ADDR_TESTNET,
-            _ => MULTICAST_SHRED_ADDR_MAINNET,
-        };
-        info!("Starting MulticastShredCheckService for {cluster_type:?} ({multicast_addr})");
+        info!("Starting MulticastShredCheckService for {multicast_addr}");
         let thread_hdl = Builder::new()
             .name("solMcastShrdChk".to_string())
             .spawn(move || {
@@ -192,6 +212,8 @@ mod tests {
         for (multicast_addr, expected) in [
             (MULTICAST_SHRED_ADDR_MAINNET, "233.84.178.1:7733"),
             (MULTICAST_SHRED_ADDR_TESTNET, "233.84.178.10:7733"),
+            (MULTICAST_ROOT_SHRED_ADDR_MAINNET, "233.84.178.16:7733"),
+            (MULTICAST_ROOT_SHRED_ADDR_TESTNET, "233.84.178.12:7733"),
         ] {
             assert_eq!(multicast_addr, expected.parse::<SocketAddr>().unwrap());
         }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -176,6 +176,7 @@ impl Tpu {
         block_engine_config: Arc<ArcSwap<BlockEngineConfig>>,
         relayer_config: Arc<ArcSwap<RelayerConfig>>,
         tip_manager_config: TipManagerConfig,
+        shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         multicast_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
@@ -327,7 +328,6 @@ impl Tpu {
             block_builder_commission: 0,
         }));
 
-        let shredstream_receiver_address = Arc::new(ArcSwap::from_pointee(None)); // set by `[BlockEngineStage::connect_auth_and_stream()]`
         let (unverified_bundle_sender, unverified_bundle_receiver) = bounded(1024);
         let bam_enabled = Arc::new(AtomicU8::new(BamConnectionState::Disconnected as u8));
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -78,7 +78,7 @@ use {
     solana_turbine::{ShredReceiverAddresses, XdpSender, retransmit_stage::RetransmitStage},
     std::{
         collections::HashSet,
-        net::UdpSocket,
+        net::{SocketAddr, UdpSocket},
         num::NonZeroUsize,
         sync::{Arc, RwLock, atomic::AtomicBool},
         thread::{self, JoinHandle},
@@ -238,8 +238,10 @@ impl Tvu {
         slot_status_notifier: Option<SlotStatusNotifier>,
         vote_connection_cache: Arc<ConnectionCache>,
         votor_init: AlpenglowInitializationState,
+        shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        multicast_root_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> Result<Self, String> {
         let migration_status = bank_forks.read().unwrap().migration_status();
 
@@ -397,8 +399,10 @@ impl Tvu {
             slot_status_notifier.clone(),
             tvu_config.turbine_xdp_sender,
             votor_event_sender.clone(),
+            shredstream_receiver_address,
             shred_receiver_addresses,
             bam_shred_receiver_addresses,
+            multicast_root_receiver_address,
         );
 
         let (ancestor_duplicate_slots_sender, ancestor_duplicate_slots_receiver) = unbounded();
@@ -887,8 +891,10 @@ pub mod tests {
                 build_reward_certs_receiver,
                 reward_certs_sender,
             },
+            Arc::new(ArcSwap::from_pointee(None)),
             Arc::new(ArcSwap::from_pointee(ShredReceiverAddresses::new())),
             Arc::default(),
+            Arc::new(ArcSwap::from_pointee(None)),
         )
         .expect("assume success");
         exit.store(true, Ordering::Relaxed);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -17,7 +17,9 @@ use {
             tower_storage::{NullTowerStorage, TowerStorage},
         },
         forwarding_stage::ForwardingClientConfig,
-        multicast_shred_check_service::MulticastShredCheckService,
+        multicast_shred_check_service::{
+            MulticastShredCheckService, multicast_shred_addresses_for_cluster,
+        },
         proxy::{block_engine_stage::BlockEngineConfig, relayer_stage::RelayerConfig},
         repair::{
             self, repair_handler::RepairHandlerType, serve_repair_service::ServeRepairService,
@@ -672,9 +674,12 @@ pub struct Validator {
     transaction_status_service: Option<TransactionStatusService>,
     entry_notifier_service: Option<EntryNotifierService>,
     system_monitor_service: Option<SystemMonitorService>,
-    /// Background watcher that keeps the cluster multicast shred address in sync
-    /// with kernel route availability.
-    multicast_shred_check_service: Option<MulticastShredCheckService>,
+    /// Background watcher that keeps the leader-broadcast multicast shred
+    /// address in sync with kernel route availability.
+    leader_multicast_shred_check_service: Option<MulticastShredCheckService>,
+    /// Background watcher that keeps the turbine-root multicast shred address
+    /// in sync with kernel route availability.
+    root_multicast_shred_check_service: Option<MulticastShredCheckService>,
     sample_performance_service: Option<SamplePerformanceService>,
     stats_reporter_service: StatsReporterService,
     gossip_service: GossipService,
@@ -1529,6 +1534,8 @@ impl Validator {
         );
 
         let bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>> = Arc::default();
+        let shredstream_receiver_address = Arc::new(ArcSwap::from_pointee(None)); // set by BlockEngineStage
+        let multicast_root_receiver_address = Arc::new(ArcSwap::from_pointee(None));
 
         let vote_tracker = Arc::<VoteTracker>::default();
 
@@ -1669,8 +1676,10 @@ impl Validator {
                 build_reward_certs_receiver,
                 reward_certs_sender,
             },
+            shredstream_receiver_address.clone(),
             config.shred_retransmit_receiver_addresses.clone(),
             bam_shred_receiver_addresses.clone(),
+            multicast_root_receiver_address.clone(),
         )
         .map_err(ValidatorError::Other)?;
 
@@ -1749,6 +1758,7 @@ impl Validator {
             config.block_engine_config.clone(),
             config.relayer_config.clone(),
             config.tip_manager_config.clone(),
+            shredstream_receiver_address,
             config.shred_receiver_addresses.clone(),
             bam_shred_receiver_addresses,
             config.multicast_receiver_address.clone(),
@@ -1793,16 +1803,22 @@ impl Validator {
             shred_retransmit_receiver_addresses: config.shred_retransmit_receiver_addresses.clone(),
         });
 
-        let multicast_shred_check_service = (!config.disable_multicast_shred_check
-            && matches!(
-                genesis_config.cluster_type,
-                ClusterType::MainnetBeta | ClusterType::Testnet
-            ))
-        .then(|| {
+        let multicast_shred_addresses = (!config.disable_multicast_shred_check)
+            .then(|| multicast_shred_addresses_for_cluster(genesis_config.cluster_type))
+            .flatten();
+        let leader_multicast_shred_check_service =
+            multicast_shred_addresses.map(|(leader_addr, _)| {
+                MulticastShredCheckService::new(
+                    exit.clone(),
+                    config.multicast_receiver_address.clone(),
+                    leader_addr,
+                )
+            });
+        let root_multicast_shred_check_service = multicast_shred_addresses.map(|(_, root_addr)| {
             MulticastShredCheckService::new(
                 exit.clone(),
-                config.multicast_receiver_address.clone(),
-                genesis_config.cluster_type,
+                multicast_root_receiver_address,
+                root_addr,
             )
         });
 
@@ -1819,7 +1835,8 @@ impl Validator {
             transaction_status_service,
             entry_notifier_service,
             system_monitor_service,
-            multicast_shred_check_service,
+            leader_multicast_shred_check_service,
+            root_multicast_shred_check_service,
             sample_performance_service,
             snapshot_packager_service,
             completed_data_sets_service,
@@ -1968,10 +1985,18 @@ impl Validator {
                 .expect("system_monitor_service");
         }
 
-        if let Some(multicast_shred_check_service) = self.multicast_shred_check_service {
-            multicast_shred_check_service
+        if let Some(leader_multicast_shred_check_service) =
+            self.leader_multicast_shred_check_service
+        {
+            leader_multicast_shred_check_service
                 .join()
-                .expect("multicast_shred_check_service");
+                .expect("leader_multicast_shred_check_service");
+        }
+
+        if let Some(root_multicast_shred_check_service) = self.root_multicast_shred_check_service {
+            root_multicast_shred_check_service
+                .join()
+                .expect("root_multicast_shred_check_service");
         }
 
         if let Some(sample_performance_service) = self.sample_performance_service {

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -538,17 +538,17 @@ pub fn broadcast_shreds(
         .saturating_add(usize::from(shredstream_receiver_address.is_some()))
         .saturating_add(bam_shred_receiver_addresses.len());
     let mut external_addrs = ShredReceiverAddresses::with_capacity(external_addr_capacity);
-    for &addr in shredstream_receiver_address
-        .into_iter()
+    for &addr in bam_shred_receiver_addresses
+        .iter()
         .chain(multicast_receiver_address.iter())
+        .chain(shredstream_receiver_address)
         .chain(
             shred_receiver_addresses
                 .iter()
                 .take(num_shred_receiver_addresses),
         )
-        .chain(bam_shred_receiver_addresses)
     {
-        // Shredstream, ShredReceiverAddresses, and multicast_receiver_address are external
+        // BAM, multicast_receiver_address, Shredstream, and ShredReceiverAddresses are external
         // receivers that may be reachable via a different interface than --bind-address. They are
         // collected separately so they can be sent through the right path:
         //   - UDP path: shred_receiver_socket (0.0.0.0:0), letting the kernel pick the interface.

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -307,6 +307,8 @@ fn retransmit(
     migration_status: &MigrationStatus,
     shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
     bam_shred_receiver_addresses: &ArcSwap<ShredReceiverAddresses>,
+    shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
+    multicast_root_receiver_address: &ArcSwap<Option<SocketAddr>>,
 ) -> Result<(), ()> {
     // Try to receive shreds from the channel without blocking. If the channel
     // is empty precompute turbine trees speculatively. If no cache updates are
@@ -369,6 +371,8 @@ fn retransmit(
         .collect();
     let shred_receiver_addresses_local = shred_receiver_addresses.load();
     let bam_shred_receiver_addresses_local = bam_shred_receiver_addresses.load();
+    let shredstream_receiver_address_local = shredstream_receiver_address.load();
+    let multicast_root_receiver_address_local = multicast_root_receiver_address.load();
     let my_pubkey = cluster_info.id();
     let mut leader_schedule_epoch = None;
     let mut leader_schedule = None;
@@ -443,6 +447,8 @@ fn retransmit(
             stats,
             &shred_receiver_addresses_local,
             &bam_shred_receiver_addresses_local,
+            &shredstream_receiver_address_local,
+            &multicast_root_receiver_address_local,
         )
     };
 
@@ -516,6 +522,8 @@ fn retransmit_shred(
     stats: &RetransmitStats,
     shred_receiver_addresses: &ShredReceiverAddresses,
     bam_shred_receiver_addresses: &ShredReceiverAddresses,
+    shredstream_receiver_address: &Option<SocketAddr>,
+    multicast_root_receiver_address: &Option<SocketAddr>,
 ) -> Option<RetransmitShredOutput> {
     let key = shred::layout::get_shred_id(shred.as_ref())?;
     if key.slot() < root_bank.slot()
@@ -544,21 +552,31 @@ fn retransmit_shred(
     let num_shred_receiver_addresses = shred_receiver_addresses
         .len()
         .min(MAX_SHRED_RECEIVER_ADDRESSES);
-    let external_addr_capacity =
-        num_shred_receiver_addresses.saturating_add(if include_bam_shred_receivers {
+    let external_addr_capacity = num_shred_receiver_addresses
+        .saturating_add(if include_bam_shred_receivers {
             bam_shred_receiver_addresses.len()
         } else {
             0
-        });
+        })
+        .saturating_add(usize::from(root_distance == 0) * 2);
     let mut external_addrs = ShredReceiverAddresses::with_capacity(external_addr_capacity);
-    for &addr in shred_receiver_addresses
-        .iter()
-        .take(num_shred_receiver_addresses)
+    let root_external_addrs = if root_distance == 0 {
+        [
+            multicast_root_receiver_address.as_ref(),
+            shredstream_receiver_address.as_ref(),
+        ]
+    } else {
+        [None, None]
+    };
+    for &addr in include_bam_shred_receivers
+        .then_some(bam_shred_receiver_addresses)
+        .into_iter()
+        .flatten()
+        .chain(root_external_addrs.into_iter().flatten())
         .chain(
-            include_bam_shred_receivers
-                .then_some(bam_shred_receiver_addresses)
-                .into_iter()
-                .flatten(),
+            shred_receiver_addresses
+                .iter()
+                .take(num_shred_receiver_addresses),
         )
     {
         if !turbine_addrs.contains(&addr) && !external_addrs.contains(&addr) {
@@ -773,8 +791,10 @@ impl RetransmitStage {
         slot_status_notifier: Option<SlotStatusNotifier>,
         xdp_sender: Option<XdpSender>,
         votor_event_sender: Sender<VotorEvent>,
+        shredstream_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
         shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
         bam_shred_receiver_addresses: Arc<ArcSwap<ShredReceiverAddresses>>,
+        multicast_root_receiver_address: Arc<ArcSwap<Option<SocketAddr>>>,
     ) -> Self {
         let migration_status = bank_forks.read().unwrap().migration_status();
         let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
@@ -798,10 +818,16 @@ impl RetransmitStage {
         let retransmit_thread_handle = Builder::new()
             .name("solRetransmittr".to_string())
             .spawn({
-                let external_sender_socket = Arc::new(
-                    bind_to_unspecified()
-                        .expect("bind retransmit external_sender_socket 0.0.0.0:0"),
-                );
+                let external_sender_socket = Arc::new({
+                    let socket = bind_to_unspecified()
+                        .expect("bind retransmit external_sender_socket 0.0.0.0:0");
+                    if let Err(err) = socket.set_multicast_ttl_v4(64) {
+                        warn!(
+                            "retransmit external_sender_socket: failed to set multicast TTL: {err}"
+                        );
+                    }
+                    socket
+                });
                 move || {
                     let mut shred_buf = Vec::with_capacity(RETRANSMIT_BATCH_SIZE);
                     while retransmit(
@@ -825,6 +851,8 @@ impl RetransmitStage {
                         &migration_status,
                         &shred_receiver_addresses,
                         &bam_shred_receiver_addresses,
+                        &shredstream_receiver_address,
+                        &multicast_root_receiver_address,
                     )
                     .is_ok()
                     {}
@@ -1105,10 +1133,14 @@ mod tests {
         let duplicate_configured_receiver = bind_receiver();
         let configured_receiver = bind_receiver();
         let bam_receiver = bind_receiver();
+        let shredstream_receiver = bind_receiver();
+        let multicast_receiver = bind_receiver();
         let turbine_addr = turbine_receiver.local_addr().unwrap();
         let duplicate_configured_addr = duplicate_configured_receiver.local_addr().unwrap();
         let configured_addr = configured_receiver.local_addr().unwrap();
         let bam_addr = bam_receiver.local_addr().unwrap();
+        let shredstream_addr = shredstream_receiver.local_addr().unwrap();
+        let multicast_addr = multicast_receiver.local_addr().unwrap();
         let retransmit_socket = bind_to_localhost_unique().unwrap();
         let external_sender_socket = bind_to_localhost_unique().unwrap();
 
@@ -1150,40 +1182,49 @@ mod tests {
                 .into_iter()
                 .collect();
 
-        let retransmit_once = |include_bam_shred_receivers| {
-            let mut cache = HashMap::new();
-            cache.insert(
-                key.slot(),
-                (
-                    Pubkey::new_unique(),
-                    cluster_nodes.clone(),
-                    include_bam_shred_receivers,
-                ),
-            );
-            let mut addr_cache = AddrCache::with_capacity(1);
-            addr_cache.put(
-                &key,
-                (0, Box::new([turbine_addr, duplicate_configured_addr])),
-            );
-            let mut rng = ChaChaRng::from_seed([0xa5; 32]);
-            let shred_deduper = ShredDeduper::<2>::new(&mut rng, /*num_bits:*/ 640_007);
-            retransmit_shred(
-                shred.clone(),
-                &root_bank,
-                &shred_deduper,
-                &cache,
-                &addr_cache,
-                &SocketAddrSpace::Unspecified,
-                RetransmitSocket::Socket(&retransmit_socket),
-                &external_sender_socket,
-                &RetransmitStats::new(Instant::now()),
-                &shred_receiver_addresses,
-                &bam_shred_receiver_addresses,
-            )
-            .unwrap()
-        };
+        let retransmit_once =
+            |include_bam_shred_receivers,
+             root_distance,
+             shredstream_receiver_address: Option<SocketAddr>,
+             multicast_root_receiver_address: Option<SocketAddr>| {
+                let mut cache = HashMap::new();
+                cache.insert(
+                    key.slot(),
+                    (
+                        Pubkey::new_unique(),
+                        cluster_nodes.clone(),
+                        include_bam_shred_receivers,
+                    ),
+                );
+                let mut addr_cache = AddrCache::with_capacity(1);
+                addr_cache.put(
+                    &key,
+                    (
+                        root_distance,
+                        Box::new([turbine_addr, duplicate_configured_addr]),
+                    ),
+                );
+                let mut rng = ChaChaRng::from_seed([0xa5; 32]);
+                let shred_deduper = ShredDeduper::<2>::new(&mut rng, /*num_bits:*/ 640_007);
+                retransmit_shred(
+                    shred.clone(),
+                    &root_bank,
+                    &shred_deduper,
+                    &cache,
+                    &addr_cache,
+                    &SocketAddrSpace::Unspecified,
+                    RetransmitSocket::Socket(&retransmit_socket),
+                    &external_sender_socket,
+                    &RetransmitStats::new(Instant::now()),
+                    &shred_receiver_addresses,
+                    &bam_shred_receiver_addresses,
+                    &shredstream_receiver_address,
+                    &multicast_root_receiver_address,
+                )
+                .unwrap()
+            };
 
-        let out = retransmit_once(false);
+        let out = retransmit_once(false, 0, None, None);
         assert_eq!(out.num_nodes, 2);
         assert!(recv_one(&turbine_receiver));
         assert!(recv_one(&duplicate_configured_receiver));
@@ -1193,7 +1234,44 @@ mod tests {
         assert_no_packet(&configured_receiver);
         assert_no_packet(&bam_receiver);
 
-        let out = retransmit_once(true);
+        let out = retransmit_once(true, 0, None, None);
+        assert_eq!(out.num_nodes, 2);
+        assert!(recv_one(&turbine_receiver));
+        assert!(recv_one(&duplicate_configured_receiver));
+        assert!(recv_one(&configured_receiver));
+        assert!(recv_one(&bam_receiver));
+        assert_no_packet(&turbine_receiver);
+        assert_no_packet(&duplicate_configured_receiver);
+        assert_no_packet(&configured_receiver);
+        assert_no_packet(&bam_receiver);
+
+        let out = retransmit_once(false, 0, Some(shredstream_addr), Some(multicast_addr));
+        assert_eq!(out.num_nodes, 2);
+        assert!(recv_one(&turbine_receiver));
+        assert!(recv_one(&duplicate_configured_receiver));
+        assert!(recv_one(&configured_receiver));
+        assert!(recv_one(&shredstream_receiver));
+        assert!(recv_one(&multicast_receiver));
+        assert_no_packet(&turbine_receiver);
+        assert_no_packet(&duplicate_configured_receiver);
+        assert_no_packet(&configured_receiver);
+        assert_no_packet(&bam_receiver);
+        assert_no_packet(&shredstream_receiver);
+        assert_no_packet(&multicast_receiver);
+
+        let out = retransmit_once(false, 1, Some(shredstream_addr), Some(multicast_addr));
+        assert_eq!(out.num_nodes, 2);
+        assert!(recv_one(&turbine_receiver));
+        assert!(recv_one(&duplicate_configured_receiver));
+        assert!(recv_one(&configured_receiver));
+        assert_no_packet(&turbine_receiver);
+        assert_no_packet(&duplicate_configured_receiver);
+        assert_no_packet(&configured_receiver);
+        assert_no_packet(&bam_receiver);
+        assert_no_packet(&shredstream_receiver);
+        assert_no_packet(&multicast_receiver);
+
+        let out = retransmit_once(true, 0, Some(turbine_addr), Some(configured_addr));
         assert_eq!(out.num_nodes, 2);
         assert!(recv_one(&turbine_receiver));
         assert!(recv_one(&duplicate_configured_receiver));


### PR DESCRIPTION
Add root shred forwarding to multicast.

Verified that root turbine shreds are forwarded to:
- root multicast: `233.84.178.16:7733`
- Shredstream autoconfig: `64.130.51.60:1002`


## Verification

The running validator command line included XDP zero-copy retransmit:

```text
--experimental-retransmit-xdp-cpu-cores 1
--experimental-retransmit-xdp-interface eno12399np0
--experimental-retransmit-xdp-zero-copy
--block-engine-url https://ny.mainnet.block-engine.jito.wtf
--bam-url http://ny.mainnet.bam.jito.wtf
--shred-receiver-address 141.98.216.96:1002
--shred-retransmit-receiver-address 141.98.216.96:1002
```

### Multicast Services and Routes

Both multicast destinations were enabled:

```text
2026-06-09T21:59:57.968874411Z INFO  solana_core::multicast_shred_check_service] Set multicast receiver state for 233.84.178.16:7733: enabled
2026-06-09T21:59:57.969180351Z INFO  solana_core::multicast_shred_check_service] Set multicast receiver state for 233.84.178.1:7733: enabled
2026-06-09T21:59:57.969275861Z INFO  solana_metrics::metrics] datapoint: multicast_shred_check status="enabled" address="233.84.178.16:7733"
2026-06-09T21:59:57.969278341Z INFO  solana_metrics::metrics] datapoint: multicast_shred_check status="enabled" address="233.84.178.1:7733"
```

Kernel routes for DoubleZero multicast were present:

```text
route get 233.84.178.16:
multicast 233.84.178.16 via 169.254.8.6 dev doublezero1 src 148.51.122.229 rt_offload_failed uid 1001
    cache <mc> expires 569sec mtu 1476

route exact 233.84.178.16/32:
233.84.178.16 via 169.254.8.6 dev doublezero1 proto static src 148.51.122.229
```

DoubleZero interface details:

```text
428: doublezero1@NONE: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1476 qdisc noqueue state UNKNOWN mode DEFAULT group default
    link/gre 64.130.59.234 peer 141.98.216.72
    gre remote 141.98.216.72 local 64.130.59.234 ttl 64 nopmtudisc
```

### Packet-Level Verification

Example decoded route-check probes from the pcap:

```text
64.130.59.234 > 141.98.216.72: GREv0, length 36:
  148.51.122.229.38873 > 233.84.178.1.5765: UDP, length 4

64.130.59.234 > 141.98.216.72: GREv0, length 36:
  148.51.122.229.38873 > 233.84.178.16.5765: UDP, length 4
```

Focused trace output over 10s:

```text
Tracing focused AF_XDP root/autoconfig/configured destinations for 10s...
Attaching 2 probes...
@counts[7733, 280122601]: 24
@counts[1002, 1010008640]: 24
@counts[1002, 1624793741]: 41378
```

### Retransmit Metrics During Capture

```text
datapoint: retransmit-stage,is_xdp=true total_batches=490i num_nodes=51638i num_addrs_failed=0i num_shreds_dropped_xdp_full=0i num_loopback_errs=0i num_shreds=11867i unknown_shred_slot_leader=0i
```