### PR TITLE
Zercopy bam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-transaction-view",
  "bincode",
+ "bytes",
  "criterion",
  "solana-hash 4.3.0",
  "solana-instruction",
@@ -1298,6 +1299,7 @@ dependencies = [
  "agave-logger",
  "arc-swap",
  "assert_matches",
+ "bytes",
  "clap 3.2.23",
  "crossbeam-channel",
  "jito-protos",

--- a/bam-banking-bench/Cargo.toml
+++ b/bam-banking-bench/Cargo.toml
@@ -19,6 +19,7 @@ agave-banking-stage-ingress-types = { workspace = true }
 agave-logger = { workspace = true }
 arc-swap = { workspace = true }
 assert_matches = { workspace = true }
+bytes = { workspace = true }
 clap = { version = "3.1.8", features = ["derive", "cargo"] }
 crossbeam-channel = { workspace = true }
 jito-protos = { workspace = true }

--- a/bam-banking-bench/src/mock_bam_server.rs
+++ b/bam-banking-bench/src/mock_bam_server.rs
@@ -1,4 +1,5 @@
 use {
+    bytes::{BufMut, BytesMut},
     crossbeam_channel::Sender,
     jito_protos::proto::bam_types::{AtomicTxnBatch, AtomicTxnBatchResult, Packet},
     solana_compute_budget_interface::ComputeBudgetInstruction,
@@ -6,7 +7,7 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_message::Message,
-    solana_perf::packet::solana_packet,
+    solana_perf::packet::{PACKET_DATA_SIZE, solana_packet},
     solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
@@ -235,15 +236,20 @@ impl MockBamServer {
                 1,
             );
 
-            let packet = solana_packet::Packet::from_data(None, &tx).unwrap();
-            let data = packet.data(..).unwrap_or_default().to_vec();
+            let data = {
+                let buffer = BytesMut::with_capacity(PACKET_DATA_SIZE);
+                let mut writer = buffer.writer();
+                solana_packet::Encode::encode(&tx, &mut writer).unwrap();
+                writer.into_inner().freeze()
+            };
+            let data_len = data.len();
             let atomic_txn_batch = AtomicTxnBatch {
                 seq_id: *seq_id,
                 max_schedule_slot: bank.slot(),
                 packets: vec![Packet {
-                    data: data.to_vec(),
+                    data,
                     meta: Some(jito_protos::proto::bam_types::Meta {
-                        size: data.len() as u64,
+                        size: data_len as u64,
                         flags: None,
                     }),
                 }],

--- a/core/benches/proto_to_packet.rs
+++ b/core/benches/proto_to_packet.rs
@@ -15,7 +15,7 @@ use {
 
 fn get_proto_packet(i: u8) -> PbPacket {
     PbPacket {
-        data: repeat_n(i, PACKET_DATA_SIZE).collect(),
+        data: repeat_n(i, PACKET_DATA_SIZE).collect::<Vec<_>>().into(),
         meta: Some(PbMeta {
             size: PACKET_DATA_SIZE as u64,
             addr: "255.255.255.255:65535".to_string(),

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -20,7 +20,7 @@ use {
                     DisconnectedError, ReceivingStats, calculate_max_age,
                     contains_blacklisted_account,
                 },
-                transaction_state_container::{SharedBytes, StateContainer},
+                transaction_state_container::StateContainer,
             },
         },
     },
@@ -56,7 +56,6 @@ use {
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction::sanitized::MessageHash,
     std::{
-        cmp::min,
         sync::{
             Arc, RwLock,
             atomic::{AtomicBool, AtomicU8, Ordering},
@@ -67,7 +66,7 @@ use {
 };
 
 type PrevalidationResult = Result<(usize, bool, u32, u64), (Reason, u32)>;
-type VerifyResult = Result<(Vec<SharedBytes>, bool, u32, u64), (Reason, u32)>;
+type VerifyResult = Result<(Vec<Bytes>, bool, u32, u64), (Reason, u32)>;
 
 pub struct BamReceiveAndBuffer {
     bam_enabled: Arc<AtomicU8>,
@@ -80,10 +79,7 @@ pub struct BamReceiveAndBuffer {
 
 struct ParsedBatch {
     pub txns_max_age: SmallVec<
-        [(
-            RuntimeTransaction<ResolvedTransactionView<SharedBytes>>,
-            MaxAge,
-        ); MAX_PACKETS_PER_BUNDLE],
+        [(RuntimeTransaction<ResolvedTransactionView<Bytes>>, MaxAge); MAX_PACKETS_PER_BUNDLE],
     >,
     pub revert_on_error: bool,
     pub max_schedule_slot: u64,
@@ -190,7 +186,7 @@ impl BamReceiveAndBuffer {
 
             let (deserialize_stats, duration_us) = measure_us!(Self::batch_verify(
                 &sigverify_thread_pool,
-                &recv_buffer,
+                &mut recv_buffer,
                 current_slot,
                 &mut metrics,
                 &mut prevalidated,
@@ -281,7 +277,7 @@ impl BamReceiveAndBuffer {
     }
 
     fn parse_batch(
-        verified_batch: Vec<SharedBytes>,
+        verified_batch: Vec<Bytes>,
         seq_id: u32,
         revert_on_error: bool,
         max_schedule_slot: u64,
@@ -643,94 +639,45 @@ impl BamReceiveAndBuffer {
 
     fn batch_verify(
         sigverify_thread_pool: &rayon::ThreadPool,
-        atomic_txn_batches: &[AtomicTxnBatch],
+        atomic_txn_batches: &mut [AtomicTxnBatch],
         current_slot: Slot,
         metrics: &mut BamReceiveAndBufferMetrics,
         prevalidated: &mut Vec<PrevalidationResult>,
         packet_batches: &mut Vec<solana_perf::packet::PacketBatch>,
         results: &mut Vec<VerifyResult>,
     ) -> ReceivingStats {
-        fn proto_packet_to_packet(from_packet: &Packet) -> BytesPacket {
-            let data_len = from_packet.data.len();
-            let mut to_packet = BytesPacket::new(
-                Bytes::copy_from_slice(&from_packet.data[0..min(PACKET_DATA_SIZE, data_len)]),
-                Meta::default(),
-            );
-
-            if data_len > PACKET_DATA_SIZE {
-                to_packet.meta_mut().set_discard(true);
-                return to_packet;
-            }
-
-            to_packet.meta_mut().size = data_len;
-            to_packet.meta_mut().set_discard(false);
-
-            if let Some(meta) = &from_packet.meta {
-                if let Some(flags) = &meta.flags {
-                    if flags.simple_vote_tx {
-                        to_packet
-                            .meta_mut()
-                            .flags
-                            .insert(PacketFlags::SIMPLE_VOTE_TX);
-                    }
-                }
-            }
-            to_packet
-        }
-
-        fn pkt_to_shared_bytes(
-            solana_packet_ref: &solana_perf::packet::PacketRef,
-            i: usize,
-            seq_id: u32,
-            metrics: &mut BamReceiveAndBufferMetrics,
-        ) -> Result<SharedBytes, (Reason, u32)> {
-            if solana_packet_ref.meta().discard() {
-                let reason = DeserializationErrorReason::SanitizeError;
-                return Err((
-                    Reason::DeserializationError(
-                        jito_protos::proto::bam_types::DeserializationError {
-                            index: i as u32,
-                            reason: reason as i32,
-                        },
-                    ),
-                    seq_id,
-                ));
-            }
-
-            metrics
-                .sigverify_metrics
-                .increment_total_packets_verified(1);
-
-            let Some(data) = solana_packet_ref.data(..) else {
-                let reason = DeserializationErrorReason::SanitizeError;
-                return Err((
-                    Reason::DeserializationError(
-                        jito_protos::proto::bam_types::DeserializationError {
-                            index: i as u32,
-                            reason: reason as i32,
-                        },
-                    ),
-                    seq_id,
-                ));
-            };
-
-            Ok(SharedBytes::new(data.to_vec()))
-        }
-
-        let mut stats = ReceivingStats::default();
-
-        let preverify_stats =
-            Self::prevalidate_batches(atomic_txn_batches, current_slot, prevalidated);
-        stats.accumulate(preverify_stats);
+        let stats = Self::prevalidate_batches(atomic_txn_batches, current_slot, prevalidated);
 
         packet_batches.clear();
         packet_batches.reserve(prevalidated.len());
         let mut packet_count = 0;
         prevalidated.iter().flatten().for_each(|result| {
-            let solana_packet_batch: Vec<_> = atomic_txn_batches[result.0]
+            let atomic_txn_batch = &mut atomic_txn_batches[result.0];
+            let solana_packet_batch: Vec<_> = atomic_txn_batch
                 .packets
-                .iter()
-                .map(proto_packet_to_packet)
+                .drain(..)
+                .map(|from_packet| {
+                    let Packet { data, meta } = from_packet;
+                    let data_len = data.len();
+                    if data_len > PACKET_DATA_SIZE {
+                        let mut to_packet = BytesPacket::new(Bytes::new(), Meta::default());
+                        to_packet.meta_mut().set_discard(true);
+                        return to_packet;
+                    }
+
+                    let mut to_packet = BytesPacket::new(data, Meta::default());
+                    to_packet.meta_mut().size = data_len;
+
+                    if let Some(meta) = meta {
+                        if meta.flags.is_some_and(|flags| flags.simple_vote_tx) {
+                            to_packet
+                                .meta_mut()
+                                .flags
+                                .insert(PacketFlags::SIMPLE_VOTE_TX);
+                        }
+                    }
+                    to_packet
+                })
                 .collect();
             packet_count += solana_packet_batch.len();
             packet_batches.push(solana_perf::packet::PacketBatch::Bytes(
@@ -760,15 +707,34 @@ impl BamReceiveAndBuffer {
 
         results.clear();
         results.reserve(prevalidated.len());
-        let mut packet_batch_iter = packet_batches.iter();
+        let mut packet_batch_iter = packet_batches.drain(..);
         for pre_result in prevalidated.drain(..) {
             let result = pre_result.and_then(|(_, revert_on_error, seq_id, max_schedule_slot)| {
                 let batch = packet_batch_iter.next().unwrap();
-                let deserialized = batch
-                    .iter()
-                    .enumerate()
-                    .map(|(i, pkt)| pkt_to_shared_bytes(&pkt, i, seq_id, metrics))
-                    .collect::<Result<Vec<_>, _>>()?;
+                let solana_perf::packet::PacketBatch::Bytes(batch) = batch else {
+                    unreachable!("BAM sigverify builds Bytes packet batches");
+                };
+
+                let mut deserialized = Vec::with_capacity(batch.len());
+                for (i, pkt) in batch.iter().enumerate() {
+                    if pkt.meta().discard() {
+                        return Err((
+                            Reason::DeserializationError(
+                                jito_protos::proto::bam_types::DeserializationError {
+                                    index: i as u32,
+                                    reason: DeserializationErrorReason::SanitizeError as i32,
+                                },
+                            ),
+                            seq_id,
+                        ));
+                    }
+
+                    metrics
+                        .sigverify_metrics
+                        .increment_total_packets_verified(1);
+
+                    deserialized.push(pkt.buffer().clone());
+                }
 
                 Ok((deserialized, revert_on_error, seq_id, max_schedule_slot))
             });
@@ -784,7 +750,7 @@ const ATOMIC_TXN_BATCH_BURST: usize = 128;
 const TIMEOUT: Duration = Duration::from_millis(1);
 
 impl ReceiveAndBuffer for BamReceiveAndBuffer {
-    type Transaction = RuntimeTransaction<ResolvedTransactionView<SharedBytes>>;
+    type Transaction = RuntimeTransaction<ResolvedTransactionView<Bytes>>;
     type Container = TransactionStateContainer<Self::Transaction>;
 
     fn receive_and_buffer_packets(
@@ -1114,7 +1080,7 @@ mod tests {
     ) -> (
         Arc<AtomicBool>,
         BamReceiveAndBuffer,
-        TransactionStateContainer<RuntimeTransaction<ResolvedTransactionView<SharedBytes>>>,
+        TransactionStateContainer<RuntimeTransaction<ResolvedTransactionView<Bytes>>>,
         tokio::sync::mpsc::Receiver<BamOutboundMessage>,
     ) {
         let exit: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
@@ -1158,7 +1124,7 @@ mod tests {
     }
 
     fn run_batch_verify(
-        batches: &[AtomicTxnBatch],
+        mut batches: Vec<AtomicTxnBatch>,
         current_slot: Slot,
         metrics: &mut BamReceiveAndBufferMetrics,
     ) -> (Vec<VerifyResult>, ReceivingStats) {
@@ -1171,7 +1137,7 @@ mod tests {
         let mut results = Vec::new();
         let stats = BamReceiveAndBuffer::batch_verify(
             &thread_pool,
-            batches,
+            &mut batches,
             current_slot,
             metrics,
             &mut prevalidated,
@@ -1207,7 +1173,10 @@ mod tests {
         let data = bincode::serialize(&transaction).expect("serializes");
         let bundle = AtomicTxnBatch {
             seq_id: 1,
-            packets: vec![Packet { data, meta: None }],
+            packets: vec![Packet {
+                data: data.into(),
+                meta: None,
+            }],
             max_schedule_slot: Slot::MAX,
         };
         sender.send(bundle).unwrap();
@@ -1236,7 +1205,7 @@ mod tests {
         let bundle = AtomicTxnBatch {
             seq_id: 1,
             packets: vec![Packet {
-                data: vec![],
+                data: Bytes::new(),
                 meta: None,
             }],
             max_schedule_slot: Slot::MAX,
@@ -1271,14 +1240,15 @@ mod tests {
                     1,
                     bank_forks.read().unwrap().root_bank().last_blockhash(),
                 ))
-                .unwrap(),
+                .unwrap()
+                .into(),
                 meta: None,
             }],
             max_schedule_slot: Slot::MAX,
         };
 
         let mut stats = BamReceiveAndBufferMetrics::default();
-        let (results, _batch_stats) = run_batch_verify(&[bundle], Slot::MAX, &mut stats);
+        let (results, _batch_stats) = run_batch_verify(vec![bundle], Slot::MAX, &mut stats);
 
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
@@ -1298,7 +1268,7 @@ mod tests {
         };
 
         let mut stats = BamReceiveAndBufferMetrics::default();
-        let (results, batch_stats) = run_batch_verify(&[batch], Slot::MAX, &mut stats);
+        let (results, batch_stats) = run_batch_verify(vec![batch], Slot::MAX, &mut stats);
 
         assert_eq!(results.len(), 1);
         assert!(results[0].is_err());
@@ -1315,14 +1285,14 @@ mod tests {
         let batch = AtomicTxnBatch {
             seq_id: 1,
             packets: vec![Packet {
-                data: vec![0; PACKET_DATA_SIZE + 1],
+                data: vec![0; PACKET_DATA_SIZE + 1].into(),
                 meta: None,
             }],
             max_schedule_slot: Slot::MAX,
         };
 
         let mut stats = BamReceiveAndBufferMetrics::default();
-        let (results, _batch_stats) = run_batch_verify(&[batch], Slot::MAX, &mut stats);
+        let (results, _batch_stats) = run_batch_verify(vec![batch], Slot::MAX, &mut stats);
 
         assert_eq!(results.len(), 1);
         assert!(results[0].is_err());
@@ -1345,14 +1315,15 @@ mod tests {
                     1,
                     bank_forks.read().unwrap().root_bank().last_blockhash(),
                 ))
-                .unwrap(),
+                .unwrap()
+                .into(),
                 meta: None,
             }],
             max_schedule_slot: Slot::MAX,
         };
 
         let mut stats = BamReceiveAndBufferMetrics::default();
-        let (results, _batch_stats) = run_batch_verify(&[batch], Slot::MAX, &mut stats);
+        let (results, _batch_stats) = run_batch_verify(vec![batch], Slot::MAX, &mut stats);
 
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
@@ -1389,7 +1360,8 @@ mod tests {
                         1,
                         bank_forks.read().unwrap().root_bank().last_blockhash(),
                     ))
-                    .unwrap(),
+                    .unwrap()
+                    .into(),
                     meta: None,
                 },
                 Packet {
@@ -1399,7 +1371,8 @@ mod tests {
                         1,
                         bank_forks.read().unwrap().root_bank().last_blockhash(),
                     ))
-                    .unwrap(),
+                    .unwrap()
+                    .into(),
                     meta: None,
                 },
             ],
@@ -1407,7 +1380,7 @@ mod tests {
         };
 
         let mut stats = BamReceiveAndBufferMetrics::default();
-        let (results, _batch_stats) = run_batch_verify(&[batch], Slot::MAX, &mut stats);
+        let (results, _batch_stats) = run_batch_verify(vec![batch], Slot::MAX, &mut stats);
 
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
@@ -1444,7 +1417,8 @@ mod tests {
                         1,
                         bank_forks.read().unwrap().root_bank().last_blockhash(),
                     ))
-                    .unwrap(),
+                    .unwrap()
+                    .into(),
                     meta: None,
                 },
                 Packet {
@@ -1454,7 +1428,8 @@ mod tests {
                         1,
                         bank_forks.read().unwrap().root_bank().last_blockhash(),
                     ))
-                    .unwrap(),
+                    .unwrap()
+                    .into(),
                     meta: Some(jito_protos::proto::bam_types::Meta {
                         flags: Some(jito_protos::proto::bam_types::PacketFlags {
                             revert_on_error: true,
@@ -1468,7 +1443,7 @@ mod tests {
         };
 
         let mut stats = BamReceiveAndBufferMetrics::default();
-        let (results, batch_stats) = run_batch_verify(&[bundle], Slot::MAX, &mut stats);
+        let (results, batch_stats) = run_batch_verify(vec![bundle], Slot::MAX, &mut stats);
         assert_eq!(results.len(), 1);
         assert!(results[0].is_err());
         assert_eq!(batch_stats.num_dropped_without_parsing, 1);
@@ -1493,14 +1468,15 @@ mod tests {
                     100,
                     bank_forks.read().unwrap().root_bank().last_blockhash(),
                 ))
-                .unwrap(),
+                .unwrap()
+                .into(),
                 meta: None,
             }],
             max_schedule_slot: Slot::MAX,
         };
 
         let mut stats = BamReceiveAndBufferMetrics::default();
-        let (results, _batch_stats) = run_batch_verify(&[batch], Slot::MAX, &mut stats);
+        let (results, _batch_stats) = run_batch_verify(vec![batch], Slot::MAX, &mut stats);
 
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
@@ -1558,14 +1534,14 @@ mod tests {
         let batch = AtomicTxnBatch {
             seq_id: 1,
             packets: vec![Packet {
-                data: vote_data,
+                data: vote_data.into(),
                 meta: Some(meta),
             }],
             max_schedule_slot: Slot::MAX,
         };
 
         let mut stats = BamReceiveAndBufferMetrics::default();
-        let (results, _batch_stats) = run_batch_verify(&[batch], Slot::MAX, &mut stats);
+        let (results, _batch_stats) = run_batch_verify(vec![batch], Slot::MAX, &mut stats);
 
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
@@ -1603,14 +1579,15 @@ mod tests {
                     1,
                     bank_forks.read().unwrap().root_bank().last_blockhash(),
                 ))
-                .unwrap(),
+                .unwrap()
+                .into(),
                 meta: None,
             }],
             max_schedule_slot: 0,
         };
 
         let mut stats = BamReceiveAndBufferMetrics::default();
-        let (results, _batch_stats) = run_batch_verify(&[batch], Slot::MAX, &mut stats);
+        let (results, _batch_stats) = run_batch_verify(vec![batch], Slot::MAX, &mut stats);
 
         assert_eq!(results.len(), 1);
         assert!(results[0].is_err());

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -76,24 +76,18 @@ extern crate solana_frozen_abi_macro;
 extern crate assert_matches;
 
 use {
-    bytes::Bytes,
     solana_packet::{Meta, PACKET_DATA_SIZE, PacketFlags},
     solana_perf::packet::BytesPacket,
-    std::{
-        cmp::min,
-        net::{IpAddr, Ipv4Addr},
-    },
+    std::net::{IpAddr, Ipv4Addr},
 };
 
 const UNKNOWN_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
 
 // NOTE: last profiled at around 180ns
 pub fn proto_packet_to_packet(p: jito_protos::proto::packet::Packet) -> BytesPacket {
-    let copy_len = min(PACKET_DATA_SIZE, p.data.len());
-    let mut packet = BytesPacket::new(
-        Bytes::copy_from_slice(&p.data[0..copy_len]),
-        Meta::default(),
-    );
+    let mut data = p.data;
+    data.truncate(PACKET_DATA_SIZE);
+    let mut packet = BytesPacket::new(data, Meta::default());
 
     if let Some(meta) = p.meta {
         packet.meta_mut().size = meta.size as usize;

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -531,7 +531,7 @@ mod bam_connection_tests {
             seq_id: 42,
             max_schedule_slot: 100,
             packets: vec![Packet {
-                data: vec![1, 2, 3],
+                data: vec![1, 2, 3].into(),
                 meta: None,
             }],
         };

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
 name = "agave-transaction-view"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "bytes",
  "solana-hash 4.3.0",
  "solana-message",
  "solana-packet 4.1.0",

--- a/jito-protos/build.rs
+++ b/jito-protos/build.rs
@@ -32,6 +32,8 @@ fn main() -> Result<(), std::io::Error> {
     }
 
     configure()
+        .bytes(".packet.Packet.data")
+        .bytes(".bam_types.Packet.data")
         .build_client(true)
         .build_server(true)
         .server_mod_attribute(".", "#[allow(clippy::default_trait_access)]")

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
 name = "agave-transaction-view"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "bytes",
  "solana-hash 4.3.0",
  "solana-message",
  "solana-packet 4.1.0",

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -14,6 +14,7 @@ agave-unstable-api = []
 dev-context-only-utils = []
 
 [dependencies]
+bytes = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-packet = { workspace = true }

--- a/transaction-view/src/transaction_data.rs
+++ b/transaction-view/src/transaction_data.rs
@@ -17,3 +17,10 @@ impl TransactionData for std::sync::Arc<Vec<u8>> {
         self.as_ref()
     }
 }
+
+impl TransactionData for bytes::Bytes {
+    #[inline]
+    fn data(&self) -> &[u8] {
+        self.as_ref()
+    }
+}


### PR DESCRIPTION
#### Problem

BAM packet handling copied protobuf packet payloads into new buffers before sigverify and transaction parsing, adding avoidable allocation/copy work in the receive hot path.

#### Summary of Changes

- Generate protobuf `Packet.data` fields as `bytes::Bytes` for BAM and packet protos.
- Move BAM packet payloads through `BytesPacket` and parse `ResolvedTransactionView<Bytes>`, cloning only `Bytes` handles after sigverify.

#### Allocation Impact

For each accepted BAM packet/transaction, this removes 3 heap allocations in the receive/sigverify handoff path, and 2 full packet-payload copies per transaction.

#### BAM Load Benchmark

Production shape was taken from `singapore-mainnet-validator-1` during BAM leader windows:
- `bundle_received`: p50 44, p99 127, max 230
- receive-call packet-count histogram: p50 1, p75 2, p90 15, p99 33, max 80
- payload size: 1,105 bytes, the p50 server-to-validator HTTP/2 DATA frame length from a local BAM capture

Results:

```text
before_copy_path       150.49 us median, 4.8004 GiB/s
after_zero_copy_path    27.371 us median, 26.395 GiB/s
```

The focused receive handoff benchmark is about 5.5x faster with the zero-copy path.

Benchmark function bodies:

```rust
fn before_copy_path(bursts: &mut [Vec<AtomicTxnBatch>]) -> usize {
    let mut total_bytes = 0;
    let mut packet_batches = Vec::new();
    let mut retained_payloads: Vec<Arc<Vec<u8>>> = Vec::new();

    for atomic_txn_batches in bursts {
        packet_batches.clear();
        retained_payloads.clear();
        packet_batches.reserve(atomic_txn_batches.len());

        for atomic_txn_batch in atomic_txn_batches {
            let solana_packet_batch = atomic_txn_batch
                .packets
                .iter()
                .map(|from_packet| {
                    let data_len = from_packet.data.len();
                    let mut to_packet = BytesPacket::new(
                        Bytes::copy_from_slice(
                            &from_packet.data[..min(PACKET_DATA_SIZE, data_len)],
                        ),
                        Meta::default(),
                    );

                    if data_len > PACKET_DATA_SIZE {
                        to_packet.meta_mut().set_discard(true);
                        return to_packet;
                    }

                    to_packet.meta_mut().size = data_len;
                    to_packet
                })
                .collect::<Vec<_>>();
            packet_batches.push(BytesPacketBatch::from(solana_packet_batch));
        }

        for batch in &packet_batches {
            for pkt in batch.iter() {
                if let Some(data) = pkt.data(..) {
                    total_bytes += data.len();
                    retained_payloads.push(Arc::new(data.to_vec()));
                }
            }
        }

        black_box(&retained_payloads);
    }

    total_bytes
}

fn after_zero_copy_path(bursts: &mut [Vec<AtomicTxnBatch>]) -> usize {
    let mut total_bytes = 0;
    let mut packet_batches = Vec::new();
    let mut retained_payloads = Vec::new();

    for atomic_txn_batches in bursts {
        packet_batches.clear();
        retained_payloads.clear();
        packet_batches.reserve(atomic_txn_batches.len());

        for atomic_txn_batch in atomic_txn_batches {
            let solana_packet_batch = atomic_txn_batch
                .packets
                .drain(..)
                .map(|from_packet| {
                    let BamPacket { data, .. } = from_packet;
                    let data_len = data.len();
                    if data_len > PACKET_DATA_SIZE {
                        let mut to_packet = BytesPacket::new(Bytes::new(), Meta::default());
                        to_packet.meta_mut().set_discard(true);
                        return to_packet;
                    }

                    let mut to_packet = BytesPacket::new(data, Meta::default());
                    to_packet.meta_mut().size = data_len;
                    to_packet
                })
                .collect::<Vec<_>>();
            packet_batches.push(BytesPacketBatch::from(solana_packet_batch));
        }

        for batch in packet_batches.drain(..) {
            for pkt in batch.iter() {
                if !pkt.meta().discard() {
                    total_bytes += pkt.buffer().len();
                    retained_payloads.push(pkt.buffer().clone());
                }
            }
        }

        black_box(&retained_payloads);
    }

    total_bytes
}
```