### PR TITLE
Use native CA roots

### DIFF
--- a/core/src/proxy/mod.rs
+++ b/core/src/proxy/mod.rs
@@ -123,7 +123,7 @@ fn endpoint_from_url(
         .tcp_keepalive(Some(Duration::from_secs(60)));
     if url.starts_with("https") {
         endpoint = endpoint
-            .tls_config(tonic::transport::ClientTlsConfig::new())
+            .tls_config(tonic::transport::ClientTlsConfig::new().with_native_roots())
             .map_err(|_| tls_error())?;
     }
     Ok(endpoint)


### PR DESCRIPTION
#### Problem

We have started seeing BlockEngine connection error after upgrading to 4.1, related to certificate.
```
[2026-07-01T15:52:20.012183242Z WARN  solana_metrics::metrics] datapoint: block_engine_stage-proxy_error count=343i error="BlockEngineConnectionError: tonic::transport::Error(Transport, ConnectError(Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) }))"
```

After digging a bit it looks like it was caused by `tonic` upgrade to 0.14.6.

Looks like `ClientTlsConfig::new()` creates an empty trust store so no certificates can be trusted. With 0.9.2 certs were loaded automatically if the cargo feature was enabled, which is no longer the case in 0.14.6.

Ref tonic 0.9.2 https://github.com/grpc/grpc-rust/blob/v0.9.2/tonic/src/transport/service/tls.rs#L38-L67

Ref tonic 0.14.6 https://github.com/grpc/grpc-rust/blob/tonic-v0.14.6/tonic/src/transport/channel/service/tls.rs#L86 (flag needs to be set to true)

#### Summary of Changes

This fixes the issue by explicitly calling `with_native_roots()` on TLS config.

We have patched our Solana clients with this and we no longer see the error.

Fixes #
