### PR TITLE
Clean up priority handling

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -18,7 +18,7 @@ use {
                 bam_utils::convert_txn_error_to_proto,
                 receive_and_buffer::{
                     DisconnectedError, ReceivingStats, calculate_max_age,
-                    calculate_priority_and_cost, contains_blacklisted_account,
+                    contains_blacklisted_account,
                 },
                 transaction_state_container::{SharedBytes, StateContainer},
             },
@@ -84,7 +84,6 @@ struct ParsedBatch {
             MaxAge,
         ); MAX_PACKETS_PER_BUNDLE],
     >,
-    pub cost: u64,
     pub revert_on_error: bool,
     pub max_schedule_slot: u64,
     pub seq_id: u32,
@@ -304,7 +303,6 @@ impl BamReceiveAndBuffer {
         let enable_instruction_accounts_limit = root_bank
             .feature_set
             .is_active(&agave_feature_set::limit_instruction_accounts::ID);
-        let mut cost: u64 = 0;
         let mut txns_max_age = SmallVec::with_capacity(verified_batch.len());
 
         if vote_only {
@@ -440,22 +438,19 @@ impl BamReceiveAndBuffer {
             let (result, duration_us) =
                 measure_us!(view.transaction_configuration(&working_bank.feature_set));
             metrics.increment_fee_budget_extraction_us(duration_us);
-            let transaction_configuration = match result {
-                Ok(transaction_configuration) => transaction_configuration,
-                Err(err) => {
-                    let reason = convert_txn_error_to_proto(err);
-                    stats.num_dropped_on_compute_budget += 1;
-                    return (
-                        Err(Reason::TransactionError(
-                            jito_protos::proto::bam_types::TransactionError {
-                                index: index as u32,
-                                reason: reason as i32,
-                            },
-                        )),
-                        stats,
-                    );
-                }
-            };
+            if let Err(err) = result {
+                let reason = convert_txn_error_to_proto(err);
+                stats.num_dropped_on_compute_budget += 1;
+                return (
+                    Err(Reason::TransactionError(
+                        jito_protos::proto::bam_types::TransactionError {
+                            index: index as u32,
+                            reason: reason as i32,
+                        },
+                    )),
+                    stats,
+                );
+            }
 
             // Check 4: Ensure valid blockhash and blockhash is not too old
             let lock_results: [_; 1] = core::array::from_fn(|_| Ok(()));
@@ -524,17 +519,12 @@ impl BamReceiveAndBuffer {
             }
 
             let max_age = calculate_max_age(sanitized_epoch, deactivation_slot, alt_resolved_slot);
-
-            let (_, txn_cost) =
-                calculate_priority_and_cost(&view, &transaction_configuration, &working_bank);
-            cost = cost.saturating_add(txn_cost);
             txns_max_age.push((view, max_age));
         }
 
         (
             Ok(ParsedBatch {
                 txns_max_age,
-                cost,
                 revert_on_error,
                 max_schedule_slot,
                 seq_id,
@@ -829,7 +819,6 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
 
                 let ParsedBatch {
                     txns_max_age,
-                    cost,
                     revert_on_error,
                     max_schedule_slot,
                     seq_id,
@@ -839,7 +828,6 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
                     .insert_new_batch(
                         txns_max_age,
                         self.next_fifo_priority,
-                        cost,
                         revert_on_error,
                         max_schedule_slot,
                         seq_id,

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -74,6 +74,7 @@ pub struct BamReceiveAndBuffer {
     parsed_batch_receiver: crossbeam_channel::Receiver<ParsedBatch>,
     recv_stats_receiver: crossbeam_channel::Receiver<ReceivingStats>,
     parsing_thread: Option<std::thread::JoinHandle<()>>,
+    next_fifo_priority: u64,
 }
 
 struct ParsedBatch {
@@ -84,7 +85,6 @@ struct ParsedBatch {
         ); MAX_PACKETS_PER_BUNDLE],
     >,
     pub cost: u64,
-    priority: u64,
     pub revert_on_error: bool,
     pub max_schedule_slot: u64,
     pub seq_id: u32,
@@ -125,6 +125,7 @@ impl BamReceiveAndBuffer {
             parsed_batch_receiver,
             recv_stats_receiver,
             parsing_thread: Some(parsing_thread),
+            next_fifo_priority: u64::MAX,
         }
     }
 
@@ -530,13 +531,10 @@ impl BamReceiveAndBuffer {
             txns_max_age.push((view, max_age));
         }
 
-        let priority = seq_id_to_priority(seq_id);
-
         (
             Ok(ParsedBatch {
                 txns_max_age,
                 cost,
-                priority,
                 revert_on_error,
                 max_schedule_slot,
                 seq_id,
@@ -832,7 +830,6 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
                 let ParsedBatch {
                     txns_max_age,
                     cost,
-                    priority,
                     revert_on_error,
                     max_schedule_slot,
                     seq_id,
@@ -841,10 +838,11 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
                 if container
                     .insert_new_batch(
                         txns_max_age,
-                        priority,
+                        self.next_fifo_priority,
                         cost,
                         revert_on_error,
                         max_schedule_slot,
+                        seq_id,
                     )
                     .is_none()
                 {
@@ -852,12 +850,14 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
                     self.send_container_full_txn_batch_result(seq_id);
                     continue;
                 };
+                self.next_fifo_priority = self.next_fifo_priority.saturating_sub(1);
             },
             BufferedPacketsDecision::ForwardAndHold | BufferedPacketsDecision::Forward => {
                 // Ensure nothing is left in the container
                 while let Some(next_batch_id) = container.pop() {
-                    let seq_id = priority_to_seq_id(next_batch_id.priority);
-                    self.send_no_leader_slot_txn_batch_result(seq_id);
+                    if let Some((_, _, _, seq_id)) = container.get_batch(next_batch_id.id) {
+                        self.send_no_leader_slot_txn_batch_result(seq_id);
+                    }
                     container.remove_by_id(next_batch_id.id);
                 }
 
@@ -891,14 +891,6 @@ impl Drop for BamReceiveAndBuffer {
             parsing_thread.join().unwrap();
         }
     }
-}
-
-pub fn seq_id_to_priority(seq_id: u32) -> u64 {
-    u64::MAX.saturating_sub(seq_id as u64)
-}
-
-pub fn priority_to_seq_id(priority: u64) -> u32 {
-    u32::try_from(u64::MAX.saturating_sub(priority)).unwrap_or(u32::MAX)
 }
 
 #[derive(Default)]
@@ -1114,18 +1106,6 @@ mod tests {
         test_case::test_case,
     };
 
-    #[test]
-    fn test_seq_id_to_priority() {
-        assert_eq!(seq_id_to_priority(0), u64::MAX);
-        assert_eq!(seq_id_to_priority(1), u64::MAX - 1);
-    }
-
-    #[test]
-    fn test_priority_to_seq_id() {
-        assert_eq!(priority_to_seq_id(u64::MAX), 0);
-        assert_eq!(priority_to_seq_id(u64::MAX - 1), 1);
-    }
-
     fn test_bank_forks() -> (Arc<RwLock<BankForks>>, Keypair) {
         let GenesisConfigInfo {
             genesis_config,
@@ -1170,7 +1150,7 @@ mod tests {
     ) {
         let mut actual_length: usize = 0;
         while let Some(id) = container.pop() {
-            let Some((ids, _, _)) = container.get_batch(id.id) else {
+            let Some((ids, _, _, _)) = container.get_batch(id.id) else {
                 panic!(
                     "transaction in queue position {} with id {} must exist.",
                     actual_length, id.id

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -90,7 +90,7 @@ pub struct BamScheduler<Tx: TransactionWithMeta> {
 struct InflightBatchInfo {
     pub schedule_time: Instant,
     // SmallVec 1: each scheduled work item typically corresponds to one batch id.
-    pub batch_priority_ids: SmallVec<[TransactionPriorityId; 1]>,
+    pub batch_priority_ids: SmallVec<[(TransactionPriorityId, u32 /* seq_id */); 1]>,
     pub slot: Slot,
 }
 
@@ -286,14 +286,14 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                 container,
                 slot,
             );
-            self.send_to_worker(SmallVec::from([id]), work, slot);
+            self.send_to_worker(SmallVec::from([(id, seq_id)]), work, slot);
         }
     }
 
     fn send_to_worker(
         &mut self,
         // SmallVec 1: scheduler currently sends a single batch id per work item.
-        priority_ids: SmallVec<[TransactionPriorityId; 1]>,
+        priority_ids: SmallVec<[(TransactionPriorityId, u32); 1]>,
         work: ConsumeWork<Tx>,
         slot: Slot,
     ) {
@@ -528,7 +528,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         // Unblock all transactions blocked by inflight batches
         // and then drain the prio-graph
         for (_, inflight_info) in self.inflight_batch_info.iter() {
-            for priority_id in &inflight_info.batch_priority_ids {
+            for (priority_id, _) in &inflight_info.batch_priority_ids {
                 if prev_slot == Some(inflight_info.slot) {
                     self.prio_graph.unblock(priority_id);
                 }
@@ -741,24 +741,19 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for BamScheduler<Tx> {
             } else {
                 inflight_batch_info.batch_priority_ids.len()
             };
-            for (i, priority_id) in inflight_batch_info
+            for (i, (priority_id, seq_id)) in inflight_batch_info
                 .batch_priority_ids
                 .iter()
+                .copied()
                 .enumerate()
                 .take(len)
             {
-                let seq_id = container
-                    .get_batch(priority_id.id)
-                    .map(|(_, _, _, seq_id)| seq_id);
-
                 // If we got extra info, we can send back the result
                 if revert_on_error {
                     if let Some(processed_results) = processed_results.take() {
                         let bundle_result =
                             Self::generate_revert_on_error_bundle_result(processed_results);
-                        if let Some(seq_id) = seq_id {
-                            self.send_back_result(seq_id, bundle_result);
-                        }
+                        self.send_back_result(seq_id, bundle_result);
                     }
                 } else if let Some(processed_results) = processed_results.as_mut() {
                     let Some(txn_result) = processed_results.next() else {
@@ -769,14 +764,12 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for BamScheduler<Tx> {
                         continue;
                     };
                     let bundle_result = Self::generate_bundle_result(txn_result);
-                    if let Some(seq_id) = seq_id {
-                        self.send_back_result(seq_id, bundle_result);
-                    }
+                    self.send_back_result(seq_id, bundle_result);
                 }
 
                 // If in the same slot, unblock the transaction
                 if Some(inflight_batch_info.slot) == self.slot {
-                    self.prio_graph.unblock(priority_id);
+                    self.prio_graph.unblock(&priority_id);
                 }
 
                 // Remove the transaction from the container

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -4,7 +4,6 @@
 ///
 use {
     super::{
-        bam_receive_and_buffer::priority_to_seq_id,
         scheduler::{Scheduler, SchedulingSummary},
         scheduler_error::SchedulerError,
         transaction_priority_id::TransactionPriorityId,
@@ -145,7 +144,8 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         let working_bank = self.bank_forks.read().unwrap().working_bank();
 
         while let Some(next_batch_id) = container.pop() {
-            let Some((batch_ids, _, max_schedule_slot)) = container.get_batch(next_batch_id.id)
+            let Some((batch_ids, _, max_schedule_slot, seq_id)) =
+                container.get_batch(next_batch_id.id)
             else {
                 error!("Batch {} not found in container", next_batch_id.id);
                 continue;
@@ -153,7 +153,6 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
 
             if max_schedule_slot < slot {
                 // If the slot has changed, we cannot schedule this batch
-                let seq_id = priority_to_seq_id(next_batch_id.priority);
                 self.send_no_leader_slot_bundle_result(seq_id);
                 container.remove_by_id(next_batch_id.id);
                 continue;
@@ -182,7 +181,6 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                     drop(txns);
                     container.remove_by_id(next_batch_id.id);
 
-                    let seq_id = priority_to_seq_id(next_batch_id.priority);
                     let result = atomic_txn_batch_result::Result::NotCommitted(
                         jito_protos::proto::bam_types::NotCommitted {
                             reason: Some(Self::convert_reason_to_proto(
@@ -197,7 +195,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             }
 
             self.insertion_to_prio_graph_time
-                .insert(priority_to_seq_id(next_batch_id.priority), Instant::now());
+                .insert(seq_id, Instant::now());
             self.prio_graph.insert_transaction(
                 next_batch_id,
                 Self::get_transactions_account_access(txns.into_iter()),
@@ -218,14 +216,11 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         let now = Instant::now();
         let working_bank = self.bank_forks.read().unwrap().working_bank();
         while let Some(id) = self.prio_graph.pop() {
-            let (batch_ids, revert_on_error, max_schedule_slot) =
+            let (batch_ids, revert_on_error, max_schedule_slot, seq_id) =
                 container.get_batch(id.id).unwrap();
 
             // Update time in prio-graph metric
-            if let Some(insertion_time) = self
-                .insertion_to_prio_graph_time
-                .remove(&priority_to_seq_id(id.priority))
-            {
+            if let Some(insertion_time) = self.insertion_to_prio_graph_time.remove(&seq_id) {
                 let _ = self
                     .time_in_priograph_us
                     .increment(now.duration_since(insertion_time).as_micros() as u64);
@@ -234,7 +229,6 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             // Filter on slot
             if max_schedule_slot < slot {
                 self.prio_graph.unblock(&id);
-                let seq_id = priority_to_seq_id(id.priority);
                 self.send_no_leader_slot_bundle_result(seq_id);
                 container.remove_by_id(id.id);
                 continue;
@@ -267,7 +261,6 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                     container.remove_by_id(id.id);
                     self.prio_graph.unblock(&id);
 
-                    let seq_id = priority_to_seq_id(id.priority);
                     let result = atomic_txn_batch_result::Result::NotCommitted(
                         jito_protos::proto::bam_types::NotCommitted {
                             reason: Some(Self::convert_reason_to_proto(
@@ -360,7 +353,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             priority_ids
                 .iter()
                 .filter_map(|priority_id| container.get_batch(priority_id.id))
-                .flat_map(|(batch_ids, _, _)| batch_ids.into_iter())
+                .flat_map(|(batch_ids, _, _, _)| batch_ids.into_iter())
                 .copied(),
         );
 
@@ -525,8 +518,9 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         // Drain container and send back 'retryable'
         if self.slot.is_none() {
             while let Some(next_batch_id) = container.pop() {
-                let seq_id = priority_to_seq_id(next_batch_id.priority);
-                self.send_no_leader_slot_bundle_result(seq_id);
+                if let Some((_, _, _, seq_id)) = container.get_batch(next_batch_id.id) {
+                    self.send_no_leader_slot_bundle_result(seq_id);
+                }
                 container.remove_by_id(next_batch_id.id);
             }
         }
@@ -542,16 +536,16 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         }
         let now = Instant::now();
         while let Some((next_batch_id, _)) = self.prio_graph.pop_and_unblock() {
-            if let Some(insertion_time) = self
-                .insertion_to_prio_graph_time
-                .remove(&priority_to_seq_id(next_batch_id.priority))
-            {
+            let Some((_, _, _, seq_id)) = container.get_batch(next_batch_id.id) else {
+                container.remove_by_id(next_batch_id.id);
+                continue;
+            };
+            if let Some(insertion_time) = self.insertion_to_prio_graph_time.remove(&seq_id) {
                 let _ = self
                     .time_in_priograph_us
                     .increment(now.duration_since(insertion_time).as_micros() as u64);
             };
 
-            let seq_id = priority_to_seq_id(next_batch_id.priority);
             self.send_no_leader_slot_bundle_result(seq_id);
             container.remove_by_id(next_batch_id.id);
         }
@@ -753,15 +747,18 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for BamScheduler<Tx> {
                 .enumerate()
                 .take(len)
             {
+                let seq_id = container
+                    .get_batch(priority_id.id)
+                    .map(|(_, _, _, seq_id)| seq_id);
+
                 // If we got extra info, we can send back the result
                 if revert_on_error {
                     if let Some(processed_results) = processed_results.take() {
                         let bundle_result =
                             Self::generate_revert_on_error_bundle_result(processed_results);
-                        self.send_back_result(
-                            priority_to_seq_id(priority_id.priority),
-                            bundle_result,
-                        );
+                        if let Some(seq_id) = seq_id {
+                            self.send_back_result(seq_id, bundle_result);
+                        }
                     }
                 } else if let Some(processed_results) = processed_results.as_mut() {
                     let Some(txn_result) = processed_results.next() else {
@@ -772,7 +769,9 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for BamScheduler<Tx> {
                         continue;
                     };
                     let bundle_result = Self::generate_bundle_result(txn_result);
-                    self.send_back_result(priority_to_seq_id(priority_id.priority), bundle_result);
+                    if let Some(seq_id) = seq_id {
+                        self.send_back_result(seq_id, bundle_result);
+                    }
                 }
 
                 // If in the same slot, unblock the transaction
@@ -805,7 +804,6 @@ mod tests {
                 },
                 tests::create_slow_genesis_config,
                 transaction_scheduler::{
-                    bam_receive_and_buffer::seq_id_to_priority,
                     bam_scheduler::{BamScheduler, MAX_PACKETS_PER_BUNDLE},
                     scheduler::Scheduler,
                     transaction_state_container::{StateContainer, TransactionStateContainer},
@@ -894,32 +892,34 @@ mod tests {
                 impl Borrow<Keypair>,
                 impl IntoIterator<Item = impl Borrow<Pubkey>>,
                 u64,
-                u64,
+                u32,
                 u64,
             ),
         >,
     ) -> TransactionStateContainer<RuntimeTransaction<SanitizedTransaction>> {
         let mut container = TransactionStateContainer::with_capacity(10 * 1024);
-        for (from_keypair, to_pubkeys, lamports, compute_unit_price, max_schedule_slot) in
-            tx_infos.into_iter()
+        for (fifo_index, (from_keypair, to_pubkeys, lamports, seq_id, max_schedule_slot)) in
+            tx_infos.into_iter().enumerate()
         {
             let transaction = prioritized_tranfers(
                 from_keypair.borrow(),
                 to_pubkeys,
                 lamports,
-                compute_unit_price,
+                u64::from(seq_id),
             );
             const TEST_TRANSACTION_COST: u64 = 5000;
             let mut txns_max_age: SmallVec<
                 [(RuntimeTransaction<SanitizedTransaction>, MaxAge); MAX_PACKETS_PER_BUNDLE],
             > = SmallVec::new();
             txns_max_age.push((transaction, MaxAge::MAX));
+            let priority = u64::MAX.saturating_sub(fifo_index as u64);
             container.insert_new_batch(
                 txns_max_age,
-                compute_unit_price,
+                priority,
                 TEST_TRANSACTION_COST,
                 false,
                 max_schedule_slot,
+                seq_id,
             );
         }
 
@@ -965,38 +965,15 @@ mod tests {
 
         let keypair_a = Keypair::new();
 
-        let first_recipient = Pubkey::new_unique();
+        let first_fifo_recipient = Pubkey::new_unique();
+        let blocked_recipient = Pubkey::new_unique();
         let second_recipient = Pubkey::new_unique();
 
         let mut container = create_container(vec![
-            (
-                &keypair_a,
-                vec![Pubkey::new_unique()],
-                1000,
-                seq_id_to_priority(1),
-                u64::MAX,
-            ),
-            (
-                &keypair_a,
-                vec![first_recipient],
-                1500,
-                seq_id_to_priority(0),
-                u64::MAX,
-            ),
-            (
-                &keypair_a,
-                vec![Pubkey::new_unique()],
-                1500,
-                seq_id_to_priority(2),
-                u64::MAX,
-            ),
-            (
-                &Keypair::new(),
-                vec![second_recipient],
-                2000,
-                seq_id_to_priority(3),
-                u64::MAX,
-            ),
+            (&keypair_a, vec![first_fifo_recipient], 1000, 1, u64::MAX),
+            (&keypair_a, vec![blocked_recipient], 1500, 0, u64::MAX),
+            (&keypair_a, vec![Pubkey::new_unique()], 1500, 2, u64::MAX),
+            (&Keypair::new(), vec![second_recipient], 2000, 3, u64::MAX),
         ]);
 
         assert!(
@@ -1035,7 +1012,7 @@ mod tests {
         );
         assert_eq!(
             work_1.transactions[0].message().account_keys()[1],
-            first_recipient
+            first_fifo_recipient
         );
 
         // Check that the second transaction is from the other keypair
@@ -1092,7 +1069,7 @@ mod tests {
         let BamOutboundMessage::AtomicTxnBatchResult(bundle_result) = response else {
             panic!("Expected AtomicTxnBatchResult message");
         };
-        assert_eq!(bundle_result.seq_id, 0);
+        assert_eq!(bundle_result.seq_id, 1);
         assert!(
             bundle_result.result.is_some(),
             "Bundle result should be present"
@@ -1179,7 +1156,7 @@ mod tests {
         let BamOutboundMessage::AtomicTxnBatchResult(bundle_result) = response else {
             panic!("Expected AtomicTxnBatchResult message");
         };
-        assert_eq!(bundle_result.seq_id, 1);
+        assert_eq!(bundle_result.seq_id, 0);
         assert!(
             bundle_result.result.is_some(),
             "Bundle result should be present"
@@ -1264,7 +1241,7 @@ mod tests {
             &keypair_a,
             vec![Pubkey::new_unique()],
             1000,
-            seq_id_to_priority(0),
+            0,
             u64::MAX,
         )]);
         let decision = BufferedPacketsDecision::Consume(bank.clone());
@@ -1277,20 +1254,8 @@ mod tests {
         // Pull transactions into prio_graph
         // Create container with some transactions
         let mut container = create_container(vec![
-            (
-                &keypair_a,
-                vec![Pubkey::new_unique()],
-                1000,
-                seq_id_to_priority(0),
-                u64::MAX,
-            ),
-            (
-                &keypair_b,
-                vec![Pubkey::new_unique()],
-                2000,
-                seq_id_to_priority(1),
-                u64::MAX,
-            ),
+            (&keypair_a, vec![Pubkey::new_unique()], 1000, 0, u64::MAX),
+            (&keypair_b, vec![Pubkey::new_unique()], 2000, 1, u64::MAX),
         ]);
         scheduler.pull_into_prio_graph(&mut container);
         assert!(
@@ -1309,7 +1274,7 @@ mod tests {
         // Re-insert the transactions back into prio_graph for testing
         for txn_id in &stored_txn_ids {
             // Get transaction from container to re-insert
-            if let Some((batch_ids, _, _)) = container.get_batch(txn_id.id) {
+            if let Some((batch_ids, _, _, _)) = container.get_batch(txn_id.id) {
                 let txns = batch_ids
                     .iter()
                     .filter_map(|id| container.get_transaction(*id));
@@ -1356,7 +1321,7 @@ mod tests {
             &Keypair::new(),
             vec![Pubkey::new_unique()],
             1000,
-            seq_id_to_priority(0),
+            0,
             u64::MAX,
         )]);
         scheduler
@@ -1370,7 +1335,7 @@ mod tests {
         // One batch, two transactions sharing a writable account: both are
         // signed by `keypair_a`, so both write its fee-payer account (index 0).
         let keypair_a = Keypair::new();
-        let priority = seq_id_to_priority(0);
+        let priority = u64::MAX;
         let mut txns_max_age: SmallVec<
             [(RuntimeTransaction<SanitizedTransaction>, MaxAge); MAX_PACKETS_PER_BUNDLE],
         > = SmallVec::new();
@@ -1384,7 +1349,7 @@ mod tests {
         ));
 
         let mut container = TransactionStateContainer::with_capacity(10 * 1024);
-        container.insert_new_batch(txns_max_age, priority, 5000, false, u64::MAX);
+        container.insert_new_batch(txns_max_age, priority, 5000, false, u64::MAX, 0);
 
         // Must not panic; the bundle becomes a single schedulable node.
         scheduler.pull_into_prio_graph(&mut container);

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -954,8 +954,16 @@ mod tests {
         let blocked_recipient = Pubkey::new_unique();
         let second_recipient = Pubkey::new_unique();
 
+        // First two batches conflict on fee payer and span the seq_id wrap boundary.
+        // FIFO should schedule u32::MAX before 0.
         let mut container = create_container(vec![
-            (&keypair_a, vec![first_fifo_recipient], 1000, 1, u64::MAX),
+            (
+                &keypair_a,
+                vec![first_fifo_recipient],
+                1000,
+                u32::MAX,
+                u64::MAX,
+            ),
             (&keypair_a, vec![blocked_recipient], 1500, 0, u64::MAX),
             (&keypair_a, vec![Pubkey::new_unique()], 1500, 2, u64::MAX),
             (&Keypair::new(), vec![second_recipient], 2000, 3, u64::MAX),
@@ -1054,7 +1062,7 @@ mod tests {
         let BamOutboundMessage::AtomicTxnBatchResult(bundle_result) = response else {
             panic!("Expected AtomicTxnBatchResult message");
         };
-        assert_eq!(bundle_result.seq_id, 1);
+        assert_eq!(bundle_result.seq_id, u32::MAX);
         assert!(
             bundle_result.result.is_some(),
             "Bundle result should be present"

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -148,6 +148,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                 container.get_batch(next_batch_id.id)
             else {
                 error!("Batch {} not found in container", next_batch_id.id);
+                container.remove_by_id(next_batch_id.id);
                 continue;
             };
 

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -907,20 +907,12 @@ mod tests {
                 lamports,
                 u64::from(seq_id),
             );
-            const TEST_TRANSACTION_COST: u64 = 5000;
             let mut txns_max_age: SmallVec<
                 [(RuntimeTransaction<SanitizedTransaction>, MaxAge); MAX_PACKETS_PER_BUNDLE],
             > = SmallVec::new();
             txns_max_age.push((transaction, MaxAge::MAX));
             let priority = u64::MAX.saturating_sub(fifo_index as u64);
-            container.insert_new_batch(
-                txns_max_age,
-                priority,
-                TEST_TRANSACTION_COST,
-                false,
-                max_schedule_slot,
-                seq_id,
-            );
+            container.insert_new_batch(txns_max_age, priority, false, max_schedule_slot, seq_id);
         }
 
         container
@@ -1349,7 +1341,7 @@ mod tests {
         ));
 
         let mut container = TransactionStateContainer::with_capacity(10 * 1024);
-        container.insert_new_batch(txns_max_age, priority, 5000, false, u64::MAX, 0);
+        container.insert_new_batch(txns_max_age, priority, false, u64::MAX, 0);
 
         // Must not panic; the bundle becomes a single schedulable node.
         scheduler.pull_into_prio_graph(&mut container);

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -52,8 +52,10 @@ pub(crate) struct TransactionStateContainer<Tx: TransactionWithMeta> {
 
 struct BatchInfo {
     batch_id: usize,
+    priority: u64,
     revert_on_error: bool,
     max_schedule_slot: u64,
+    seq_id: u32,
 }
 
 enum BatchIdOrTransactionState<Tx: TransactionWithMeta> {
@@ -95,6 +97,7 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
         &SmallVec<[TransactionId; MAX_PACKETS_PER_BUNDLE]>,
         bool,
         u64,
+        u32,
     )>;
 
     /// Retries a transaction - inserts transaction back into map (but not packet).
@@ -209,6 +212,7 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
         &SmallVec<[TransactionId; MAX_PACKETS_PER_BUNDLE]>,
         bool,
         u64,
+        u32,
     )> {
         let Some(BatchIdOrTransactionState::Batch(batch_info)) =
             self.id_to_transaction_state.get(id)
@@ -219,6 +223,7 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
             self.batch_id_to_transaction_ids.get(&batch_info.batch_id)?,
             batch_info.revert_on_error,
             batch_info.max_schedule_slot,
+            batch_info.seq_id,
         ))
     }
 
@@ -254,15 +259,7 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
     fn remove_by_id(&mut self, id: TransactionId) {
         let priority = match self.id_to_transaction_state.get(id) {
             Some(BatchIdOrTransactionState::TransactionState(state)) => state.priority(),
-            Some(BatchIdOrTransactionState::Batch(batch_info)) => self
-                .batch_id_to_transaction_ids
-                .get(&batch_info.batch_id)
-                .and_then(|ids| ids.first())
-                .and_then(|&tid| match self.id_to_transaction_state.get(tid) {
-                    Some(BatchIdOrTransactionState::TransactionState(s)) => Some(s.priority()),
-                    _ => None,
-                })
-                .unwrap_or(0),
+            Some(BatchIdOrTransactionState::Batch(batch_info)) => batch_info.priority,
             None => return,
         };
         self.priority_queue
@@ -343,6 +340,7 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
         cost: u64,
         revert_on_error: bool,
         max_schedule_slot: u64,
+        seq_id: u32,
     ) -> Option<usize> {
         let entries_required = txns_max_age.len().saturating_add(1); // add entry for BatchInfo
         let available_entries = self
@@ -357,8 +355,10 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
         let batch_id = entry.key();
         entry.insert(BatchIdOrTransactionState::Batch(BatchInfo {
             batch_id,
+            priority,
             revert_on_error,
             max_schedule_slot,
+            seq_id,
         }));
 
         let transaction_ids: SmallVec<[TransactionId; MAX_PACKETS_PER_BUNDLE]> = txns_max_age
@@ -511,6 +511,7 @@ impl StateContainer<RuntimeTransactionView> for TransactionViewStateContainer {
         &SmallVec<[TransactionId; MAX_PACKETS_PER_BUNDLE]>,
         bool,
         u64,
+        u32,
     )> {
         unimplemented!("get_batch not implemented for TransactionViewStateContainer");
     }
@@ -794,7 +795,7 @@ mod tests {
         }
 
         // Insert a batch of transactions.
-        let batch_id = container.insert_new_batch(transaction_max_ages, 10, 100, true, 0);
+        let batch_id = container.insert_new_batch(transaction_max_ages, 10, 100, true, 0, 7);
         assert!(batch_id.is_some());
         assert_eq!(container.priority_queue.len(), 1);
         assert_eq!(container.id_to_transaction_state.len(), 6);
@@ -802,10 +803,11 @@ mod tests {
 
         // Get the batch id and revert_on_error flag.
         let batch_id = batch_id.unwrap();
-        let (batch, revert_on_error, slot) = container.get_batch(batch_id).unwrap();
+        let (batch, revert_on_error, slot, seq_id) = container.get_batch(batch_id).unwrap();
         assert_eq!(batch.len(), 5);
         assert!(revert_on_error);
         assert_eq!(slot, 0);
+        assert_eq!(seq_id, 7);
 
         // Remove a batch of transactions.
         let batch_id = container.pop().unwrap();
@@ -824,8 +826,10 @@ mod tests {
             let batch_id = entry.key();
             entry.insert(BatchIdOrTransactionState::Batch(BatchInfo {
                 batch_id,
+                priority: 0,
                 revert_on_error: false,
                 max_schedule_slot: 0,
+                seq_id: 0,
             }));
             container
                 .batch_id_to_transaction_ids
@@ -844,7 +848,7 @@ mod tests {
         let mut txns_max_age = SmallVec::new();
         txns_max_age.push((transaction, max_age));
 
-        let batch_id = container.insert_new_batch(txns_max_age, 10, 100, true, 0);
+        let batch_id = container.insert_new_batch(txns_max_age, 10, 100, true, 0, 0);
         assert!(batch_id.is_some());
         assert_eq!(container.id_to_transaction_state.len(), map_capacity);
     }
@@ -861,7 +865,7 @@ mod tests {
         let mut txns_max_age = SmallVec::new();
         txns_max_age.push((transaction, max_age));
 
-        let batch_id = container.insert_new_batch(txns_max_age, 10, 100, true, 0);
+        let batch_id = container.insert_new_batch(txns_max_age, 10, 100, true, 0, 0);
         assert!(batch_id.is_none());
         assert_eq!(container.id_to_transaction_state.len(), target_len);
         assert_eq!(

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -51,7 +51,6 @@ pub(crate) struct TransactionStateContainer<Tx: TransactionWithMeta> {
 }
 
 struct BatchInfo {
-    batch_id: usize,
     priority: u64,
     revert_on_error: bool,
     max_schedule_slot: u64,
@@ -220,7 +219,7 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
             return None;
         };
         Some((
-            self.batch_id_to_transaction_ids.get(&batch_info.batch_id)?,
+            self.batch_id_to_transaction_ids.get(&id)?,
             batch_info.revert_on_error,
             batch_info.max_schedule_slot,
             batch_info.seq_id,
@@ -264,14 +263,10 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
         };
         self.priority_queue
             .remove(&TransactionPriorityId::new(priority, id));
-        let BatchIdOrTransactionState::Batch(batch_info) = self.id_to_transaction_state.remove(id)
-        else {
+        let BatchIdOrTransactionState::Batch(_) = self.id_to_transaction_state.remove(id) else {
             return;
         };
-        let Some(batch) = self
-            .batch_id_to_transaction_ids
-            .remove(&batch_info.batch_id)
-        else {
+        let Some(batch) = self.batch_id_to_transaction_ids.remove(&id) else {
             return;
         };
         for transaction_id in batch {
@@ -337,7 +332,6 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
         &mut self,
         txns_max_age: SmallVec<[(Tx, MaxAge); MAX_PACKETS_PER_BUNDLE]>,
         priority: u64,
-        cost: u64,
         revert_on_error: bool,
         max_schedule_slot: u64,
         seq_id: u32,
@@ -354,7 +348,6 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
         let entry = self.get_vacant_map_entry();
         let batch_id = entry.key();
         entry.insert(BatchIdOrTransactionState::Batch(BatchInfo {
-            batch_id,
             priority,
             revert_on_error,
             max_schedule_slot,
@@ -367,7 +360,7 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
                 let entry = self.get_vacant_map_entry();
                 let transaction_id: TransactionId = entry.key();
                 entry.insert(BatchIdOrTransactionState::TransactionState(
-                    TransactionState::new(txn, max_age, priority, cost),
+                    TransactionState::new(txn, max_age, priority, 0),
                 ));
                 transaction_id
             })
@@ -795,7 +788,7 @@ mod tests {
         }
 
         // Insert a batch of transactions.
-        let batch_id = container.insert_new_batch(transaction_max_ages, 10, 100, true, 0, 7);
+        let batch_id = container.insert_new_batch(transaction_max_ages, 10, true, 0, 7);
         assert!(batch_id.is_some());
         assert_eq!(container.priority_queue.len(), 1);
         assert_eq!(container.id_to_transaction_state.len(), 6);
@@ -825,7 +818,6 @@ mod tests {
             let entry = container.get_vacant_map_entry();
             let batch_id = entry.key();
             entry.insert(BatchIdOrTransactionState::Batch(BatchInfo {
-                batch_id,
                 priority: 0,
                 revert_on_error: false,
                 max_schedule_slot: 0,
@@ -848,7 +840,7 @@ mod tests {
         let mut txns_max_age = SmallVec::new();
         txns_max_age.push((transaction, max_age));
 
-        let batch_id = container.insert_new_batch(txns_max_age, 10, 100, true, 0, 0);
+        let batch_id = container.insert_new_batch(txns_max_age, 10, true, 0, 0);
         assert!(batch_id.is_some());
         assert_eq!(container.id_to_transaction_state.len(), map_capacity);
     }
@@ -865,7 +857,7 @@ mod tests {
         let mut txns_max_age = SmallVec::new();
         txns_max_age.push((transaction, max_age));
 
-        let batch_id = container.insert_new_batch(txns_max_age, 10, 100, true, 0, 0);
+        let batch_id = container.insert_new_batch(txns_max_age, 10, true, 0, 0);
         assert!(batch_id.is_none());
         assert_eq!(container.id_to_transaction_state.len(), target_len);
         assert_eq!(


### PR DESCRIPTION
#### Problem
`seq_id == 0` is mapped to the highest possible priority and `seq_id == u32::MAX` to a lower priority. If two conflicting batches are pending and batch A has `seq_id == u32::MAX` while the next batch B wraps to `seq_id == 0`, we would schedule B before A, while FIFO schedulers process A before B. This fixes the `seq_id` rollover ordering divergence.

#### Summary of Changes

- Store BAM `seq_id` on batch metadata and use it only for response routing.
- Remove BAM-side priority/cost fields and cost-model calculation from parsed batches.
- Store batch priority directly in `BatchInfo`, so removal no longer infers it from the first child transaction.
