### PR TITLE
[v4.0] fix rustfmt in validator.rs multicast root receiver

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1870,14 +1870,13 @@ impl Validator {
                     leader_addr,
                 )
             });
-        let root_multicast_shred_check_service =
-            multicast_shred_addresses.map(|(_, root_addr)| {
-                MulticastShredCheckService::new(
-                    exit.clone(),
-                    multicast_root_receiver_address,
-                    root_addr,
-                )
-            });
+        let root_multicast_shred_check_service = multicast_shred_addresses.map(|(_, root_addr)| {
+            MulticastShredCheckService::new(
+                exit.clone(),
+                multicast_root_receiver_address,
+                root_addr,
+            )
+        });
 
         Ok(Self {
             log_config: config.log_config.clone(),


### PR DESCRIPTION
cargo +nightly fmt collapsed the `let` binding onto one line; build 4887 failed the `fmt --check` gate. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)