### PR TITLE
[codex] Run cargo audit at the end of CI

### DIFF
--- a/ci/buildkite-secondary.yml
+++ b/ci/buildkite-secondary.yml
@@ -2,13 +2,6 @@
 # Build steps that run after the primary pipeline on pushes and tags.
 # Pull requests to not run these steps.
 steps:
-  - name: "cargo audit"
-    command: "ci/docker-run-default-image.sh ci/do-audit.sh"
-    if: build.pull_request.id == null
-    agents:
-      queue: "release-build"
-    timeout_in_minutes: 10
-  - wait
   - name: "publish tarball (x86_64-unknown-linux-gnu)"
     command: "ci/publish-tarball.sh"
     if: build.pull_request.id == null
@@ -21,6 +14,13 @@ steps:
     agents:
       queue: "release-build"
     timeout_in_minutes: 5
+  - wait
+  - name: "cargo audit"
+    command: "ci/docker-run-default-image.sh ci/do-audit.sh"
+    if: build.pull_request.id == null
+    agents:
+      queue: "release-build"
+    timeout_in_minutes: 10
   # - wait
   # - name: "publish crate"
   #   command: "ci/publish-crate.sh"

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -54,8 +54,6 @@ _ ci/order-crates-for-publishing.py
 
 _ scripts/cargo-clippy.sh
 
-_ ci/do-audit.sh
-
 if [[ -n $CI ]] && [[ $CHANNEL = "stable" ]]; then
   _ ci/check-install-all.sh
 fi

--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -99,6 +99,10 @@ fn generate_private_pipeline() -> Result<buildkite::Pipeline> {
     pipeline.add_step(default_stable_sbf_step());
     pipeline.add_step(default_shuttle_step());
 
+    pipeline.add_step(buildkite::Step::Wait(buildkite::WaitStep {}));
+
+    pipeline.add_step(default_audit_step());
+
     Ok(pipeline)
 }
 
@@ -137,6 +141,8 @@ fn generate_merge_queue_pipeline() -> Result<buildkite::Pipeline> {
     pipeline.set_priority(10);
     pipeline.add_step(default_sanity_step());
     pipeline.add_step(default_checks_step());
+    pipeline.add_step(buildkite::Step::Wait(buildkite::WaitStep {}));
+    pipeline.add_step(default_audit_step());
     Ok(pipeline)
 }
 
@@ -212,6 +218,10 @@ pub async fn generate_pull_request_pipeline(pr_number: u64) -> Result<buildkite:
         pipeline.add_step(default_stable_sbf_step());
         pipeline.add_step(default_shuttle_step());
         pipeline.add_step(default_coverage_step(3));
+
+        pipeline.add_step(buildkite::Step::Wait(buildkite::WaitStep {}));
+
+        pipeline.add_step(default_audit_step());
     } else if coverage_scripts_changed {
         pipeline.add_step(default_coverage_step(3));
     }
@@ -246,6 +256,10 @@ fn generate_full_pipeline() -> Result<buildkite::Pipeline> {
     pipeline.add_step(default_coverage_step(3));
     // Jito does not publish workspace crates to crates.io.
     // pipeline.add_step(default_crate_publish_test_step());
+
+    pipeline.add_step(buildkite::Step::Wait(buildkite::WaitStep {}));
+
+    pipeline.add_step(default_audit_step());
 
     pipeline.add_step(buildkite::Step::Wait(buildkite::WaitStep {}));
 
@@ -289,6 +303,19 @@ fn default_checks_step() -> buildkite::Step {
             String::from("default"),
         )])),
         timeout_in_minutes: Some(20),
+        ..Default::default()
+    })
+}
+
+fn default_audit_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("cargo audit"),
+        command: String::from("ci/docker-run-default-image.sh ci/do-audit.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("default"),
+        )])),
+        timeout_in_minutes: Some(10),
         ..Default::default()
     })
 }


### PR DESCRIPTION
## Summary
- Remove `cargo audit` from the early `ci/test-checks.sh` check path.
- Add a dedicated generated Buildkite `cargo audit` step after the final test stage for public, private, PR, and merge queue pipelines.
- Move the secondary pipeline `cargo audit` job after publish jobs.

## Why
RustSec checks should still fail CI, but only after the rest of the Buildkite work has had a chance to run.
