### PR TITLE
Polling cleanup

### DIFF
--- a/bam-banking-bench/src/main.rs
+++ b/bam-banking-bench/src/main.rs
@@ -122,14 +122,13 @@ fn main() {
 
     // create a mock bam server
     let (batch_sender, batch_receiver) = unbounded();
-    let (outbound_sender, outbound_receiver) = unbounded();
+    let (outbound_sender, outbound_receiver) = tokio::sync::mpsc::channel(100_000);
     let keypair = Keypair::new();
     let bam_dependencies = BamDependencies {
         bam_enabled: Arc::new(AtomicU8::new(BamConnectionState::Connected as u8)),
         batch_sender: batch_sender.clone(),
         batch_receiver,
         outbound_sender,
-        outbound_receiver: outbound_receiver.clone(), // unused
         cluster_info: Arc::new(ClusterInfo::new(
             ContactInfo::new_localhost(&keypair.pubkey(), timestamp()),
             Arc::new(keypair),

--- a/bam-banking-bench/src/mock_bam_server.rs
+++ b/bam-banking-bench/src/mock_bam_server.rs
@@ -1,5 +1,5 @@
 use {
-    crossbeam_channel::{Receiver, Sender},
+    crossbeam_channel::Sender,
     jito_protos::proto::bam_types::{AtomicTxnBatch, AtomicTxnBatchResult, Packet},
     solana_compute_budget_interface::ComputeBudgetInstruction,
     solana_core::bam_dependencies::BamOutboundMessage,
@@ -141,7 +141,7 @@ pub(crate) struct MockBamServer;
 impl MockBamServer {
     pub(crate) fn run(
         batch_sender: Sender<AtomicTxnBatch>,
-        outbound_receiver: Receiver<BamOutboundMessage>,
+        mut outbound_receiver: tokio::sync::mpsc::Receiver<BamOutboundMessage>,
         shared_leader_state: SharedLeaderState,
         exit: Arc<AtomicBool>,
         keypairs: Vec<Keypair>,
@@ -159,7 +159,7 @@ impl MockBamServer {
                     };
 
                     if bank.slot() != bank_stats.bank_slot {
-                        Self::wait_for_all_results(&outbound_receiver, &mut bank_stats);
+                        Self::wait_for_all_results(&mut outbound_receiver, &mut bank_stats);
 
                         bank_stats.print_stats();
                         bank_stats = BankStats::new(bank.slot());
@@ -176,14 +176,14 @@ impl MockBamServer {
                         &mut seq_id,
                     );
 
-                    Self::handle_outbound_messages(&outbound_receiver, &mut bank_stats);
+                    Self::handle_outbound_messages(&mut outbound_receiver, &mut bank_stats);
                 }
             }
         })
     }
 
     fn handle_outbound_messages(
-        outbound_receiver: &Receiver<BamOutboundMessage>,
+        outbound_receiver: &mut tokio::sync::mpsc::Receiver<BamOutboundMessage>,
         bank_stats: &mut BankStats,
     ) {
         while let Ok(msg) = outbound_receiver.try_recv() {
@@ -206,7 +206,7 @@ impl MockBamServer {
     }
 
     fn wait_for_all_results(
-        outbound_receiver: &Receiver<BamOutboundMessage>,
+        outbound_receiver: &mut tokio::sync::mpsc::Receiver<BamOutboundMessage>,
         bank_stats: &mut BankStats,
     ) {
         while !bank_stats

--- a/core/src/bam_connection.rs
+++ b/core/src/bam_connection.rs
@@ -10,15 +10,16 @@ use {
             bam_node_api_client::BamNodeApiClient, scheduler_message_v0::Msg,
             scheduler_response::VersionedMsg, scheduler_response_v0::Resp,
         },
-        bam_types::{AtomicTxnBatch, AuthProof, Pong, ValidatorHeartBeat},
+        bam_types::{
+            AtomicTxnBatch, AuthProof, MultipleAtomicTxnBatchResult, Pong, ValidatorHeartBeat,
+        },
     },
     solana_gossip::cluster_info::ClusterInfo,
-    solana_keypair::Keypair,
     solana_signer::Signer,
     std::{
         sync::{
             Arc, Mutex,
-            atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering::Relaxed},
+            atomic::{AtomicBool, AtomicU64, Ordering::Relaxed},
         },
         time::{Duration, Instant, SystemTime},
     },
@@ -33,7 +34,7 @@ use {
 
 pub struct BamConnection {
     config: Arc<Mutex<Option<ConfigResponse>>>,
-    connection_task: tokio::task::JoinHandle<()>,
+    connection_task: tokio::task::JoinHandle<mpsc::Receiver<BamOutboundMessage>>,
     is_healthy: Arc<AtomicBool>,
     url: String,
     connection_exit: Arc<AtomicBool>,
@@ -43,11 +44,10 @@ const AUTH_LABEL: &[u8] = b"X_OFF_CHAIN_JITO_BAM_V1\0";
 const CONNECTION_TIMEOUT: Duration = std::time::Duration::from_secs(5);
 const NETWORK_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const OUTBOUND_CHANNEL_CAPACITY: usize = 100_000;
+const MAX_OUTBOUND_RESULT_BATCH_SIZE: usize = 24;
 const VALIDATOR_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const METRICS_AND_HEALTH_CHECK_INTERVAL: Duration = Duration::from_millis(25);
 const REFRESH_CONFIG_INTERVAL: Duration = Duration::from_secs(1);
-const OUTBOUND_TICK_INTERVAL: Duration = Duration::from_millis(1);
-const MAX_WAITING_RESULTS: usize = 24;
 const WAIT_SLEEP_DURATION: Duration = Duration::from_millis(10);
 const CHILD_TASK_SHUTDOWN_GRACE: Duration = Duration::from_millis(100);
 const CONNECTION_TASK_DROP_GRACE: Duration = Duration::from_millis(250);
@@ -60,7 +60,7 @@ impl BamConnection {
         url: String,
         cluster_info: Arc<ClusterInfo>,
         batch_sender: crossbeam_channel::Sender<AtomicTxnBatch>,
-        outbound_receiver: crossbeam_channel::Receiver<BamOutboundMessage>,
+        outbound_receiver: &mut Option<mpsc::Receiver<BamOutboundMessage>>,
     ) -> Result<Self, TryInitError> {
         // Create connection and inbound and outbound streams
         let backend_endpoint = Self::endpoint_from_url(&url)?
@@ -81,6 +81,10 @@ impl BamConnection {
             TryInitError::StreamStartError(e)
         })?
         .into_inner();
+
+        let outbound_receiver = outbound_receiver
+            .take()
+            .expect("BAM outbound receiver already in use");
 
         // Create data structures for the connection task
         let metrics = Arc::new(BamConnectionMetrics::default());
@@ -122,8 +126,8 @@ impl BamConnection {
         cluster_info: Arc<ClusterInfo>,
         metrics: Arc<BamConnectionMetrics>,
         is_healthy: Arc<AtomicBool>,
-        outbound_receiver: crossbeam_channel::Receiver<BamOutboundMessage>,
-    ) {
+        mut outbound_receiver: mpsc::Receiver<BamOutboundMessage>,
+    ) -> mpsc::Receiver<BamOutboundMessage> {
         let mut last_heartbeat = None;
         let mut heartbeat_interval = interval(VALIDATOR_HEARTBEAT_INTERVAL);
         heartbeat_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -135,7 +139,7 @@ impl BamConnection {
         let Some(auth_proof) = Self::prepare_auth_proof(&mut validator_client, cluster_info).await
         else {
             error!("Failed to prepare auth response");
-            return;
+            return outbound_receiver;
         };
 
         // Send it as first message
@@ -145,20 +149,14 @@ impl BamConnection {
         if outbound_sender
             .send(v0_to_versioned_proto(start_message))
             .await
-            .inspect_err(|_| {
-                error!("Failed to send initial auth proof message");
-            })
             .is_err()
         {
             error!("Outbound sender channel closed before sending initial auth proof message");
-            return;
+            return outbound_receiver;
         }
 
-        let mut post_auth_start = Some((validator_client, outbound_receiver));
-        let mut post_auth_tasks: Option<(
-            tokio::task::JoinHandle<()>,
-            tokio::task::JoinHandle<()>,
-        )> = None;
+        let mut post_auth_client = Some(validator_client);
+        let mut refresh_config_task = None;
 
         while !connection_exit.load(Relaxed) {
             tokio::select! {
@@ -203,190 +201,142 @@ impl BamConnection {
                     };
 
                     // The first successful inbound scheduler message proves the auth'd stream was accepted.
-                    post_auth_tasks.get_or_insert_with(|| {
-                        let (validator_client, outbound_receiver) = post_auth_start
-                            .take()
-                            .expect("post-auth start state should only move once");
-                        (
-                            tokio::spawn(Self::refresh_config_task(
-                                connection_exit.clone(),
-                                config.clone(),
-                                validator_client,
-                                metrics.clone(),
-                            )),
-                            tokio::spawn(Self::outbound_task(
-                                connection_exit.clone(),
-                                outbound_sender.clone(),
-                                outbound_receiver,
-                                metrics.clone(),
-                            )),
-                        )
-                    });
+                    if let Some(mut validator_client) = post_auth_client.take() {
+                        let connection_exit = connection_exit.clone();
+                        let config = config.clone();
+                        let metrics = metrics.clone();
+                        refresh_config_task = Some(tokio::spawn(async move {
+                            let mut interval = interval(REFRESH_CONFIG_INTERVAL);
+                            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+                            while !connection_exit.load(Relaxed) {
+                                interval.tick().await;
+
+                                let request = tonic::Request::new(ConfigRequest {});
+                                match timeout(
+                                    NETWORK_REQUEST_TIMEOUT,
+                                    validator_client.get_builder_config(request),
+                                )
+                                .await
+                                {
+                                    Ok(Ok(response)) => {
+                                        let resp_config = response.into_inner();
+                                        *config.lock().unwrap() = Some(resp_config);
+                                        metrics.builder_config_received.fetch_add(1, Relaxed);
+                                    }
+                                    Ok(Err(e)) => {
+                                        error!("Failed to get config: {e:?}");
+                                    }
+                                    Err(_) => error!("Timed out getting config"),
+                                }
+                            }
+                        }));
+                    }
 
                     match inbound {
                         SchedulerResponseV0 { resp: Some(Resp::HeartBeat(_)), .. } => {
-                            last_heartbeat = Some(std::time::Instant::now());
+                            last_heartbeat = Some(Instant::now());
                             metrics.heartbeat_received.fetch_add(1, Relaxed);
                         }
                         SchedulerResponseV0 { resp: Some(Resp::MultipleAtomicTxnBatch(batches)), .. } => {
                             for batch in batches.batches {
                                 metrics.bundle_received.fetch_add(1, Relaxed);
-                                let _ = batch_sender.try_send(batch).inspect_err(|_| {
+                                if batch_sender.try_send(batch).is_err() {
                                     metrics.bundle_forward_to_scheduler_fail.fetch_add(1, Relaxed);
-                                });
+                                }
+                            }
+                        }
+                        SchedulerResponseV0 { resp: Some(Resp::Ping(ping)), .. } => {
+                            let outbound = SchedulerMessageV0 {
+                                msg: Some(Msg::Pong(Pong { id: ping.id })),
+                            };
+                            if outbound_sender.try_send(v0_to_versioned_proto(outbound)).is_err() {
+                                metrics.outbound_fail.fetch_add(1, Relaxed);
+                            } else {
+                                metrics.outbound_sent.fetch_add(1, Relaxed);
                             }
                         }
                         _ => {}
                     }
                 }
+                outbound = outbound_receiver.recv(), if post_auth_client.is_none() => {
+                    let Some(outbound) = outbound else {
+                        error!("BAM outbound channel closed");
+                        break;
+                    };
+                    let leader_state_to_send = match outbound {
+                        BamOutboundMessage::LeaderState(leader_state) => Some(leader_state),
+                        BamOutboundMessage::AtomicTxnBatchResult(result) => {
+                            let mut results = Vec::with_capacity(MAX_OUTBOUND_RESULT_BATCH_SIZE);
+                            results.push(result);
+                            let mut leader_state_to_send = None;
+
+                            while results.len() < MAX_OUTBOUND_RESULT_BATCH_SIZE {
+                                match outbound_receiver.try_recv() {
+                                    Ok(BamOutboundMessage::AtomicTxnBatchResult(result)) => {
+                                        results.push(result);
+                                    }
+                                    Ok(BamOutboundMessage::LeaderState(leader_state)) => {
+                                        leader_state_to_send = Some(leader_state);
+                                        break;
+                                    }
+                                    Err(_) => break,
+                                }
+                            }
+
+                            metrics.bundleresult_sent.fetch_add(results.len() as u64, Relaxed);
+                            let outbound = SchedulerMessageV0 {
+                                msg: Some(Msg::MultipleAtomicTxnBatchResult(
+                                    MultipleAtomicTxnBatchResult { results },
+                                )),
+                            };
+                            if outbound_sender.try_send(v0_to_versioned_proto(outbound)).is_err() {
+                                metrics.outbound_fail.fetch_add(1, Relaxed);
+                            } else {
+                                metrics.outbound_sent.fetch_add(1, Relaxed);
+                            }
+                            leader_state_to_send
+                        }
+                    };
+
+                    if let Some(leader_state) = leader_state_to_send {
+                        metrics.leaderstate_sent.fetch_add(1, Relaxed);
+                        let outbound = SchedulerMessageV0 {
+                            msg: Some(Msg::LeaderState(leader_state)),
+                        };
+                        if outbound_sender.try_send(v0_to_versioned_proto(outbound)).is_err() {
+                            metrics.outbound_fail.fetch_add(1, Relaxed);
+                        } else {
+                            metrics.outbound_sent.fetch_add(1, Relaxed);
+                        }
+                    }
+
+                }
             }
         }
         connection_exit.store(true, Relaxed);
         is_healthy.store(false, Relaxed);
-        let Some((refresh_config_task, outbound_task)) = post_auth_tasks.as_mut() else {
-            return;
-        };
-        tokio::join!(
-            Self::wait_or_abort_child("refresh_config", refresh_config_task),
-            Self::wait_or_abort_child("outbound", outbound_task),
-        );
-    }
 
-    async fn wait_or_abort_child(task_name: &str, task: &mut tokio::task::JoinHandle<()>) {
-        match timeout(CHILD_TASK_SHUTDOWN_GRACE, &mut *task).await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                if !e.is_cancelled() {
-                    warn!("BAM task {task_name} error: {e:?}");
-                }
-            }
-            Err(_) => {
-                warn!(
-                    "BAM task {task_name} did not exit within {CHILD_TASK_SHUTDOWN_GRACE:?}; \
-                     aborting"
-                );
-                task.abort();
-                let _ = task.await;
-            }
-        }
-    }
-
-    fn send_batch_results(
-        outbound_sender: &mut mpsc::Sender<SchedulerMessage>,
-        results: Vec<jito_protos::proto::bam_types::AtomicTxnBatchResult>,
-        metrics: &BamConnectionMetrics,
-    ) {
-        if !results.is_empty() {
-            let outbound = SchedulerMessageV0 {
-                msg: Some(Msg::MultipleAtomicTxnBatchResult(
-                    jito_protos::proto::bam_types::MultipleAtomicTxnBatchResult { results },
-                )),
-            };
-            if outbound_sender
-                .try_send(v0_to_versioned_proto(outbound))
-                .is_err()
-            {
-                metrics.outbound_fail.fetch_add(1, Relaxed);
-            } else {
-                metrics.outbound_sent.fetch_add(1, Relaxed);
-            }
-        }
-    }
-
-    async fn refresh_config_task(
-        connection_exit: Arc<AtomicBool>,
-        config: Arc<Mutex<Option<ConfigResponse>>>,
-        mut validator_client: BamNodeApiClient<tonic::transport::channel::Channel>,
-        metrics: Arc<BamConnectionMetrics>,
-    ) {
-        let mut interval = interval(REFRESH_CONFIG_INTERVAL);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-        while !connection_exit.load(Relaxed) {
-            tokio::select! {
-                _ = interval.tick() => {
-                    let request = tonic::Request::new(ConfigRequest {});
-                    match timeout(
-                        NETWORK_REQUEST_TIMEOUT,
-                        validator_client.get_builder_config(request),
-                    )
-                    .await
-                    {
-                        Ok(Ok(response)) => {
-                            let resp_config = response.into_inner();
-                            *config.lock().unwrap() = Some(resp_config);
-                            metrics.builder_config_received.fetch_add(1, Relaxed);
-                        }
-                        Ok(Err(e)) => {
-                            error!("Failed to get config: {e:?}");
-                        }
-                        Err(_) => error!("Timed out getting config"),
+        if let Some(refresh_config_task) = refresh_config_task.as_mut() {
+            match timeout(CHILD_TASK_SHUTDOWN_GRACE, &mut *refresh_config_task).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    if !e.is_cancelled() {
+                        warn!("BAM task refresh_config error: {e:?}");
                     }
                 }
-            }
-        }
-    }
-
-    async fn outbound_task(
-        connection_exit: Arc<AtomicBool>,
-        mut outbound_sender: mpsc::Sender<SchedulerMessage>,
-        outbound_receiver: crossbeam_channel::Receiver<BamOutboundMessage>,
-        metrics: Arc<BamConnectionMetrics>,
-    ) {
-        let mut outbound_tick_interval = interval(OUTBOUND_TICK_INTERVAL);
-        outbound_tick_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
-
-        let mut waiting_results = Vec::new();
-
-        while !connection_exit.load(Relaxed) {
-            tokio::select! {
-                _ = outbound_tick_interval.tick() => {
-                    while let Ok(outbound) = outbound_receiver.try_recv() {
-                        match outbound {
-                            BamOutboundMessage::LeaderState(leader_state) => {
-                                metrics.leaderstate_sent.fetch_add(1, Relaxed);
-                                let outbound = SchedulerMessageV0 {
-                                    msg: Some(Msg::LeaderState(leader_state)),
-                                };
-                                if outbound_sender.try_send(v0_to_versioned_proto(outbound)).is_err() {
-                                    metrics.outbound_fail.fetch_add(1, Relaxed);
-                                } else {
-                                    metrics.outbound_sent.fetch_add(1, Relaxed);
-                                }
-                            }
-                            BamOutboundMessage::AtomicTxnBatchResult(result) => {
-                                metrics.bundleresult_sent.fetch_add(1, Relaxed);
-                                waiting_results.push(result);
-                                if waiting_results.len() >= MAX_WAITING_RESULTS {
-                                    Self::send_batch_results(&mut outbound_sender, std::mem::take(&mut waiting_results), metrics.as_ref());
-                                }
-                            }
-                            BamOutboundMessage::Ping(id) => {
-                                metrics.ping_received.fetch_add(1, Relaxed);
-                                metrics.last_ping_id_received.store(id, Relaxed);
-                                let pong_message_outbound = SchedulerMessageV0 {
-                                    msg: Some(Msg::Pong(Pong { id })),
-                                };
-                                if outbound_sender.try_send(v0_to_versioned_proto(pong_message_outbound)).is_err() {
-                                    metrics.outbound_pong_send_fail.fetch_add(1, Relaxed);
-                                } else {
-                                    metrics.outbound_pong_sent.fetch_add(1, Relaxed);
-                                    metrics.last_ping_id_sent.store(id, Relaxed);
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                    Self::send_batch_results(&mut outbound_sender, std::mem::take(&mut waiting_results), metrics.as_ref());
+                Err(_) => {
+                    warn!(
+                        "BAM task refresh_config did not exit within \
+                         {CHILD_TASK_SHUTDOWN_GRACE:?}; aborting"
+                    );
+                    refresh_config_task.abort();
+                    let _ = refresh_config_task.await;
                 }
             }
         }
-    }
 
-    fn sign_message(keypair: &Keypair, message: &[u8]) -> Option<String> {
-        let slot_signature = keypair.try_sign_message(message).ok()?;
-        let slot_signature = slot_signature.to_string();
-        Some(slot_signature)
+        outbound_receiver
     }
 
     pub fn is_healthy(&self) -> bool {
@@ -403,12 +353,27 @@ impl BamConnection {
             if self.connection_task.is_finished() {
                 return false;
             }
-            if self.is_healthy() && self.get_latest_config().is_some() {
+            if self.get_latest_config().is_some() {
                 return true;
             }
             std::thread::sleep(WAIT_SLEEP_DURATION);
         }
         false
+    }
+
+    pub async fn shutdown(mut self) -> mpsc::Receiver<BamOutboundMessage> {
+        self.is_healthy.store(false, Relaxed);
+        self.connection_exit.store(true, Relaxed);
+
+        let shutdown_start = Instant::now();
+        let outbound_receiver = (&mut self.connection_task)
+            .await
+            .expect("BAM connection task should return outbound receiver");
+        let shutdown_duration = shutdown_start.elapsed();
+        if shutdown_duration > CONNECTION_TASK_DROP_GRACE {
+            info!("BAM connection task shutdown took {shutdown_duration:?}");
+        }
+        outbound_receiver
     }
 
     pub fn get_latest_config(&self) -> Option<ConfigResponse> {
@@ -457,7 +422,11 @@ impl BamConnection {
         let challenge_bytes = challenge_to_sign.as_bytes();
         let to_sign = Self::labeled_bytes(challenge_bytes);
 
-        let signature = Self::sign_message(cluster_info.keypair().as_ref(), &to_sign)?;
+        let signature = cluster_info
+            .keypair()
+            .try_sign_message(&to_sign)
+            .ok()?
+            .to_string();
 
         Some(AuthProof {
             challenge_to_sign,
@@ -480,6 +449,9 @@ impl Drop for BamConnection {
     fn drop(&mut self) {
         self.is_healthy.store(false, Relaxed);
         self.connection_exit.store(true, Relaxed);
+        if self.connection_task.is_finished() {
+            return;
+        }
         std::thread::sleep(CONNECTION_TASK_DROP_GRACE);
         if !self.connection_task.is_finished() {
             self.connection_task.abort();
@@ -501,12 +473,6 @@ struct BamConnectionMetrics {
     heartbeat_sent: AtomicU64,
     outbound_sent: AtomicU64,
     outbound_fail: AtomicU64,
-
-    ping_received: AtomicU64,
-    last_ping_id_received: AtomicU32,
-    outbound_pong_sent: AtomicU64,
-    last_ping_id_sent: AtomicU32,
-    outbound_pong_send_fail: AtomicU64,
 }
 
 impl BamConnectionMetrics {
@@ -521,12 +487,9 @@ impl BamConnectionMetrics {
             || self.heartbeat_sent.load(Relaxed) > 0
             || self.outbound_sent.load(Relaxed) > 0
             || self.outbound_fail.load(Relaxed) > 0
-            || self.ping_received.load(Relaxed) > 0
-            || self.outbound_pong_send_fail.load(Relaxed) > 0
-            || self.outbound_pong_sent.load(Relaxed) > 0
     }
 
-    pub fn report(&self) {
+    fn report(&self) {
         if !self.has_data() {
             return;
         }
@@ -581,31 +544,6 @@ impl BamConnectionMetrics {
                 "outbound_fail",
                 self.outbound_fail.swap(0, Relaxed) as i64,
                 i64
-            ),
-            (
-                "ping_received",
-                self.ping_received.swap(0, Relaxed) as i64,
-                i64
-            ),
-            (
-                "last_ping_id_received",
-                self.last_ping_id_received.load(Relaxed),
-                i64
-            ),
-            (
-                "outbound_pong_sent_count",
-                self.outbound_pong_sent.swap(0, Relaxed) as i64,
-                i64
-            ),
-            (
-                "last_ping_id_sent",
-                self.last_ping_id_sent.load(Relaxed),
-                i64
-            ),
-            (
-                "outbound_pong_send_fail_count",
-                self.outbound_pong_send_fail.swap(0, Relaxed) as i64,
-                i64
             )
         );
     }
@@ -613,8 +551,6 @@ impl BamConnectionMetrics {
 
 #[derive(Error, Debug)]
 pub enum TryInitError {
-    #[error("Currently in leader slot")]
-    MidLeaderSlotError,
     #[error("Failed to connect to endpoint: {0}")]
     EndpointConnectError(#[from] tonic::transport::Error),
     #[error("Connection attempt timed out: {0}")]

--- a/core/src/bam_dependencies.rs
+++ b/core/src/bam_dependencies.rs
@@ -13,13 +13,12 @@ use {
     solana_runtime::bank_forks::BankForks,
     solana_turbine::ShredReceiverAddresses,
     std::sync::RwLock,
+    tokio::sync::mpsc,
 };
 
 pub enum BamOutboundMessage {
     AtomicTxnBatchResult(bam_types::AtomicTxnBatchResult),
-    Heartbeat(bam_types::ValidatorHeartBeat),
     LeaderState(bam_types::LeaderState),
-    Ping(u32),
 }
 
 #[repr(u8)]
@@ -48,8 +47,7 @@ pub struct BamDependencies {
     pub batch_sender: crossbeam_channel::Sender<bam_types::AtomicTxnBatch>,
     pub batch_receiver: crossbeam_channel::Receiver<bam_types::AtomicTxnBatch>,
 
-    pub outbound_sender: crossbeam_channel::Sender<BamOutboundMessage>,
-    pub outbound_receiver: crossbeam_channel::Receiver<BamOutboundMessage>,
+    pub outbound_sender: mpsc::Sender<BamOutboundMessage>,
 
     pub cluster_info: Arc<ClusterInfo>,
     pub block_builder_fee_info: Arc<ArcSwap<BlockBuilderFeeInfo>>,

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -18,7 +18,7 @@ use {
         bam_connection::{
             BamConnection, MAX_DURATION_BETWEEN_NODE_HEARTBEATS, WAIT_TO_RECONNECT_DURATION,
         },
-        bam_dependencies::{BamConnectionState, BamDependencies},
+        bam_dependencies::{BamConnectionState, BamDependencies, BamOutboundMessage},
         proxy::block_engine_stage::BlockBuilderFeeInfo,
     },
     arc_swap::ArcSwap,
@@ -34,6 +34,7 @@ use {
     solana_tls_utils::NotifyKeyUpdate,
     solana_turbine::{MAX_SHRED_RECEIVER_ADDRESSES, ShredReceiverAddresses},
     solana_version::ClientId,
+    tokio::sync::mpsc,
 };
 
 pub struct BamConnectionIdentityUpdater {
@@ -73,6 +74,7 @@ impl BamManager {
         exit: Arc<AtomicBool>,
         bam_url: Arc<ArcSwap<Option<String>>>,
         dependencies: BamDependencies,
+        outbound_receiver: mpsc::Receiver<BamOutboundMessage>,
         poh_recorder: Arc<RwLock<PohRecorder>>,
         identity_notifiers: Arc<RwLock<KeyUpdaters>>,
     ) -> Self {
@@ -97,6 +99,7 @@ impl BamManager {
                     exit,
                     bam_url,
                     dependencies,
+                    outbound_receiver,
                     poh_recorder,
                     identity_changed,
                     new_identity,
@@ -109,6 +112,7 @@ impl BamManager {
         exit: Arc<AtomicBool>,
         bam_url: Arc<ArcSwap<Option<String>>>,
         dependencies: BamDependencies,
+        outbound_receiver: mpsc::Receiver<BamOutboundMessage>,
         poh_recorder: Arc<RwLock<PohRecorder>>,
         identity_changed: Arc<AtomicBool>,
         new_identity: Arc<ArcSwap<Option<Pubkey>>>,
@@ -120,6 +124,7 @@ impl BamManager {
             .unwrap();
 
         let mut current_connection = None;
+        let mut outbound_receiver = Some(outbound_receiver);
         let mut cached_builder_config = None;
         let shared_leader_state = poh_recorder.read().unwrap().shared_leader_state();
 
@@ -165,7 +170,7 @@ impl BamManager {
                         url.clone(),
                         dependencies.cluster_info.clone(),
                         dependencies.batch_sender.clone(),
-                        dependencies.outbound_receiver.clone(),
+                        &mut outbound_receiver,
                     ));
                     let connection = match result {
                         Ok(connection) => connection,
@@ -189,6 +194,7 @@ impl BamManager {
                         );
                         cached_builder_config = None;
                         Self::set_bam_disconnected(&dependencies);
+                        outbound_receiver = Some(runtime.block_on(connection.shutdown()));
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
                     }
@@ -212,15 +218,12 @@ impl BamManager {
                 }
             };
 
-            if !connection.is_healthy() {
+            let disconnect = if !connection.is_healthy() {
                 cached_builder_config = None;
                 Self::set_bam_disconnected(&dependencies);
                 warn!("BAM connection unhealthy");
-                continue;
-            }
-
-            // Connected path: drop current connection now; disconnected path performs wait/reconnect.
-            if Self::handle_identity_change(
+                true
+            } else if Self::handle_identity_change(
                 &identity_changed,
                 &new_identity,
                 &dependencies,
@@ -228,19 +231,25 @@ impl BamManager {
                 &mut cached_builder_config,
                 false,
             ) {
-                continue;
-            }
-
-            // if url changed or cleared, then disconnect
-            let configured_bam_url = bam_url.load();
-            if configured_bam_url.as_deref() != Some(connection.url()) {
-                cached_builder_config = None;
-                Self::set_bam_disconnected(&dependencies);
-                if let Some(new_url) = configured_bam_url.as_deref() {
-                    info!("BAM URL changed, connecting to new URL: {new_url}");
+                true
+            } else {
+                let configured_bam_url = bam_url.load();
+                if configured_bam_url.as_deref() == Some(connection.url()) {
+                    false
                 } else {
-                    info!("BAM URL cleared, disconnecting");
+                    cached_builder_config = None;
+                    Self::set_bam_disconnected(&dependencies);
+                    if let Some(new_url) = configured_bam_url.as_deref() {
+                        info!("BAM URL changed, connecting to new URL: {new_url}");
+                    } else {
+                        info!("BAM URL cleared, disconnecting");
+                    }
+                    true
                 }
+            };
+
+            if disconnect {
+                outbound_receiver = Some(runtime.block_on(connection.shutdown()));
                 continue;
             }
 
@@ -273,9 +282,9 @@ impl BamManager {
             if let Some(bank) = shared_leader_state.load().working_bank() {
                 if !bank.is_frozen() {
                     let leader_state = Self::generate_leader_state(bank);
-                    let _ = dependencies.outbound_sender.try_send(
-                        crate::bam_dependencies::BamOutboundMessage::LeaderState(leader_state),
-                    );
+                    let _ = dependencies
+                        .outbound_sender
+                        .try_send(BamOutboundMessage::LeaderState(leader_state));
                 }
             }
 

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -30,7 +30,7 @@ use {
     },
     ahash::HashSet,
     bytes::Bytes,
-    crossbeam_channel::{RecvTimeoutError, Sender, TryRecvError},
+    crossbeam_channel::{RecvTimeoutError, TryRecvError},
     histogram::Histogram,
     itertools::Itertools,
     jito_protos::proto::bam_types::{
@@ -63,6 +63,7 @@ use {
         },
         time::{Duration, Instant},
     },
+    tokio::sync::mpsc::Sender as TokioSender,
 };
 
 type PrevalidationResult = Result<(usize, bool, u32, u64), (Reason, u32)>;
@@ -70,7 +71,7 @@ type VerifyResult = Result<(Vec<SharedBytes>, bool, u32, u64), (Reason, u32)>;
 
 pub struct BamReceiveAndBuffer {
     bam_enabled: Arc<AtomicU8>,
-    response_sender: Sender<BamOutboundMessage>,
+    response_sender: TokioSender<BamOutboundMessage>,
     parsed_batch_receiver: crossbeam_channel::Receiver<ParsedBatch>,
     recv_stats_receiver: crossbeam_channel::Receiver<ReceivingStats>,
     parsing_thread: Option<std::thread::JoinHandle<()>>,
@@ -95,7 +96,7 @@ impl BamReceiveAndBuffer {
         exit: Arc<AtomicBool>,
         bam_enabled: Arc<AtomicU8>,
         bundle_receiver: crossbeam_channel::Receiver<AtomicTxnBatch>,
-        response_sender: Sender<BamOutboundMessage>,
+        response_sender: TokioSender<BamOutboundMessage>,
         bank_forks: Arc<RwLock<BankForks>>,
         shared_leader_state: Option<SharedLeaderState>,
         blacklisted_accounts: HashSet<Pubkey>,
@@ -133,7 +134,7 @@ impl BamReceiveAndBuffer {
         bundle_receiver: crossbeam_channel::Receiver<AtomicTxnBatch>,
         parsed_batch_sender: crossbeam_channel::Sender<ParsedBatch>,
         recv_stats_sender: crossbeam_channel::Sender<ReceivingStats>,
-        response_sender: Sender<BamOutboundMessage>,
+        response_sender: TokioSender<BamOutboundMessage>,
         bank_forks: Arc<RwLock<BankForks>>,
         shared_leader_state: Option<SharedLeaderState>,
         blacklisted_accounts: HashSet<Pubkey>,
@@ -1146,11 +1147,11 @@ mod tests {
         Arc<AtomicBool>,
         BamReceiveAndBuffer,
         TransactionStateContainer<RuntimeTransaction<ResolvedTransactionView<SharedBytes>>>,
-        crossbeam_channel::Receiver<BamOutboundMessage>,
+        tokio::sync::mpsc::Receiver<BamOutboundMessage>,
     ) {
         let exit: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let (response_sender, response_receiver) =
-            crossbeam_channel::unbounded::<BamOutboundMessage>();
+            tokio::sync::mpsc::channel::<BamOutboundMessage>(100);
         let receive_and_buffer = BamReceiveAndBuffer::new(
             exit.clone(),
             Arc::new(AtomicU8::new(BamConnectionState::Connected as u8)),
@@ -1222,7 +1223,7 @@ mod tests {
             Arc<AtomicBool>,
             R,
             R::Container,
-            Receiver<BamOutboundMessage>,
+            tokio::sync::mpsc::Receiver<BamOutboundMessage>,
         ),
     ) {
         let (sender, receiver) = unbounded();
@@ -1261,7 +1262,7 @@ mod tests {
     fn test_receive_and_buffer_invalid_packet() {
         let (bank_forks, _mint_keypair) = test_bank_forks();
         let (sender, receiver) = unbounded();
-        let (exit, mut receive_and_buffer, mut container, response_receiver) =
+        let (exit, mut receive_and_buffer, mut container, mut response_receiver) =
             setup_bam_receive_and_buffer(receiver, bank_forks.clone(), HashSet::new());
 
         let bundle = AtomicTxnBatch {
@@ -1280,7 +1281,7 @@ mod tests {
 
         assert_eq!(num_received, 0);
         verify_container(&mut container, 0);
-        let response = response_receiver.recv().unwrap();
+        let response = response_receiver.blocking_recv().unwrap();
         assert!(matches!(
             response,
             BamOutboundMessage::AtomicTxnBatchResult(txn_batch_result) if txn_batch_result.seq_id == 1 &&

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -43,6 +43,7 @@ use {
         sync::{Arc, RwLock},
         time::Instant,
     },
+    tokio::sync::mpsc::Sender as TokioSender,
 };
 
 type SchedulerPrioGraph = PrioGraph<
@@ -65,7 +66,7 @@ pub const MAX_PACKETS_PER_BUNDLE: usize = 5; // copied from BundleStorage::MAX_P
 pub struct BamScheduler<Tx: TransactionWithMeta> {
     consume_work_sender: Sender<ConsumeWork<Tx>>,
     finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
-    response_sender: Sender<BamOutboundMessage>,
+    response_sender: TokioSender<BamOutboundMessage>,
 
     next_batch_id: u64,
     inflight_batch_info: IntMap<TransactionBatchId, InflightBatchInfo>,
@@ -99,7 +100,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
     pub fn new(
         consume_work_sender: Sender<ConsumeWork<Tx>>,
         finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
-        response_sender: Sender<BamOutboundMessage>,
+        response_sender: TokioSender<BamOutboundMessage>,
         bank_forks: Arc<RwLock<BankForks>>,
     ) -> Self {
         Self {
@@ -843,7 +844,7 @@ mod tests {
         finished_consume_work_sender: crossbeam_channel::Sender<
             FinishedConsumeWork<RuntimeTransaction<SanitizedTransaction>>,
         >,
-        response_receiver: crossbeam_channel::Receiver<BamOutboundMessage>,
+        response_receiver: tokio::sync::mpsc::Receiver<BamOutboundMessage>,
     }
 
     fn create_test_scheduler(
@@ -852,7 +853,7 @@ mod tests {
     ) -> TestScheduler {
         let (consume_work_sender, consume_work_receiver) = unbounded();
         let (finished_consume_work_sender, finished_consume_work_receiver) = unbounded();
-        let (response_sender, response_receiver) = unbounded();
+        let (response_sender, response_receiver) = tokio::sync::mpsc::channel(100);
         let scheduler = BamScheduler::new(
             consume_work_sender,
             finished_consume_work_receiver,
@@ -959,7 +960,7 @@ mod tests {
             mut scheduler,
             consume_work_receivers,
             finished_consume_work_sender,
-            response_receiver,
+            mut response_receiver,
         } = create_test_scheduler(4, &bank_forks);
         scheduler.extra_checks_enabled = false;
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -1140,11 +1140,8 @@ mod tests {
 
     #[test]
     fn test_bam_controller_process_transactions_no_panic() {
-        use crate::{
-            bam_dependencies::BamOutboundMessage,
-            banking_stage::transaction_scheduler::{
-                bam_receive_and_buffer::BamReceiveAndBuffer, bam_scheduler::BamScheduler,
-            },
+        use crate::banking_stage::transaction_scheduler::{
+            bam_receive_and_buffer::BamReceiveAndBuffer, bam_scheduler::BamScheduler,
         };
 
         let GenesisConfigInfo {
@@ -1162,7 +1159,7 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
 
         let (_bundle_sender, bundle_receiver) = unbounded();
-        let (response_sender, _response_receiver) = unbounded::<BamOutboundMessage>();
+        let (response_sender, _response_receiver) = tokio::sync::mpsc::channel(100);
 
         let receive_and_buffer = BamReceiveAndBuffer::new(
             exit.clone(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -395,13 +395,12 @@ impl Tpu {
             Arc::new(filter_keys)
         };
         let (bam_batch_sender, bam_batch_receiver) = bounded(100_000);
-        let (bam_outbound_sender, bam_outbound_receiver) = bounded(100_000);
+        let (bam_outbound_sender, bam_outbound_receiver) = mpsc::channel(100_000);
         let bam_dependencies = BamDependencies {
             bam_enabled: bam_enabled.clone(),
             batch_sender: bam_batch_sender,
             batch_receiver: bam_batch_receiver,
             outbound_sender: bam_outbound_sender,
-            outbound_receiver: bam_outbound_receiver,
             cluster_info: cluster_info.clone(),
             block_builder_fee_info: Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo::default())),
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
@@ -476,6 +475,7 @@ impl Tpu {
             exit.clone(),
             bam_url,
             bam_dependencies,
+            bam_outbound_receiver,
             poh_recorder.clone(),
             key_notifiers.clone(),
         );

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -9,8 +9,8 @@ use {
             scheduler_response_v0::Resp,
         },
         bam_types::{
-            AtomicTxnBatch, BamConfig, BlockEngineBuilderConfig, BuilderHeartBeat,
-            MultipleAtomicTxnBatch, Packet, Socket,
+            AtomicTxnBatch, AtomicTxnBatchResult, BamConfig, BlockEngineBuilderConfig,
+            BuilderHeartBeat, MultipleAtomicTxnBatch, Packet, Socket,
         },
     },
     solana_core::bam_dependencies::BamOutboundMessage,
@@ -78,8 +78,7 @@ struct MockBamNode {
     config: Arc<Mutex<MockConfig>>,
     batch_to_send: Arc<Mutex<Option<AtomicTxnBatch>>>,
     reject_scheduler_stream: bool,
-    #[allow(dead_code)]
-    outbound_tx: Arc<Mutex<Option<mpsc::Sender<AtomicTxnBatch>>>>,
+    outbound_result_batch_size: Arc<AtomicU64>,
 }
 
 impl MockBamNode {
@@ -97,7 +96,7 @@ impl MockBamNode {
             config: Arc::new(Mutex::new(MockConfig::default())),
             batch_to_send: Arc::new(Mutex::new(None)),
             reject_scheduler_stream,
-            outbound_tx: Arc::new(Mutex::new(None)),
+            outbound_result_batch_size: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -160,6 +159,7 @@ impl BamNodeApi for MockBamNode {
         let scheduler_stream_rejections = self.scheduler_stream_rejections.clone();
         let batch_to_send = self.batch_to_send.clone();
         let reject_scheduler_stream = self.reject_scheduler_stream;
+        let outbound_result_batch_size = self.outbound_result_batch_size.clone();
 
         tokio::spawn(async move {
             let mut authenticated = false;
@@ -194,22 +194,39 @@ impl BamNodeApi for MockBamNode {
                 return;
             }
 
+            let mut heartbeat_interval = tokio::time::interval(heartbeat_interval);
+            heartbeat_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            heartbeat_interval.tick().await;
+
             loop {
-                tokio::time::sleep(heartbeat_interval).await;
+                tokio::select! {
+                    msg = inbound.message() => {
+                        let Ok(Some(msg)) = msg else {
+                            break;
+                        };
+                        if let Some(VersionedMsg::V0(v0)) = msg.versioned_msg {
+                            if let Some(Msg::MultipleAtomicTxnBatchResult(results)) = v0.msg {
+                                outbound_result_batch_size
+                                    .store(results.results.len() as u64, Ordering::Relaxed);
+                            }
+                        }
+                    }
+                    _ = heartbeat_interval.tick() => {
+                        if send_heartbeats.load(Ordering::Relaxed)
+                            && tx.send(Ok(heartbeat_response())).await.is_err()
+                        {
+                            break;
+                        }
 
-                if send_heartbeats.load(Ordering::Relaxed)
-                    && tx.send(Ok(heartbeat_response())).await.is_err()
-                {
-                    break;
-                }
-
-                let batch = batch_to_send.lock().unwrap().take();
-                if let Some(batch) = batch {
-                    let resp = v0_response(Resp::MultipleAtomicTxnBatch(MultipleAtomicTxnBatch {
-                        batches: vec![batch],
-                    }));
-                    if tx.send(Ok(resp)).await.is_err() {
-                        break;
+                        let batch = batch_to_send.lock().unwrap().take();
+                        if let Some(batch) = batch {
+                            let resp = v0_response(Resp::MultipleAtomicTxnBatch(MultipleAtomicTxnBatch {
+                                batches: vec![batch],
+                            }));
+                            if tx.send(Ok(resp)).await.is_err() {
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -228,6 +245,7 @@ struct MockServerHandle {
     #[allow(dead_code)]
     config: Arc<Mutex<MockConfig>>,
     batch_to_send: Arc<Mutex<Option<AtomicTxnBatch>>>,
+    outbound_result_batch_size: Arc<AtomicU64>,
 }
 
 async fn start_mock_server(
@@ -251,6 +269,7 @@ async fn start_mock_server(
         scheduler_stream_rejections: Arc::clone(&mock.scheduler_stream_rejections),
         config: Arc::clone(&mock.config),
         batch_to_send: Arc::clone(&mock.batch_to_send),
+        outbound_result_batch_size: Arc::clone(&mock.outbound_result_batch_size),
     };
 
     let server_started = Arc::new(AtomicBool::new(false));
@@ -284,12 +303,12 @@ fn create_test_cluster_info() -> Arc<ClusterInfo> {
 fn create_channels() -> (
     crossbeam_channel::Sender<AtomicTxnBatch>,
     crossbeam_channel::Receiver<AtomicTxnBatch>,
-    crossbeam_channel::Sender<BamOutboundMessage>,
-    crossbeam_channel::Receiver<BamOutboundMessage>,
+    mpsc::Sender<BamOutboundMessage>,
+    Option<mpsc::Receiver<BamOutboundMessage>>,
 ) {
     let (batch_tx, batch_rx) = crossbeam_channel::unbounded();
-    let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded();
-    (batch_tx, batch_rx, outbound_tx, outbound_rx)
+    let (outbound_tx, outbound_rx) = mpsc::channel(100_000);
+    (batch_tx, batch_rx, outbound_tx, Some(outbound_rx))
 }
 
 async fn wait_until_healthy(
@@ -298,7 +317,7 @@ async fn wait_until_healthy(
 ) -> bool {
     let start = std::time::Instant::now();
     while start.elapsed() < timeout {
-        if connection.is_healthy() && connection.get_latest_config().is_some() {
+        if connection.get_latest_config().is_some() {
             return true;
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -316,13 +335,13 @@ mod bam_connection_tests {
         let server = start_mock_server(send_heartbeats, Duration::from_secs(2), false).await;
 
         let cluster_info = create_test_cluster_info();
-        let (batch_tx, _batch_rx, _outbound_tx, outbound_rx) = create_channels();
+        let (batch_tx, _batch_rx, _outbound_tx, mut outbound_rx) = create_channels();
 
         let connection = BamConnection::try_init(
             format!("http://{}", server.addr),
             cluster_info,
             batch_tx,
-            outbound_rx,
+            &mut outbound_rx,
         )
         .await
         .expect("should connect");
@@ -342,13 +361,13 @@ mod bam_connection_tests {
             start_mock_server(send_heartbeats.clone(), Duration::from_millis(500), false).await;
 
         let cluster_info = create_test_cluster_info();
-        let (batch_tx, _batch_rx, _outbound_tx, outbound_rx) = create_channels();
+        let (batch_tx, _batch_rx, _outbound_tx, mut outbound_rx) = create_channels();
 
         let connection = BamConnection::try_init(
             format!("http://{}", server.addr),
             cluster_info,
             batch_tx,
-            outbound_rx,
+            &mut outbound_rx,
         )
         .await
         .expect("should connect");
@@ -373,13 +392,13 @@ mod bam_connection_tests {
         let server = start_mock_server(send_heartbeats, Duration::from_secs(2), false).await;
 
         let cluster_info = create_test_cluster_info();
-        let (batch_tx, _batch_rx, _outbound_tx, outbound_rx) = create_channels();
+        let (batch_tx, _batch_rx, _outbound_tx, mut outbound_rx) = create_channels();
 
         let connection = BamConnection::try_init(
             format!("http://{}", server.addr),
             cluster_info,
             batch_tx,
-            outbound_rx,
+            &mut outbound_rx,
         )
         .await
         .expect("should connect");
@@ -393,13 +412,13 @@ mod bam_connection_tests {
     #[tokio::test]
     async fn test_connection_fails_when_server_unreachable() {
         let cluster_info = create_test_cluster_info();
-        let (batch_tx, _batch_rx, _outbound_tx, outbound_rx) = create_channels();
+        let (batch_tx, _batch_rx, _outbound_tx, mut outbound_rx) = create_channels();
 
         let result = BamConnection::try_init(
             "http://127.0.0.1:1".to_string(), // Invalid port
             cluster_info,
             batch_tx,
-            outbound_rx,
+            &mut outbound_rx,
         )
         .await;
 
@@ -416,13 +435,13 @@ mod bam_connection_tests {
         .await;
 
         let cluster_info = create_test_cluster_info();
-        let (batch_tx, _batch_rx, _outbound_tx, outbound_rx) = create_channels();
+        let (batch_tx, _batch_rx, _outbound_tx, mut outbound_rx) = create_channels();
 
         let connection = BamConnection::try_init(
             format!("http://{}", server.addr),
             cluster_info,
             batch_tx,
-            outbound_rx,
+            &mut outbound_rx,
         )
         .await
         .expect("transport should connect before auth rejection");
@@ -460,13 +479,13 @@ mod bam_connection_tests {
         let server = start_mock_server(send_heartbeats, Duration::from_secs(1), false).await;
 
         let cluster_info = create_test_cluster_info();
-        let (batch_tx, _batch_rx, _outbound_tx, outbound_rx) = create_channels();
+        let (batch_tx, _batch_rx, _outbound_tx, mut outbound_rx) = create_channels();
 
         let connection = BamConnection::try_init(
             format!("http://{}", server.addr),
             cluster_info,
             batch_tx,
-            outbound_rx,
+            &mut outbound_rx,
         )
         .await
         .expect("should connect");
@@ -484,16 +503,27 @@ mod bam_connection_tests {
         let server = start_mock_server(send_heartbeats, Duration::from_millis(100), false).await;
 
         let cluster_info = create_test_cluster_info();
-        let (batch_tx, batch_rx, _outbound_tx, outbound_rx) = create_channels();
+        let (batch_tx, batch_rx, outbound_tx, mut outbound_rx) = create_channels();
 
         let connection = BamConnection::try_init(
             format!("http://{}", server.addr),
             cluster_info,
             batch_tx,
-            outbound_rx,
+            &mut outbound_rx,
         )
         .await
         .expect("should connect");
+
+        for seq_id in 0..3 {
+            outbound_tx
+                .try_send(BamOutboundMessage::AtomicTxnBatchResult(
+                    AtomicTxnBatchResult {
+                        seq_id,
+                        result: None,
+                    },
+                ))
+                .expect("outbound result should queue");
+        }
 
         assert!(wait_until_healthy(&connection, Duration::from_secs(10)).await);
 
@@ -512,6 +542,20 @@ mod bam_connection_tests {
         let received = batch_rx.try_recv().expect("should receive batch");
         assert_eq!(received.seq_id, 42);
         assert_eq!(received.max_schedule_slot, 100);
+
+        let batch_size = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let batch_size = server.outbound_result_batch_size.load(Ordering::Relaxed);
+                if batch_size != 0 {
+                    return batch_size;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("outbound results should be sent");
+
+        assert_eq!(batch_size, 3);
     }
 
     #[tokio::test]
@@ -520,13 +564,13 @@ mod bam_connection_tests {
         let server = start_mock_server(send_heartbeats, Duration::from_secs(1), false).await;
 
         let cluster_info = create_test_cluster_info();
-        let (batch_tx, _batch_rx, _outbound_tx, outbound_rx) = create_channels();
+        let (batch_tx, _batch_rx, _outbound_tx, mut outbound_rx) = create_channels();
 
         let connection = BamConnection::try_init(
             format!("http://{}", server.addr),
             cluster_info,
             batch_tx,
-            outbound_rx,
+            &mut outbound_rx,
         )
         .await
         .expect("should connect");
@@ -560,23 +604,23 @@ mod bam_manager_tests {
     fn create_test_bam_dependencies(
         cluster_info: Arc<ClusterInfo>,
         bank_forks: Arc<RwLock<solana_runtime::bank_forks::BankForks>>,
-    ) -> BamDependencies {
+    ) -> (BamDependencies, mpsc::Receiver<BamOutboundMessage>) {
         let (batch_tx, batch_rx) = crossbeam_channel::unbounded();
-        let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded();
+        let (outbound_tx, outbound_rx) = mpsc::channel(100_000);
 
-        BamDependencies {
+        let dependencies = BamDependencies {
             bam_enabled: Arc::new(AtomicU8::new(BamConnectionState::Disconnected as u8)),
             batch_sender: batch_tx,
             batch_receiver: batch_rx,
             outbound_sender: outbound_tx,
-            outbound_receiver: outbound_rx,
             cluster_info,
             block_builder_fee_info: Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo::default())),
             bank_forks,
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bam_tpu_info: Arc::new(ArcSwap::new(Arc::new(None))),
             bam_shred_receiver_addresses: Arc::default(),
-        }
+        };
+        (dependencies, outbound_rx)
     }
 
     fn bam_is_connected(bam_enabled: &Arc<AtomicU8>) -> bool {
@@ -618,7 +662,8 @@ mod bam_manager_tests {
         let cluster_info = create_test_cluster_info();
         let (exit, poh_recorder, bank_forks, poh_service, _ledger_path) =
             create_test_poh_recorder();
-        let dependencies = create_test_bam_dependencies(cluster_info, bank_forks);
+        let (dependencies, outbound_receiver) =
+            create_test_bam_dependencies(cluster_info, bank_forks);
         let bam_enabled = dependencies.bam_enabled.clone();
 
         let bam_url = Arc::new(ArcSwap::from_pointee(Some(format!(
@@ -631,6 +676,7 @@ mod bam_manager_tests {
             exit.clone(),
             bam_url,
             dependencies,
+            outbound_receiver,
             poh_recorder,
             identity_notifiers,
         );
@@ -658,7 +704,8 @@ mod bam_manager_tests {
         let cluster_info = create_test_cluster_info();
         let (exit, poh_recorder, bank_forks, poh_service, _ledger_path) =
             create_test_poh_recorder();
-        let dependencies = create_test_bam_dependencies(cluster_info, bank_forks);
+        let (dependencies, outbound_receiver) =
+            create_test_bam_dependencies(cluster_info, bank_forks);
         let bam_enabled = dependencies.bam_enabled.clone();
 
         let bam_url = Arc::new(ArcSwap::from_pointee(Some(format!(
@@ -671,6 +718,7 @@ mod bam_manager_tests {
             exit.clone(),
             bam_url,
             dependencies,
+            outbound_receiver,
             poh_recorder,
             identity_notifiers,
         );
@@ -708,7 +756,8 @@ mod bam_manager_tests {
         let cluster_info = create_test_cluster_info();
         let (exit, poh_recorder, bank_forks, poh_service, _ledger_path) =
             create_test_poh_recorder();
-        let dependencies = create_test_bam_dependencies(cluster_info, bank_forks);
+        let (dependencies, outbound_receiver) =
+            create_test_bam_dependencies(cluster_info, bank_forks);
         let bam_enabled = dependencies.bam_enabled.clone();
 
         let bam_url = Arc::new(ArcSwap::from_pointee(None));
@@ -718,6 +767,7 @@ mod bam_manager_tests {
             exit.clone(),
             bam_url,
             dependencies,
+            outbound_receiver,
             poh_recorder,
             identity_notifiers,
         );
@@ -744,7 +794,8 @@ mod bam_manager_tests {
         let cluster_info = create_test_cluster_info();
         let (exit, poh_recorder, bank_forks, poh_service, _ledger_path) =
             create_test_poh_recorder();
-        let dependencies = create_test_bam_dependencies(cluster_info, bank_forks);
+        let (dependencies, outbound_receiver) =
+            create_test_bam_dependencies(cluster_info, bank_forks);
         let bam_enabled = dependencies.bam_enabled.clone();
 
         let bam_url = Arc::new(ArcSwap::from_pointee(Some(format!(
@@ -757,6 +808,7 @@ mod bam_manager_tests {
             exit.clone(),
             bam_url.clone(),
             dependencies,
+            outbound_receiver,
             poh_recorder,
             identity_notifiers,
         );
@@ -792,7 +844,8 @@ mod bam_manager_tests {
         let cluster_info = create_test_cluster_info();
         let (exit, poh_recorder, bank_forks, poh_service, _ledger_path) =
             create_test_poh_recorder();
-        let dependencies = create_test_bam_dependencies(cluster_info.clone(), bank_forks);
+        let (dependencies, outbound_receiver) =
+            create_test_bam_dependencies(cluster_info.clone(), bank_forks);
         let bam_enabled = dependencies.bam_enabled.clone();
 
         let bam_url = Arc::new(ArcSwap::from_pointee(Some(format!(
@@ -805,6 +858,7 @@ mod bam_manager_tests {
             exit.clone(),
             bam_url,
             dependencies,
+            outbound_receiver,
             poh_recorder,
             identity_notifiers.clone(),
         );
@@ -870,7 +924,8 @@ mod bam_manager_tests {
         let cluster_info = create_test_cluster_info();
         let (exit, poh_recorder, bank_forks, poh_service, _ledger_path) =
             create_test_poh_recorder();
-        let dependencies = create_test_bam_dependencies(cluster_info, bank_forks);
+        let (dependencies, outbound_receiver) =
+            create_test_bam_dependencies(cluster_info, bank_forks);
         let block_builder_fee_info = dependencies.block_builder_fee_info.clone();
         let bam_enabled = dependencies.bam_enabled.clone();
 
@@ -884,6 +939,7 @@ mod bam_manager_tests {
             exit.clone(),
             bam_url,
             dependencies,
+            outbound_receiver,
             poh_recorder,
             identity_notifiers,
         );


### PR DESCRIPTION
#### Problem

BAM outbound handling used a dedicated polling task over a clonable receiver, waking frequently even when there was no outbound work and complicating reconnect ownership.

#### Summary of Changes

- Move BAM outbound handling to a single owned Tokio `mpsc` receiver inside the connection task.
- Preserve the outbound receiver across reconnects with explicit connection shutdown.
- Keep batching for queued transaction batch results while handling leader state sends inline.
- Remove unused outbound message variants and ping/pong-only metrics.
- Respond to BAM pings directly from the inbound scheduler stream.

#### Performance

- Eliminates the 1ms outbound polling task and its periodic wakeups.
- Uses async receiver wakeups instead of repeatedly draining an idle channel.
- Reduces task/channel overhead on the BAM connection path.