### PR TITLE
BAM URL switch cleanups

### DIFF
--- a/core/src/bam_connection.rs
+++ b/core/src/bam_connection.rs
@@ -25,7 +25,7 @@ use {
     },
     thiserror::Error,
     tokio::{
-        sync::mpsc,
+        sync::{mpsc, oneshot},
         time::{interval, timeout},
     },
     tokio_stream::wrappers::ReceiverStream,
@@ -156,6 +156,7 @@ impl BamConnection {
         }
 
         let mut post_auth_client = Some(validator_client);
+        let mut refresh_config_exit_sender = None;
         let mut refresh_config_task = None;
 
         while !connection_exit.load(Relaxed) {
@@ -202,23 +203,29 @@ impl BamConnection {
 
                     // The first successful inbound scheduler message proves the auth'd stream was accepted.
                     if let Some(mut validator_client) = post_auth_client.take() {
-                        let connection_exit = connection_exit.clone();
                         let config = config.clone();
                         let metrics = metrics.clone();
+                        let (exit_sender, mut exit_receiver) = oneshot::channel();
+                        refresh_config_exit_sender = Some(exit_sender);
                         refresh_config_task = Some(tokio::spawn(async move {
                             let mut interval = interval(REFRESH_CONFIG_INTERVAL);
                             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-                            while !connection_exit.load(Relaxed) {
-                                interval.tick().await;
-
-                                let request = tonic::Request::new(ConfigRequest {});
-                                match timeout(
-                                    NETWORK_REQUEST_TIMEOUT,
-                                    validator_client.get_builder_config(request),
-                                )
-                                .await
-                                {
+                            loop {
+                                let result = tokio::select! {
+                                    biased;
+                                    _ = &mut exit_receiver => break,
+                                    result = async {
+                                        interval.tick().await;
+                                        let request = tonic::Request::new(ConfigRequest {});
+                                        timeout(
+                                            NETWORK_REQUEST_TIMEOUT,
+                                            validator_client.get_builder_config(request),
+                                        )
+                                        .await
+                                    } => result,
+                                };
+                                match result {
                                     Ok(Ok(response)) => {
                                         let resp_config = response.into_inner();
                                         *config.lock().unwrap() = Some(resp_config);
@@ -316,6 +323,10 @@ impl BamConnection {
         }
         connection_exit.store(true, Relaxed);
         is_healthy.store(false, Relaxed);
+
+        if let Some(refresh_config_exit_sender) = refresh_config_exit_sender.take() {
+            let _ = refresh_config_exit_sender.send(());
+        }
 
         if let Some(refresh_config_task) = refresh_config_task.as_mut() {
             match timeout(CHILD_TASK_SHUTDOWN_GRACE, &mut *refresh_config_task).await {

--- a/core/src/bam_connection.rs
+++ b/core/src/bam_connection.rs
@@ -156,7 +156,7 @@ impl BamConnection {
         }
 
         let mut post_auth_client = Some(validator_client);
-        let mut refresh_config_exit_sender = None;
+        let mut refresh_config_exit_sender: Option<oneshot::Sender<()>> = None;
         let mut refresh_config_task = None;
 
         while !connection_exit.load(Relaxed) {
@@ -212,28 +212,25 @@ impl BamConnection {
                             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
                             loop {
+                                let request = tonic::Request::new(ConfigRequest {});
                                 let result = tokio::select! {
                                     biased;
-                                    _ = &mut exit_receiver => break,
                                     result = async {
                                         interval.tick().await;
-                                        let request = tonic::Request::new(ConfigRequest {});
                                         timeout(
                                             NETWORK_REQUEST_TIMEOUT,
                                             validator_client.get_builder_config(request),
                                         )
                                         .await
                                     } => result,
+                                    _ = &mut exit_receiver => break,
                                 };
                                 match result {
                                     Ok(Ok(response)) => {
-                                        let resp_config = response.into_inner();
-                                        *config.lock().unwrap() = Some(resp_config);
+                                        *config.lock().unwrap() = Some(response.into_inner());
                                         metrics.builder_config_received.fetch_add(1, Relaxed);
                                     }
-                                    Ok(Err(e)) => {
-                                        error!("Failed to get config: {e:?}");
-                                    }
+                                    Ok(Err(e)) => error!("Failed to get config: {e:?}"),
                                     Err(_) => error!("Timed out getting config"),
                                 }
                             }
@@ -324,9 +321,7 @@ impl BamConnection {
         connection_exit.store(true, Relaxed);
         is_healthy.store(false, Relaxed);
 
-        if let Some(refresh_config_exit_sender) = refresh_config_exit_sender.take() {
-            let _ = refresh_config_exit_sender.send(());
-        }
+        drop(refresh_config_exit_sender.take());
 
         if let Some(refresh_config_task) = refresh_config_task.as_mut() {
             match timeout(CHILD_TASK_SHUTDOWN_GRACE, &mut *refresh_config_task).await {

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -126,6 +126,7 @@ impl BamManager {
         let mut current_connection = None;
         let mut outbound_receiver = Some(outbound_receiver);
         let mut cached_builder_config = None;
+        let mut last_observed_bam_url = bam_url.load_full();
         let shared_leader_state = poh_recorder.read().unwrap().shared_leader_state();
 
         let fallback_client_id = ClientId::JitoLabs;
@@ -133,6 +134,15 @@ impl BamManager {
         let bam_client_id = ClientId::AgaveBam;
 
         while !exit.load(Ordering::Relaxed) {
+            let configured_bam_url = bam_url.load_full();
+            if configured_bam_url != last_observed_bam_url {
+                match configured_bam_url.as_deref() {
+                    Some(new_url) => info!("BAM URL changed, connecting to new URL: {new_url}"),
+                    None => info!("BAM URL cleared, disconnecting"),
+                }
+                last_observed_bam_url = configured_bam_url.clone();
+            }
+
             let connection = match current_connection.take() {
                 // Connected: keep processing and disconnect fast on identity/url/health changes.
                 Some(connection) => connection,
@@ -156,8 +166,7 @@ impl BamManager {
                     }
 
                     // Try to connect to BAM
-                    let bam_url = bam_url.load();
-                    let Some(url) = bam_url.as_ref() else {
+                    let Some(url) = configured_bam_url.as_ref() else {
                         Self::set_bam_disconnected(&dependencies);
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
                         continue;
@@ -233,17 +242,11 @@ impl BamManager {
             ) {
                 true
             } else {
-                let configured_bam_url = bam_url.load();
                 if configured_bam_url.as_deref() == Some(connection.url()) {
                     false
                 } else {
                     cached_builder_config = None;
                     Self::set_bam_disconnected(&dependencies);
-                    if let Some(new_url) = configured_bam_url.as_deref() {
-                        info!("BAM URL changed, connecting to new URL: {new_url}");
-                    } else {
-                        info!("BAM URL cleared, disconnecting");
-                    }
                     true
                 }
             };

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -125,10 +125,10 @@ impl BamNodeApi for MockBamNode {
         _request: Request<ConfigRequest>,
     ) -> Result<Response<ConfigResponse>, Status> {
         self.config_requests.fetch_add(1, Ordering::Relaxed);
-        let config_response_delay_ms = self.config_response_delay_ms.load(Ordering::Relaxed);
-        if config_response_delay_ms > 0 {
-            tokio::time::sleep(Duration::from_millis(config_response_delay_ms)).await;
-        }
+        tokio::time::sleep(Duration::from_millis(
+            self.config_response_delay_ms.load(Ordering::Relaxed),
+        ))
+        .await;
         let config = self.config.lock().unwrap().clone();
         Ok(Response::new(ConfigResponse {
             block_engine_config: Some(BlockEngineBuilderConfig {

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -76,6 +76,7 @@ struct MockBamNode {
     config_requests: Arc<AtomicU64>,
     scheduler_stream_rejections: Arc<AtomicU64>,
     config: Arc<Mutex<MockConfig>>,
+    config_response_delay_ms: Arc<AtomicU64>,
     batch_to_send: Arc<Mutex<Option<AtomicTxnBatch>>>,
     reject_scheduler_stream: bool,
     outbound_result_batch_size: Arc<AtomicU64>,
@@ -94,6 +95,7 @@ impl MockBamNode {
             config_requests: Arc::new(AtomicU64::new(0)),
             scheduler_stream_rejections: Arc::new(AtomicU64::new(0)),
             config: Arc::new(Mutex::new(MockConfig::default())),
+            config_response_delay_ms: Arc::new(AtomicU64::new(0)),
             batch_to_send: Arc::new(Mutex::new(None)),
             reject_scheduler_stream,
             outbound_result_batch_size: Arc::new(AtomicU64::new(0)),
@@ -123,6 +125,10 @@ impl BamNodeApi for MockBamNode {
         _request: Request<ConfigRequest>,
     ) -> Result<Response<ConfigResponse>, Status> {
         self.config_requests.fetch_add(1, Ordering::Relaxed);
+        let config_response_delay_ms = self.config_response_delay_ms.load(Ordering::Relaxed);
+        if config_response_delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(config_response_delay_ms)).await;
+        }
         let config = self.config.lock().unwrap().clone();
         Ok(Response::new(ConfigResponse {
             block_engine_config: Some(BlockEngineBuilderConfig {
@@ -244,6 +250,7 @@ struct MockServerHandle {
     scheduler_stream_rejections: Arc<AtomicU64>,
     #[allow(dead_code)]
     config: Arc<Mutex<MockConfig>>,
+    config_response_delay_ms: Arc<AtomicU64>,
     batch_to_send: Arc<Mutex<Option<AtomicTxnBatch>>>,
     outbound_result_batch_size: Arc<AtomicU64>,
 }
@@ -268,6 +275,7 @@ async fn start_mock_server(
         config_requests: Arc::clone(&mock.config_requests),
         scheduler_stream_rejections: Arc::clone(&mock.scheduler_stream_rejections),
         config: Arc::clone(&mock.config),
+        config_response_delay_ms: Arc::clone(&mock.config_response_delay_ms),
         batch_to_send: Arc::clone(&mock.batch_to_send),
         outbound_result_batch_size: Arc::clone(&mock.outbound_result_batch_size),
     };
@@ -495,6 +503,41 @@ mod bam_connection_tests {
         let config = connection.get_latest_config().expect("config should exist");
         let bam_config = config.bam_config.expect("bam_config should exist");
         assert_eq!(bam_config.commission_bps, 100);
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_cancels_inflight_config_refresh() {
+        let send_heartbeats = Arc::new(AtomicBool::new(true));
+        let server = start_mock_server(send_heartbeats, Duration::from_secs(1), false).await;
+        server.config_response_delay_ms.store(5_000, Ordering::Relaxed);
+
+        let cluster_info = create_test_cluster_info();
+        let (batch_tx, _batch_rx, _outbound_tx, mut outbound_rx) = create_channels();
+
+        let connection = BamConnection::try_init(
+            format!("http://{}", server.addr),
+            cluster_info,
+            batch_tx,
+            &mut outbound_rx,
+        )
+        .await
+        .expect("should connect");
+
+        let start = std::time::Instant::now();
+        while start.elapsed() < Duration::from_secs(5) {
+            if server.config_requests.load(Ordering::Relaxed) > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(server.config_requests.load(Ordering::Relaxed), 1);
+
+        let shutdown_start = std::time::Instant::now();
+        let _outbound_rx = connection.shutdown().await;
+        assert!(
+            shutdown_start.elapsed() < Duration::from_millis(100),
+            "shutdown should cancel refresh_config before the abort grace timeout"
+        );
     }
 
     #[tokio::test]

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -509,7 +509,9 @@ mod bam_connection_tests {
     async fn test_shutdown_cancels_inflight_config_refresh() {
         let send_heartbeats = Arc::new(AtomicBool::new(true));
         let server = start_mock_server(send_heartbeats, Duration::from_secs(1), false).await;
-        server.config_response_delay_ms.store(5_000, Ordering::Relaxed);
+        server
+            .config_response_delay_ms
+            .store(5_000, Ordering::Relaxed);
 
         let cluster_info = create_test_cluster_info();
         let (batch_tx, _batch_rx, _outbound_tx, mut outbound_rx) = create_channels();

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -624,7 +624,6 @@ impl AdminRpc for AdminRpcImpl {
         let manual_disconnect = bam_url.as_deref().is_some_and(|url| url.trim().is_empty());
         let bam_url = bam_url.filter(|url| !url.trim().is_empty());
         let old_bam_url = meta.bam_url.load();
-        debug!("set_bam_url old= {old_bam_url:?}, new={bam_url:?}");
 
         if let Some(new_bam_url) = &bam_url {
             Endpoint::from_str(new_bam_url).map_err(|e| {


### PR DESCRIPTION
#### Problem

BAM URL changes were only logged when an active connection noticed a URL mismatch. If the validator was already disconnected or retrying, a later URL change could be picked up silently.

During intentional BAM disconnects, `refresh_config` could also be waiting on its interval or config RPC. Shutdown only waited 100ms before aborting it, causing this noisy warning:

`BAM task refresh_config did not exit within 100ms; aborting`

#### Summary of Changes

- Track the last observed BAM URL in `BamManager` and log every configured URL change.
- Cancel the BAM config refresh task with a one-shot shutdown signal before waiting on task shutdown.
- Remove the redundant `set_bam_url` debug log.
- Add coverage for shutdown while config refresh is in flight