### PR TITLE
feat: support txv1 transactions in bundle and BAM ingest

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -41,7 +41,7 @@ use {
     solana_accounts_db::account_locks::validate_account_locks,
     solana_clock::{MAX_PROCESSING_AGE, Slot},
     solana_measure::{measure::Measure, measure_us},
-    solana_packet::{Meta, PACKET_DATA_SIZE, PacketFlags},
+    solana_packet::{Meta, PacketFlags},
     solana_perf::{
         packet::{BytesPacket, BytesPacketBatch},
         sigverify::ed25519_verify,
@@ -649,6 +649,29 @@ impl BamReceiveAndBuffer {
         stats
     }
 
+    fn proto_packet_to_packet(from_packet: Packet) -> BytesPacket {
+        let Packet { data, meta } = from_packet;
+        let data_len = data.len();
+        if data_len > solana_message::v1::MAX_TRANSACTION_SIZE {
+            let mut p = BytesPacket::new(Bytes::new(), Meta::default());
+            p.meta_mut().set_discard(true);
+            return p;
+        }
+
+        let mut to_packet = BytesPacket::new(data.into(), Meta::default());
+        to_packet.meta_mut().size = data_len;
+
+        if let Some(meta) = meta
+            && meta.flags.is_some_and(|flags| flags.simple_vote_tx)
+        {
+            to_packet
+                .meta_mut()
+                .flags
+                .insert(PacketFlags::SIMPLE_VOTE_TX);
+        }
+        to_packet
+    }
+
     fn batch_verify(
         sigverify_thread_pool: &rayon::ThreadPool,
         atomic_txn_batches: &mut [MultipleAtomicTxnBatch],
@@ -672,28 +695,7 @@ impl BamReceiveAndBuffer {
                 let solana_packet_batch: Vec<_> = atomic_txn_batch
                     .packets
                     .drain(..)
-                    .map(|from_packet| {
-                        let Packet { data, meta } = from_packet;
-                        let data_len = data.len();
-                        if data_len > PACKET_DATA_SIZE {
-                            let mut to_packet = BytesPacket::new(Bytes::new(), Meta::default());
-                            to_packet.meta_mut().set_discard(true);
-                            return to_packet;
-                        }
-
-                        let mut to_packet = BytesPacket::new(data, Meta::default());
-                        to_packet.meta_mut().size = data_len;
-
-                        if let Some(meta) = meta
-                            && meta.flags.is_some_and(|flags| flags.simple_vote_tx)
-                        {
-                            to_packet
-                                .meta_mut()
-                                .flags
-                                .insert(PacketFlags::SIMPLE_VOTE_TX);
-                        }
-                        to_packet
-                    })
+                    .map(Self::proto_packet_to_packet)
                     .collect();
                 packet_count += solana_packet_batch.len();
                 packet_batches.push(solana_perf::packet::PacketBatch::Bytes(
@@ -1315,7 +1317,7 @@ mod tests {
         let batch = AtomicTxnBatch {
             seq_id: 1,
             packets: vec![Packet {
-                data: vec![0; PACKET_DATA_SIZE + 1].into(),
+                data: vec![0; solana_message::v1::MAX_TRANSACTION_SIZE + 1].into(),
                 meta: None,
             }],
             max_schedule_slot: Slot::MAX,
@@ -1621,5 +1623,84 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert!(results[0].is_err());
+    }
+
+    #[test]
+    fn test_proto_packet_to_packet_keeps_txv1_sized() {
+        let p = BamReceiveAndBuffer::proto_packet_to_packet(Packet {
+            data: vec![0u8; 2000].into(),
+            meta: None,
+        });
+        assert!(!p.meta().discard(), "txv1-sized packet must not be discarded at copy");
+        assert_eq!(p.meta().size, 2000);
+    }
+
+    #[test]
+    fn test_proto_packet_to_packet_discards_over_txv1_max() {
+        let p = BamReceiveAndBuffer::proto_packet_to_packet(Packet {
+            data: vec![0u8; solana_message::v1::MAX_TRANSACTION_SIZE + 1].into(),
+            meta: None,
+        });
+        assert!(p.meta().discard(), "packet over txv1 max must be discarded");
+    }
+
+    #[test]
+    fn test_txv1_transaction_over_1232_survives_ingest() {
+        use {
+            solana_message::{VersionedMessage, v1},
+            solana_system_interface::instruction as system_instruction,
+        };
+
+        let (bank_forks, mint_keypair) = test_bank_forks();
+        let payer_pubkey = mint_keypair.pubkey();
+        let recent_blockhash = bank_forks.read().unwrap().root_bank().last_blockhash();
+
+        // Pack enough transfer instructions to push the serialized tx over 1232 bytes.
+        // Each extra account key adds ~32 bytes to the message; ~20 instructions clears
+        // PACKET_DATA_SIZE while staying well under MAX_TRANSACTION_SIZE.
+        let serialized = (1usize..=64)
+            .map(|n| {
+                let ixs: Vec<_> = (0..n)
+                    .map(|_| {
+                        system_instruction::transfer(&payer_pubkey, &Pubkey::new_unique(), 1)
+                    })
+                    .collect();
+                let message =
+                    v1::Message::try_compile(&payer_pubkey, &ixs, recent_blockhash).unwrap();
+                let tx =
+                    VersionedTransaction::try_new(VersionedMessage::V1(message), &[&mint_keypair])
+                        .unwrap();
+                bincode::serialize(&tx).unwrap()
+            })
+            .find(|bytes| {
+                bytes.len() > solana_packet::PACKET_DATA_SIZE
+                    && bytes.len() <= solana_message::v1::MAX_TRANSACTION_SIZE
+            })
+            .expect("a txv1 tx between PACKET_DATA_SIZE and MAX_TRANSACTION_SIZE");
+
+        assert!(serialized.len() > solana_packet::PACKET_DATA_SIZE);
+        assert!(serialized.len() <= solana_message::v1::MAX_TRANSACTION_SIZE);
+
+        let batch = AtomicTxnBatch {
+            seq_id: 1,
+            packets: vec![Packet {
+                data: serialized.into(),
+                meta: None,
+            }],
+            max_schedule_slot: Slot::MAX,
+        };
+
+        let mut stats = BamReceiveAndBufferMetrics::default();
+        let (results, _batch_stats) = run_batch_verify(vec![batch], Slot::MAX, &mut stats);
+
+        assert_eq!(results.len(), 1);
+        // batch_verify calls ed25519_verify with enable_tx_v1=false, so a real V1 tx is
+        // rejected at sigverify and surfaces as DeserializationError. That's fine here.
+        // What matters is the packet reaches sigverify at full length, not truncated at copy.
+        assert!(
+            results[0].is_ok() || matches!(&results[0], Err((Reason::DeserializationError(_), _))),
+            "txv1 tx must reach sigverify at full length, got unexpected result: {:?}",
+            results[0]
+        );
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -185,15 +185,18 @@ impl BamReceiveAndBuffer {
                 }
             }
 
-            let current_slot = shared_leader_state
+            let working_bank = shared_leader_state
                 .as_ref()
-                .and_then(|leader_state| leader_state.load().working_bank().map(|b| b.slot()))
-                .unwrap_or_else(|| bank_forks.read().unwrap().working_bank().slot());
+                .and_then(|leader_state| leader_state.load().working_bank())
+                .unwrap_or_else(|| bank_forks.read().unwrap().working_bank());
+            let current_slot = working_bank.slot();
+            let enable_tx_v1 = working_bank.feature_set.snapshot().enable_tx_v1;
 
             let (deserialize_stats, duration_us) = measure_us!(Self::batch_verify(
                 &sigverify_thread_pool,
                 &mut recv_buffer,
                 current_slot,
+                enable_tx_v1,
                 &mut metrics,
                 &mut prevalidated,
                 &mut packet_batches,
@@ -676,6 +679,7 @@ impl BamReceiveAndBuffer {
         sigverify_thread_pool: &rayon::ThreadPool,
         atomic_txn_batches: &mut [MultipleAtomicTxnBatch],
         current_slot: Slot,
+        enable_tx_v1: bool,
         metrics: &mut BamReceiveAndBufferMetrics,
         prevalidated: &mut Vec<PrevalidationResult>,
         packet_batches: &mut Vec<solana_perf::packet::PacketBatch>,
@@ -709,7 +713,7 @@ impl BamReceiveAndBuffer {
             packet_batches,
             false,
             packet_count,
-            false,
+            enable_tx_v1,
         );
         verify_packet_batch_time_us.stop();
 
@@ -1163,6 +1167,7 @@ mod tests {
             &thread_pool,
             &mut batches,
             current_slot,
+            false, // enable_tx_v1: tests run without the feature active
             metrics,
             &mut prevalidated,
             &mut packet_batches,
@@ -1670,7 +1675,7 @@ mod tests {
                 let tx =
                     VersionedTransaction::try_new(VersionedMessage::V1(message), &[&mint_keypair])
                         .unwrap();
-                bincode::serialize(&tx).unwrap()
+                wincode::serialize(&tx).unwrap()
             })
             .find(|bytes| {
                 bytes.len() > solana_packet::PACKET_DATA_SIZE
@@ -1694,9 +1699,9 @@ mod tests {
         let (results, _batch_stats) = run_batch_verify(vec![batch], Slot::MAX, &mut stats);
 
         assert_eq!(results.len(), 1);
-        // batch_verify calls ed25519_verify with enable_tx_v1=false, so a real V1 tx is
-        // rejected at sigverify and surfaces as DeserializationError. That's fine here.
-        // What matters is the packet reaches sigverify at full length, not truncated at copy.
+        // run_batch_verify passes enable_tx_v1=false (feature not active in tests), so a real
+        // V1 tx is rejected at sigverify and surfaces as DeserializationError. That's expected.
+        // What matters is the packet reaches sigverify at full length, not discarded at copy.
         assert!(
             results[0].is_ok() || matches!(&results[0], Err((Reason::DeserializationError(_), _))),
             "txv1 tx must reach sigverify at full length, got unexpected result: {:?}",

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -187,7 +187,7 @@ impl BamReceiveAndBuffer {
 
             let working_bank = shared_leader_state
                 .as_ref()
-                .and_then(|leader_state| leader_state.load().working_bank())
+                .and_then(|leader_state| leader_state.load().working_bank().cloned())
                 .unwrap_or_else(|| bank_forks.read().unwrap().working_bank());
             let current_slot = working_bank.slot();
             let enable_tx_v1 = working_bank.feature_set.snapshot().enable_tx_v1;

--- a/core/src/bundle_sigverify_stage.rs
+++ b/core/src/bundle_sigverify_stage.rs
@@ -3,6 +3,7 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     rayon::ThreadPool,
     solana_perf::sigverify::ed25519_verify,
+    solana_runtime::bank_forks::SharableBanks,
     std::{
         sync::{
             Arc,
@@ -23,8 +24,11 @@ impl BundleSigverifyStage {
         receiver: Receiver<Vec<PacketBundle>>,
         sender: Sender<VerifiedPacketBundle>,
         exit: Arc<AtomicBool>,
+        sharable_banks: SharableBanks,
     ) -> Self {
-        let thread = spawn(move || Self::sigverify_service(thread_pool, receiver, sender, exit));
+        let thread = spawn(move || {
+            Self::sigverify_service(thread_pool, receiver, sender, exit, sharable_banks)
+        });
         Self { thread }
     }
 
@@ -37,6 +41,7 @@ impl BundleSigverifyStage {
         receiver: Receiver<Vec<PacketBundle>>,
         sender: Sender<VerifiedPacketBundle>,
         exit: Arc<AtomicBool>,
+        sharable_banks: SharableBanks,
     ) {
         let mut workspace = Vec::with_capacity(100);
 
@@ -92,7 +97,12 @@ impl BundleSigverifyStage {
             num_bundles_received += workspace.len();
             num_packets_received += packet_count;
 
-            ed25519_verify(&thread_pool, &mut workspace, false, packet_count, false);
+            let enable_tx_v1 = sharable_banks
+                .working()
+                .feature_set
+                .snapshot()
+                .enable_tx_v1;
+            ed25519_verify(&thread_pool, &mut workspace, false, packet_count, enable_tx_v1);
 
             for bundle in workspace.drain(..) {
                 let num_packets_failed_sigverify_in_bundle = bundle
@@ -152,13 +162,21 @@ mod tests {
     use {
         super::*,
         crossbeam_channel::bounded,
+        solana_genesis_config::create_genesis_config,
         solana_keypair::Signature,
         solana_perf::{
             packet::{BytesPacket, PacketBatch},
             test_tx::test_tx,
         },
+        solana_runtime::bank::Bank,
         solana_transaction::Transaction,
     };
+
+    fn test_sharable_banks() -> SharableBanks {
+        let (_bank, bank_forks) =
+            Bank::new_with_bank_forks_for_tests(&create_genesis_config(1).genesis_config);
+        bank_forks.read().unwrap().sharable_banks()
+    }
 
     #[test]
     fn test_bundle_sigverify_stage_exit() {
@@ -171,6 +189,7 @@ mod tests {
             unverified_receiver,
             verified_sender,
             exit.clone(),
+            test_sharable_banks(),
         );
         exit.store(true, Ordering::Relaxed);
         stage.join().unwrap();
@@ -214,6 +233,7 @@ mod tests {
             unverified_receiver,
             verified_sender,
             exit.clone(),
+            test_sharable_banks(),
         );
 
         let verified_bundle_1 = verified_receiver.recv().unwrap();
@@ -277,6 +297,7 @@ mod tests {
             unverified_receiver,
             verified_sender,
             exit.clone(),
+            test_sharable_banks(),
         );
 
         assert_eq!(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -77,7 +77,7 @@ extern crate solana_frozen_abi_macro;
 extern crate assert_matches;
 
 use {
-    solana_packet::{Meta, PACKET_DATA_SIZE, PacketFlags},
+    solana_packet::{Meta, PacketFlags},
     solana_perf::packet::BytesPacket,
     std::net::{IpAddr, Ipv4Addr},
 };
@@ -87,7 +87,7 @@ const UNKNOWN_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
 // NOTE: last profiled at around 180ns
 pub fn proto_packet_to_packet(p: jito_protos::proto::packet::Packet) -> BytesPacket {
     let mut data = p.data;
-    data.truncate(PACKET_DATA_SIZE);
+    data.truncate(solana_message::v1::MAX_TRANSACTION_SIZE);
     let mut packet = BytesPacket::new(data, Meta::default());
 
     if let Some(meta) = p.meta {
@@ -113,4 +113,47 @@ pub fn proto_packet_to_packet(p: jito_protos::proto::packet::Packet) -> BytesPac
         }
     }
     packet
+}
+
+#[cfg(test)]
+mod proto_packet_to_packet_tests {
+    use {
+        super::*,
+        jito_protos::proto::packet::{Meta as ProtoMeta, Packet as ProtoPacket},
+    };
+
+    fn proto_with_len(len: usize) -> ProtoPacket {
+        ProtoPacket {
+            data: vec![7u8; len],
+            meta: Some(ProtoMeta {
+                size: len as u64,
+                addr: "0.0.0.0".to_string(),
+                port: 0,
+                flags: None,
+                sender_stake: 0,
+            }),
+        }
+    }
+
+    #[test]
+    fn txv1_sized_packet_is_not_truncated() {
+        // 2000 bytes: bigger than the old PACKET_DATA_SIZE (1232), within txv1 max (4096)
+        let packet = proto_packet_to_packet(proto_with_len(2000));
+        assert_eq!(packet.data(..).unwrap().len(), 2000);
+    }
+
+    #[test]
+    fn packet_over_txv1_max_is_capped_at_max_transaction_size() {
+        let packet = proto_packet_to_packet(proto_with_len(10_000));
+        assert_eq!(
+            packet.data(..).unwrap().len(),
+            solana_message::v1::MAX_TRANSACTION_SIZE
+        );
+    }
+
+    #[test]
+    fn legacy_sized_packet_is_unchanged() {
+        let packet = proto_packet_to_packet(proto_with_len(1000));
+        assert_eq!(packet.data(..).unwrap().len(), 1000);
+    }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -77,6 +77,7 @@ extern crate solana_frozen_abi_macro;
 extern crate assert_matches;
 
 use {
+    bytes::Bytes,
     solana_packet::{Meta, PacketFlags},
     solana_perf::packet::BytesPacket,
     std::net::{IpAddr, Ipv4Addr},
@@ -86,9 +87,12 @@ const UNKNOWN_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
 
 // NOTE: last profiled at around 180ns
 pub fn proto_packet_to_packet(p: jito_protos::proto::packet::Packet) -> BytesPacket {
-    let mut data = p.data;
-    data.truncate(solana_message::v1::MAX_TRANSACTION_SIZE);
-    let mut packet = BytesPacket::new(data, Meta::default());
+    if p.data.len() > solana_message::v1::MAX_TRANSACTION_SIZE {
+        let mut packet = BytesPacket::new(Bytes::new(), Meta::default());
+        packet.meta_mut().set_discard(true);
+        return packet;
+    }
+    let mut packet = BytesPacket::new(p.data, Meta::default());
 
     if let Some(meta) = p.meta {
         packet.meta_mut().size = meta.size as usize;
@@ -143,12 +147,9 @@ mod proto_packet_to_packet_tests {
     }
 
     #[test]
-    fn packet_over_txv1_max_is_capped_at_max_transaction_size() {
+    fn packet_over_txv1_max_is_discarded() {
         let packet = proto_packet_to_packet(proto_with_len(10_000));
-        assert_eq!(
-            packet.data(..).unwrap().len(),
-            solana_message::v1::MAX_TRANSACTION_SIZE
-        );
+        assert!(packet.meta().discard());
     }
 
     #[test]

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -369,6 +369,7 @@ impl Tpu {
             unverified_bundle_receiver,
             verified_bundle_sender,
             exit.clone(),
+            bank_forks.read().unwrap().sharable_banks(),
         );
 
         let bam_tpu_info = Arc::new(ArcSwap::new(Arc::new(None)));


### PR DESCRIPTION
Fixes #1452

## What's broken

Protocol v4.2 added txv1 transactions which can be up to 4096 bytes. The old packet size limit was 1232 bytes (`PACKET_DATA_SIZE`). Two converter functions, i.e. one on the relayer/block-engine path (`core/src/lib.rs`) and one on the BAM path (`bam_receive_and_buffer.rs`) both capped their byte copies at that old limit. Any txv1 transaction over 1232 bytes was silently truncated before it
reached the sanitizer, while on the BAM path it was outright discarded.

The sanitizer already handles txv1 correctly. The converters just had a stale ceiling

## What changed

Raised the copy ceiling in both converters from `PACKET_DATA_SIZE` (1232) to `solana_message::v1::MAX_TRANSACTION_SIZE` (4096). Legacy and v0 behavior is unchanged since the sanitizer still enforces the old limit for those formats.

The BAM converter was also hoisted from a nested function inside `batch_verify` to `impl` scope so it can be tested directly. The oversized-packet discard path was cleaned up to skip the heap allocation entirely.

**core/src/lib.rs** (relayer/block-engine path, called from `relayer_stage.rs` and `block_engine_stage.rs`):
- one-line ceiling change
- 3 unit tests covering txv1-sized, over-max, and legacy packet sizes

**core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs** (BAM path):
- ceiling raised, converter moved to impl scope
- 2 direct converter tests
- 1 end-to-end test using a real signed txv1 transaction that exceeds 1232 bytes

## Test results

```
cargo test -p solana-core -- proto_packet bam_receive_and_buffer proxy bundle
test result: ok. 56 passed; 0 failed
```