### PR TITLE
Open unpack directories on Windows

### DIFF
--- a/snapshots/src/hardened_unpack.rs
+++ b/snapshots/src/hardened_unpack.rs
@@ -230,6 +230,27 @@ fn should_fallback_to_tar_unpack<R: io::Read>(entry: &tar::Entry<'_, R>) -> bool
     ) || entry.header().as_ustar().is_none() && entry.path_bytes().ends_with(b"/")
 }
 
+fn open_dir(path: &Path) -> io::Result<File> {
+    open_dir_impl(path)
+}
+
+#[cfg(not(windows))]
+fn open_dir_impl(path: &Path) -> io::Result<File> {
+    File::open(path)
+}
+
+#[cfg(windows)]
+fn open_dir_impl(path: &Path) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x02000000;
+
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)
+}
+
 // return Err on file system error
 // return Some((path, open_dir)) if path is good
 // return None if we should skip this file
@@ -282,7 +303,7 @@ fn sanitize_path_and_open_dir(
             // ignore return value here
             validate_inside_dst(dst, parent)?;
 
-            let opened_dir = Arc::new(File::open(parent)?);
+            let opened_dir = Arc::new(open_dir(parent)?);
             open_dirs.insert(insert_at, (parent.to_path_buf(), opened_dir.clone()));
             opened_dir
         }
@@ -462,6 +483,14 @@ mod tests {
     };
 
     const MAX_GENESIS_SIZE_FOR_TESTS: u64 = 1024;
+
+    #[test]
+    fn test_open_dir_opens_directory() -> io::Result<()> {
+        let temp_dir = tempfile::TempDir::new()?;
+        let dir = open_dir(temp_dir.path())?;
+        assert!(dir.metadata()?.is_dir());
+        Ok(())
+    }
 
     #[test]
     fn test_archive_is_valid_entry() {


### PR DESCRIPTION
#### Problem

On native Windows, genesis archive verification can fail while unpacking with:

```text
Error checking to unpack genesis archive: IO error: Access is denied. (os error 5)
```

The hardened unpacker opens the destination parent directory with `File::open(parent)`. Windows requires directory handles to be opened with `FILE_FLAG_BACKUP_SEMANTICS`, so the normal file-open path can fail before the archive contents are verified.

#### Summary of Changes

- Add a small `open_dir()` helper that preserves the current non-Windows behavior.
- Open unpack destination directories with `FILE_FLAG_BACKUP_SEMANTICS` on Windows.
- Add a focused test that verifies the helper can open a directory handle.

#### Tests

- `cargo +nightly fmt --check -- snapshots/src/hardened_unpack.rs`
- `cargo test -p agave-snapshots --features agave-unstable-api test_open_dir_opens_directory -- --nocapture`
- `cargo test -p agave-snapshots --features agave-unstable-api unpack_genesis -- --nocapture`
- `cargo test -p solana-rpc-test test_simulate_bundle --test rpc -- --nocapture`
- `cargo test -p solana-runtime test_simulate_transactions_unchecked_with_pre_accounts -- --nocapture`