### PR TITLE
Cleanup BAM Connection

### DIFF
--- a/bam-banking-bench/src/mock_bam_server.rs
+++ b/bam-banking-bench/src/mock_bam_server.rs
@@ -1,7 +1,9 @@
 use {
     bytes::{BufMut, BytesMut},
     crossbeam_channel::Sender,
-    jito_protos::proto::bam_types::{AtomicTxnBatch, AtomicTxnBatchResult, Packet},
+    jito_protos::proto::bam_types::{
+        AtomicTxnBatch, AtomicTxnBatchResult, MultipleAtomicTxnBatch, Packet,
+    },
     solana_compute_budget_interface::ComputeBudgetInstruction,
     solana_core::bam_dependencies::BamOutboundMessage,
     solana_hash::Hash,
@@ -141,7 +143,7 @@ pub(crate) struct MockBamServer;
 
 impl MockBamServer {
     pub(crate) fn run(
-        batch_sender: Sender<AtomicTxnBatch>,
+        batch_sender: Sender<MultipleAtomicTxnBatch>,
         mut outbound_receiver: tokio::sync::mpsc::Receiver<BamOutboundMessage>,
         shared_leader_state: SharedLeaderState,
         exit: Arc<AtomicBool>,
@@ -222,7 +224,7 @@ impl MockBamServer {
     fn send_transactions(
         keypairs: &[Keypair],
         bank_stats: &mut BankStats,
-        batch_sender: &Sender<AtomicTxnBatch>,
+        batch_sender: &Sender<MultipleAtomicTxnBatch>,
         bank: &Arc<Bank>,
         nonce: &mut u64,
         seq_id: &mut u32,
@@ -255,7 +257,11 @@ impl MockBamServer {
                 }],
             };
 
-            batch_sender.send(atomic_txn_batch).unwrap();
+            batch_sender
+                .send(MultipleAtomicTxnBatch {
+                    batches: vec![atomic_txn_batch],
+                })
+                .unwrap();
 
             bank_stats.sent_transactions_and_results.insert(
                 *seq_id,

--- a/core/src/bam_connection.rs
+++ b/core/src/bam_connection.rs
@@ -11,7 +11,8 @@ use {
             scheduler_response::VersionedMsg, scheduler_response_v0::Resp,
         },
         bam_types::{
-            AtomicTxnBatch, AuthProof, MultipleAtomicTxnBatchResult, Pong, ValidatorHeartBeat,
+            AuthProof, MultipleAtomicTxnBatch, MultipleAtomicTxnBatchResult, Pong,
+            ValidatorHeartBeat,
         },
     },
     solana_gossip::cluster_info::ClusterInfo,
@@ -34,6 +35,7 @@ use {
 
 pub struct BamConnection {
     config: Arc<Mutex<Option<ConfigResponse>>>,
+    config_version: Arc<AtomicU64>,
     connection_task: tokio::task::JoinHandle<mpsc::Receiver<BamOutboundMessage>>,
     is_healthy: Arc<AtomicBool>,
     url: String,
@@ -59,7 +61,7 @@ impl BamConnection {
     pub async fn try_init(
         url: String,
         cluster_info: Arc<ClusterInfo>,
-        batch_sender: crossbeam_channel::Sender<AtomicTxnBatch>,
+        batch_sender: crossbeam_channel::Sender<MultipleAtomicTxnBatch>,
         outbound_receiver: &mut Option<mpsc::Receiver<BamOutboundMessage>>,
     ) -> Result<Self, TryInitError> {
         // Create connection and inbound and outbound streams
@@ -87,9 +89,9 @@ impl BamConnection {
             .expect("BAM outbound receiver already in use");
 
         // Create data structures for the connection task
-        let metrics = Arc::new(BamConnectionMetrics::default());
         let is_healthy = Arc::new(AtomicBool::new(false));
         let config = Arc::new(Mutex::new(None));
+        let config_version = Arc::new(AtomicU64::new(0));
         let connection_exit = Arc::new(AtomicBool::new(false));
 
         // Start the connection task
@@ -99,15 +101,16 @@ impl BamConnection {
             outbound_sender,
             validator_client,
             config.clone(),
+            config_version.clone(),
             batch_sender,
             cluster_info,
-            metrics.clone(),
             is_healthy.clone(),
             outbound_receiver,
         ));
 
         Ok(Self {
             config,
+            config_version,
             connection_task,
             is_healthy,
             url,
@@ -122,12 +125,13 @@ impl BamConnection {
         outbound_sender: mpsc::Sender<SchedulerMessage>,
         mut validator_client: BamNodeApiClient<tonic::transport::channel::Channel>,
         config: Arc<Mutex<Option<ConfigResponse>>>,
-        batch_sender: crossbeam_channel::Sender<AtomicTxnBatch>,
+        config_version: Arc<AtomicU64>,
+        batch_sender: crossbeam_channel::Sender<MultipleAtomicTxnBatch>,
         cluster_info: Arc<ClusterInfo>,
-        metrics: Arc<BamConnectionMetrics>,
         is_healthy: Arc<AtomicBool>,
         mut outbound_receiver: mpsc::Receiver<BamOutboundMessage>,
     ) -> mpsc::Receiver<BamOutboundMessage> {
+        let mut metrics = BamConnectionMetrics::default();
         let mut last_heartbeat = None;
         let mut heartbeat_interval = interval(VALIDATOR_HEARTBEAT_INTERVAL);
         heartbeat_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -170,15 +174,13 @@ impl BamConnection {
                                 .as_micros()).unwrap_or_default(),
                         })),
                     }));
-                    metrics.heartbeat_sent.fetch_add(1, Relaxed);
+                    metrics.heartbeat_sent += 1;
                 }
                 _ = metrics_and_health_check_interval.tick() => {
                     let is_healthy_now = last_heartbeat.is_some_and(|t: Instant| t.elapsed() < MAX_DURATION_BETWEEN_NODE_HEARTBEATS);
                     is_healthy.store(is_healthy_now, Relaxed);
                     if !is_healthy_now {
-                        metrics
-                            .unhealthy_connection_count
-                            .fetch_add(1, Relaxed);
+                        metrics.unhealthy_connection_count += 1;
                     }
 
                     metrics.report();
@@ -204,7 +206,8 @@ impl BamConnection {
                     // The first successful inbound scheduler message proves the auth'd stream was accepted.
                     if let Some(mut validator_client) = post_auth_client.take() {
                         let config = config.clone();
-                        let metrics = metrics.clone();
+                        let config_version = config_version.clone();
+                        let builder_config_received = metrics.builder_config_received.clone();
                         let (exit_sender, mut exit_receiver) = oneshot::channel();
                         refresh_config_exit_sender = Some(exit_sender);
                         refresh_config_task = Some(tokio::spawn(async move {
@@ -228,7 +231,8 @@ impl BamConnection {
                                 match result {
                                     Ok(Ok(response)) => {
                                         *config.lock().unwrap() = Some(response.into_inner());
-                                        metrics.builder_config_received.fetch_add(1, Relaxed);
+                                        config_version.fetch_add(1, Relaxed);
+                                        builder_config_received.fetch_add(1, Relaxed);
                                     }
                                     Ok(Err(e)) => error!("Failed to get config: {e:?}"),
                                     Err(_) => error!("Timed out getting config"),
@@ -240,14 +244,13 @@ impl BamConnection {
                     match inbound {
                         SchedulerResponseV0 { resp: Some(Resp::HeartBeat(_)), .. } => {
                             last_heartbeat = Some(Instant::now());
-                            metrics.heartbeat_received.fetch_add(1, Relaxed);
+                            metrics.heartbeat_received += 1;
                         }
                         SchedulerResponseV0 { resp: Some(Resp::MultipleAtomicTxnBatch(batches)), .. } => {
-                            for batch in batches.batches {
-                                metrics.bundle_received.fetch_add(1, Relaxed);
-                                if batch_sender.try_send(batch).is_err() {
-                                    metrics.bundle_forward_to_scheduler_fail.fetch_add(1, Relaxed);
-                                }
+                            let num_batches = batches.batches.len() as u64;
+                            metrics.bundle_received += num_batches;
+                            if num_batches > 0 && batch_sender.try_send(batches).is_err() {
+                                metrics.bundle_forward_to_scheduler_fail += num_batches;
                             }
                         }
                         SchedulerResponseV0 { resp: Some(Resp::Ping(ping)), .. } => {
@@ -255,9 +258,9 @@ impl BamConnection {
                                 msg: Some(Msg::Pong(Pong { id: ping.id })),
                             };
                             if outbound_sender.try_send(v0_to_versioned_proto(outbound)).is_err() {
-                                metrics.outbound_fail.fetch_add(1, Relaxed);
+                                metrics.outbound_fail += 1;
                             } else {
-                                metrics.outbound_sent.fetch_add(1, Relaxed);
+                                metrics.outbound_sent += 1;
                             }
                         }
                         _ => {}
@@ -288,30 +291,30 @@ impl BamConnection {
                                 }
                             }
 
-                            metrics.bundleresult_sent.fetch_add(results.len() as u64, Relaxed);
+                            metrics.bundleresult_sent += results.len() as u64;
                             let outbound = SchedulerMessageV0 {
                                 msg: Some(Msg::MultipleAtomicTxnBatchResult(
                                     MultipleAtomicTxnBatchResult { results },
                                 )),
                             };
                             if outbound_sender.try_send(v0_to_versioned_proto(outbound)).is_err() {
-                                metrics.outbound_fail.fetch_add(1, Relaxed);
+                                metrics.outbound_fail += 1;
                             } else {
-                                metrics.outbound_sent.fetch_add(1, Relaxed);
+                                metrics.outbound_sent += 1;
                             }
                             leader_state_to_send
                         }
                     };
 
                     if let Some(leader_state) = leader_state_to_send {
-                        metrics.leaderstate_sent.fetch_add(1, Relaxed);
+                        metrics.leaderstate_sent += 1;
                         let outbound = SchedulerMessageV0 {
                             msg: Some(Msg::LeaderState(leader_state)),
                         };
                         if outbound_sender.try_send(v0_to_versioned_proto(outbound)).is_err() {
-                            metrics.outbound_fail.fetch_add(1, Relaxed);
+                            metrics.outbound_fail += 1;
                         } else {
-                            metrics.outbound_sent.fetch_add(1, Relaxed);
+                            metrics.outbound_sent += 1;
                         }
                     }
 
@@ -359,7 +362,7 @@ impl BamConnection {
             if self.connection_task.is_finished() {
                 return false;
             }
-            if self.get_latest_config().is_some() {
+            if self.is_healthy() && self.config_version.load(Relaxed) > 0 {
                 return true;
             }
             std::thread::sleep(WAIT_SLEEP_DURATION);
@@ -387,6 +390,24 @@ impl BamConnection {
             return None;
         }
         self.config.lock().unwrap().clone()
+    }
+
+    pub fn get_latest_config_if_changed(
+        &self,
+        last_seen_version: &mut u64,
+    ) -> Option<ConfigResponse> {
+        if !self.is_healthy() {
+            return None;
+        }
+        let current_version = self.config_version.load(Relaxed);
+        if current_version == 0 || current_version == *last_seen_version {
+            return None;
+        }
+        let config = self.config.lock().unwrap().clone();
+        if config.is_some() {
+            *last_seen_version = current_version;
+        }
+        config
     }
 
     pub fn url(&self) -> &str {
@@ -467,91 +488,72 @@ impl Drop for BamConnection {
 
 #[derive(Default)]
 struct BamConnectionMetrics {
-    bundle_received: AtomicU64,
-    bundle_forward_to_scheduler_fail: AtomicU64,
-    heartbeat_received: AtomicU64,
-    builder_config_received: AtomicU64,
+    bundle_received: u64,
+    bundle_forward_to_scheduler_fail: u64,
+    heartbeat_received: u64,
+    builder_config_received: Arc<AtomicU64>,
 
-    unhealthy_connection_count: AtomicU64,
+    unhealthy_connection_count: u64,
 
-    leaderstate_sent: AtomicU64,
-    bundleresult_sent: AtomicU64,
-    heartbeat_sent: AtomicU64,
-    outbound_sent: AtomicU64,
-    outbound_fail: AtomicU64,
+    leaderstate_sent: u64,
+    bundleresult_sent: u64,
+    heartbeat_sent: u64,
+    outbound_sent: u64,
+    outbound_fail: u64,
 }
 
 impl BamConnectionMetrics {
     fn has_data(&self) -> bool {
-        self.bundle_received.load(Relaxed) > 0
-            || self.bundle_forward_to_scheduler_fail.load(Relaxed) > 0
-            || self.heartbeat_received.load(Relaxed) > 0
+        self.bundle_received > 0
+            || self.bundle_forward_to_scheduler_fail > 0
+            || self.heartbeat_received > 0
             || self.builder_config_received.load(Relaxed) > 0
-            || self.unhealthy_connection_count.load(Relaxed) > 0
-            || self.leaderstate_sent.load(Relaxed) > 0
-            || self.bundleresult_sent.load(Relaxed) > 0
-            || self.heartbeat_sent.load(Relaxed) > 0
-            || self.outbound_sent.load(Relaxed) > 0
-            || self.outbound_fail.load(Relaxed) > 0
+            || self.unhealthy_connection_count > 0
+            || self.leaderstate_sent > 0
+            || self.bundleresult_sent > 0
+            || self.heartbeat_sent > 0
+            || self.outbound_sent > 0
+            || self.outbound_fail > 0
     }
 
-    fn report(&self) {
+    fn report(&mut self) {
         if !self.has_data() {
             return;
         }
         datapoint_info!(
             "bam_connection-metrics",
-            (
-                "bundle_received",
-                self.bundle_received.swap(0, Relaxed) as i64,
-                i64
-            ),
+            ("bundle_received", self.bundle_received, i64),
             (
                 "bundle_forward_to_scheduler_fail",
-                self.bundle_forward_to_scheduler_fail.swap(0, Relaxed) as i64,
+                self.bundle_forward_to_scheduler_fail,
                 i64
             ),
-            (
-                "heartbeat_received",
-                self.heartbeat_received.swap(0, Relaxed) as i64,
-                i64
-            ),
+            ("heartbeat_received", self.heartbeat_received, i64),
             (
                 "builder_config_received",
-                self.builder_config_received.swap(0, Relaxed) as i64,
+                self.builder_config_received.swap(0, Relaxed),
                 i64
             ),
             (
                 "unhealthy_connection_count",
-                self.unhealthy_connection_count.swap(0, Relaxed) as i64,
+                self.unhealthy_connection_count,
                 i64
             ),
-            (
-                "leaderstate_sent",
-                self.leaderstate_sent.swap(0, Relaxed) as i64,
-                i64
-            ),
-            (
-                "bundleresult_sent",
-                self.bundleresult_sent.swap(0, Relaxed) as i64,
-                i64
-            ),
-            (
-                "heartbeat_sent",
-                self.heartbeat_sent.swap(0, Relaxed) as i64,
-                i64
-            ),
-            (
-                "outbound_sent",
-                self.outbound_sent.swap(0, Relaxed) as i64,
-                i64
-            ),
-            (
-                "outbound_fail",
-                self.outbound_fail.swap(0, Relaxed) as i64,
-                i64
-            )
+            ("leaderstate_sent", self.leaderstate_sent, i64),
+            ("bundleresult_sent", self.bundleresult_sent, i64),
+            ("heartbeat_sent", self.heartbeat_sent, i64),
+            ("outbound_sent", self.outbound_sent, i64),
+            ("outbound_fail", self.outbound_fail, i64)
         );
+        self.bundle_received = 0;
+        self.bundle_forward_to_scheduler_fail = 0;
+        self.heartbeat_received = 0;
+        self.unhealthy_connection_count = 0;
+        self.leaderstate_sent = 0;
+        self.bundleresult_sent = 0;
+        self.heartbeat_sent = 0;
+        self.outbound_sent = 0;
+        self.outbound_fail = 0;
     }
 }
 

--- a/core/src/bam_dependencies.rs
+++ b/core/src/bam_dependencies.rs
@@ -44,8 +44,8 @@ pub struct BamDependencies {
     /// 0 = disconnected, 1 = connecting, 2 = connected
     pub bam_enabled: Arc<AtomicU8>,
 
-    pub batch_sender: crossbeam_channel::Sender<bam_types::AtomicTxnBatch>,
-    pub batch_receiver: crossbeam_channel::Receiver<bam_types::AtomicTxnBatch>,
+    pub batch_sender: crossbeam_channel::Sender<bam_types::MultipleAtomicTxnBatch>,
+    pub batch_receiver: crossbeam_channel::Receiver<bam_types::MultipleAtomicTxnBatch>,
 
     pub outbound_sender: mpsc::Sender<BamOutboundMessage>,
 

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -126,6 +126,7 @@ impl BamManager {
         let mut current_connection = None;
         let mut outbound_receiver = Some(outbound_receiver);
         let mut cached_builder_config = None;
+        let mut cached_builder_config_version = 0;
         let mut last_observed_bam_url = bam_url.load_full();
         let shared_leader_state = poh_recorder.read().unwrap().shared_leader_state();
 
@@ -156,6 +157,7 @@ impl BamManager {
                         &mut cached_builder_config,
                         true,
                     ) {
+                        cached_builder_config_version = 0;
                         continue;
                     }
 
@@ -175,6 +177,7 @@ impl BamManager {
                     dependencies
                         .bam_enabled
                         .store(BamConnectionState::Connecting as u8, Ordering::Relaxed);
+                    cached_builder_config_version = 0;
                     let result = runtime.block_on(BamConnection::try_init(
                         url.clone(),
                         dependencies.cluster_info.clone(),
@@ -202,6 +205,7 @@ impl BamManager {
                              retry",
                         );
                         cached_builder_config = None;
+                        cached_builder_config_version = 0;
                         Self::set_bam_disconnected(&dependencies);
                         outbound_receiver = Some(runtime.block_on(connection.shutdown()));
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
@@ -209,7 +213,9 @@ impl BamManager {
                     }
 
                     info!("BAM connection established");
-                    if let Some(builder_config) = connection.get_latest_config() {
+                    if let Some(builder_config) =
+                        connection.get_latest_config_if_changed(&mut cached_builder_config_version)
+                    {
                         Self::update_tpu_config(&builder_config, &dependencies);
                         Self::update_shred_socks_config(&builder_config, &dependencies);
                         Self::update_block_engine_key_and_commission(
@@ -229,6 +235,7 @@ impl BamManager {
 
             let disconnect = if !connection.is_healthy() {
                 cached_builder_config = None;
+                cached_builder_config_version = 0;
                 Self::set_bam_disconnected(&dependencies);
                 warn!("BAM connection unhealthy");
                 true
@@ -240,12 +247,14 @@ impl BamManager {
                 &mut cached_builder_config,
                 false,
             ) {
+                cached_builder_config_version = 0;
                 true
             } else {
                 if configured_bam_url.as_deref() == Some(connection.url()) {
                     false
                 } else {
                     cached_builder_config = None;
+                    cached_builder_config_version = 0;
                     Self::set_bam_disconnected(&dependencies);
                     true
                 }
@@ -257,7 +266,8 @@ impl BamManager {
             }
 
             // Check if block builder info has changed
-            if let Some(builder_config) = connection.get_latest_config()
+            if let Some(builder_config) =
+                connection.get_latest_config_if_changed(&mut cached_builder_config_version)
                 && Some(&builder_config) != cached_builder_config.as_ref()
             {
                 Self::update_tpu_config(&builder_config, &dependencies);

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -34,7 +34,7 @@ use {
     histogram::Histogram,
     itertools::Itertools,
     jito_protos::proto::bam_types::{
-        AtomicTxnBatch, DeserializationErrorReason, Packet, SchedulingError,
+        DeserializationErrorReason, MultipleAtomicTxnBatch, Packet, SchedulingError,
         TransactionErrorReason, atomic_txn_batch_result, not_committed::Reason,
     },
     smallvec::SmallVec,
@@ -65,7 +65,7 @@ use {
     tokio::sync::mpsc::Sender as TokioSender,
 };
 
-type PrevalidationResult = Result<(usize, bool, u32, u64), (Reason, u32)>;
+type PrevalidationResult = Result<(bool, u32, u64), (Reason, u32)>;
 type VerifyResult = Result<(Vec<Bytes>, bool, u32, u64), (Reason, u32)>;
 
 pub struct BamReceiveAndBuffer {
@@ -90,7 +90,7 @@ impl BamReceiveAndBuffer {
     pub fn new(
         exit: Arc<AtomicBool>,
         bam_enabled: Arc<AtomicU8>,
-        bundle_receiver: crossbeam_channel::Receiver<AtomicTxnBatch>,
+        bundle_receiver: crossbeam_channel::Receiver<MultipleAtomicTxnBatch>,
         response_sender: TokioSender<BamOutboundMessage>,
         bank_forks: Arc<RwLock<BankForks>>,
         shared_leader_state: Option<SharedLeaderState>,
@@ -127,7 +127,7 @@ impl BamReceiveAndBuffer {
 
     fn run_parsing(
         exit: Arc<AtomicBool>,
-        bundle_receiver: crossbeam_channel::Receiver<AtomicTxnBatch>,
+        bundle_receiver: crossbeam_channel::Receiver<MultipleAtomicTxnBatch>,
         parsed_batch_sender: crossbeam_channel::Sender<ParsedBatch>,
         recv_stats_sender: crossbeam_channel::Sender<ReceivingStats>,
         response_sender: TokioSender<BamOutboundMessage>,
@@ -148,7 +148,7 @@ impl BamReceiveAndBuffer {
         let mut packet_batches = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
         let mut verify_results = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
         const METRICS_REPORT_INTERVAL: Duration = Duration::from_millis(20);
-        let mut recv_buffer = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST * 2);
+        let mut recv_buffer = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
 
         while !exit.load(Ordering::Relaxed) {
             let loop_start = Instant::now();
@@ -169,9 +169,7 @@ impl BamReceiveAndBuffer {
             stats.receive_time_us += loop_start.elapsed().as_micros() as u64;
 
             match recv_info {
-                Ok((_, num_batches_received)) => {
-                    stats.num_received += num_batches_received;
-                }
+                Ok(num_batches_received) => stats.num_received += num_batches_received,
                 Err(RecvTimeoutError::Disconnected) => return,
                 Err(RecvTimeoutError::Timeout) => {
                     // No more work to do
@@ -534,54 +532,55 @@ impl BamReceiveAndBuffer {
     }
 
     fn batch_receive_until(
-        bundle_receiver: &crossbeam_channel::Receiver<AtomicTxnBatch>,
-        recv_buffer: &mut Vec<AtomicTxnBatch>,
+        bundle_receiver: &crossbeam_channel::Receiver<MultipleAtomicTxnBatch>,
+        recv_buffer: &mut Vec<MultipleAtomicTxnBatch>,
         &start: &Instant,
         recv_timeout: Duration,
         batch_count_upperbound: usize,
-    ) -> Result<(usize, usize), RecvTimeoutError> {
-        let batch = bundle_receiver.recv_timeout(recv_timeout)?;
-        let mut num_packets_received = batch.packets.len();
-        let mut num_atomic_txn_batches_received = 1;
-        recv_buffer.push(batch);
+    ) -> Result<usize, RecvTimeoutError> {
+        let batches = bundle_receiver.recv_timeout(recv_timeout)?;
+        let mut num_atomic_txn_batches_received = batches.batches.len();
+        let mut channel_messages_received = 1;
+        recv_buffer.push(batches);
 
-        while let Ok(batch) = bundle_receiver.try_recv() {
-            num_packets_received += batch.packets.len();
-            num_atomic_txn_batches_received += 1;
-            recv_buffer.push(batch);
-            if recv_buffer.len() >= batch_count_upperbound
-                || (num_atomic_txn_batches_received % 8 == 1 && start.elapsed() > recv_timeout)
-            // check if time exceeded on every 8th iteration
-            {
+        while num_atomic_txn_batches_received < batch_count_upperbound {
+            let Ok(next_batches) = bundle_receiver.try_recv() else {
+                break;
+            };
+            num_atomic_txn_batches_received += next_batches.batches.len();
+            recv_buffer.push(next_batches);
+            channel_messages_received += 1;
+            if channel_messages_received % 8 == 1 && start.elapsed() > recv_timeout {
                 break;
             }
         }
 
-        Ok((num_packets_received, num_atomic_txn_batches_received))
+        Ok(num_atomic_txn_batches_received)
     }
 
     /// Check basic constraints and extract revert_on_error flags
     fn prevalidate_batches(
-        atomic_txn_batches: &[AtomicTxnBatch],
+        atomic_txn_batch_groups: &[MultipleAtomicTxnBatch],
         current_slot: Slot,
         prevalidated: &mut Vec<PrevalidationResult>,
     ) -> ReceivingStats {
         let mut stats = ReceivingStats::default();
 
         prevalidated.clear();
-        prevalidated.extend(atomic_txn_batches.iter().enumerate().map(
-            |(batch_index, atomic_txn_batch)| {
+        for atomic_txn_batch_group in atomic_txn_batch_groups {
+            for atomic_txn_batch in &atomic_txn_batch_group.batches {
                 if atomic_txn_batch.max_schedule_slot < current_slot {
                     stats.num_dropped_without_parsing += 1;
-                    return Err((
+                    prevalidated.push(Err((
                         Reason::SchedulingError(SchedulingError::OutsideLeaderSlot as i32),
                         atomic_txn_batch.seq_id,
-                    ));
+                    )));
+                    continue;
                 }
 
                 if atomic_txn_batch.packets.is_empty() {
                     stats.num_dropped_without_parsing += 1;
-                    return Err((
+                    prevalidated.push(Err((
                         Reason::DeserializationError(
                             jito_protos::proto::bam_types::DeserializationError {
                                 index: 0,
@@ -589,12 +588,13 @@ impl BamReceiveAndBuffer {
                             },
                         ),
                         atomic_txn_batch.seq_id,
-                    ));
+                    )));
+                    continue;
                 }
 
                 if atomic_txn_batch.packets.len() > MAX_PACKETS_PER_BUNDLE {
                     stats.num_dropped_without_parsing += 1;
-                    return Err((
+                    prevalidated.push(Err((
                         Reason::DeserializationError(
                             jito_protos::proto::bam_types::DeserializationError {
                                 index: 0,
@@ -602,7 +602,8 @@ impl BamReceiveAndBuffer {
                             },
                         ),
                         atomic_txn_batch.seq_id,
-                    ));
+                    )));
+                    continue;
                 }
 
                 let Ok(revert_on_error) = atomic_txn_batch
@@ -617,7 +618,7 @@ impl BamReceiveAndBuffer {
                     .all_equal_value()
                 else {
                     stats.num_dropped_without_parsing += 1;
-                    return Err((
+                    prevalidated.push(Err((
                         Reason::DeserializationError(
                             jito_protos::proto::bam_types::DeserializationError {
                                 index: 0,
@@ -625,24 +626,24 @@ impl BamReceiveAndBuffer {
                             },
                         ),
                         atomic_txn_batch.seq_id,
-                    ));
+                    )));
+                    continue;
                 };
 
-                Ok((
-                    batch_index,
+                prevalidated.push(Ok((
                     revert_on_error,
                     atomic_txn_batch.seq_id,
                     atomic_txn_batch.max_schedule_slot,
-                ))
-            },
-        ));
+                )));
+            }
+        }
 
         stats
     }
 
     fn batch_verify(
         sigverify_thread_pool: &rayon::ThreadPool,
-        atomic_txn_batches: &mut [AtomicTxnBatch],
+        atomic_txn_batches: &mut [MultipleAtomicTxnBatch],
         current_slot: Slot,
         metrics: &mut BamReceiveAndBufferMetrics,
         prevalidated: &mut Vec<PrevalidationResult>,
@@ -654,39 +655,43 @@ impl BamReceiveAndBuffer {
         packet_batches.clear();
         packet_batches.reserve(prevalidated.len());
         let mut packet_count = 0;
-        prevalidated.iter().flatten().for_each(|result| {
-            let atomic_txn_batch = &mut atomic_txn_batches[result.0];
-            let solana_packet_batch: Vec<_> = atomic_txn_batch
-                .packets
-                .drain(..)
-                .map(|from_packet| {
-                    let Packet { data, meta } = from_packet;
-                    let data_len = data.len();
-                    if data_len > PACKET_DATA_SIZE {
-                        let mut to_packet = BytesPacket::new(Bytes::new(), Meta::default());
-                        to_packet.meta_mut().set_discard(true);
-                        return to_packet;
-                    }
+        atomic_txn_batches
+            .iter_mut()
+            .flat_map(|group| group.batches.iter_mut())
+            .zip(prevalidated.iter())
+            .filter(|(_, pre_result)| pre_result.is_ok())
+            .for_each(|(atomic_txn_batch, _)| {
+                let solana_packet_batch: Vec<_> = atomic_txn_batch
+                    .packets
+                    .drain(..)
+                    .map(|from_packet| {
+                        let Packet { data, meta } = from_packet;
+                        let data_len = data.len();
+                        if data_len > PACKET_DATA_SIZE {
+                            let mut to_packet = BytesPacket::new(Bytes::new(), Meta::default());
+                            to_packet.meta_mut().set_discard(true);
+                            return to_packet;
+                        }
 
-                    let mut to_packet = BytesPacket::new(data, Meta::default());
-                    to_packet.meta_mut().size = data_len;
+                        let mut to_packet = BytesPacket::new(data, Meta::default());
+                        to_packet.meta_mut().size = data_len;
 
-                    if let Some(meta) = meta
-                        && meta.flags.is_some_and(|flags| flags.simple_vote_tx)
-                    {
+                        if let Some(meta) = meta
+                            && meta.flags.is_some_and(|flags| flags.simple_vote_tx)
+                        {
+                            to_packet
+                                .meta_mut()
+                                .flags
+                                .insert(PacketFlags::SIMPLE_VOTE_TX);
+                        }
                         to_packet
-                            .meta_mut()
-                            .flags
-                            .insert(PacketFlags::SIMPLE_VOTE_TX);
-                    }
-                    to_packet
-                })
-                .collect();
-            packet_count += solana_packet_batch.len();
-            packet_batches.push(solana_perf::packet::PacketBatch::Bytes(
-                BytesPacketBatch::from(solana_packet_batch),
-            ));
-        });
+                    })
+                    .collect();
+                packet_count += solana_packet_batch.len();
+                packet_batches.push(solana_perf::packet::PacketBatch::Bytes(
+                    BytesPacketBatch::from(solana_packet_batch),
+                ));
+            });
 
         let mut verify_packet_batch_time_us = Measure::start("verify_packet_batch_time_us");
         ed25519_verify(
@@ -712,7 +717,7 @@ impl BamReceiveAndBuffer {
         results.reserve(prevalidated.len());
         let mut packet_batch_iter = packet_batches.drain(..);
         for pre_result in prevalidated.drain(..) {
-            let result = pre_result.and_then(|(_, revert_on_error, seq_id, max_schedule_slot)| {
+            let result = pre_result.and_then(|(revert_on_error, seq_id, max_schedule_slot)| {
                 let batch = packet_batch_iter.next().unwrap();
                 let solana_perf::packet::PacketBatch::Bytes(batch) = batch else {
                     unreachable!("BAM sigverify builds Bytes packet batches");
@@ -1051,6 +1056,7 @@ mod tests {
         },
         ahash::HashSetExt,
         crossbeam_channel::{Receiver, unbounded},
+        jito_protos::proto::bam_types::AtomicTxnBatch,
         solana_keypair::Keypair,
         solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_message::Message,
@@ -1077,7 +1083,7 @@ mod tests {
 
     #[allow(clippy::type_complexity)]
     fn setup_bam_receive_and_buffer(
-        receiver: crossbeam_channel::Receiver<AtomicTxnBatch>,
+        receiver: crossbeam_channel::Receiver<MultipleAtomicTxnBatch>,
         bank_forks: Arc<RwLock<BankForks>>,
         blacklisted_accounts: HashSet<Pubkey>,
     ) -> (
@@ -1127,7 +1133,7 @@ mod tests {
     }
 
     fn run_batch_verify(
-        mut batches: Vec<AtomicTxnBatch>,
+        batches: Vec<AtomicTxnBatch>,
         current_slot: Slot,
         metrics: &mut BamReceiveAndBufferMetrics,
     ) -> (Vec<VerifyResult>, ReceivingStats) {
@@ -1138,6 +1144,7 @@ mod tests {
         let mut prevalidated = Vec::new();
         let mut packet_batches = Vec::new();
         let mut results = Vec::new();
+        let mut batches = vec![MultipleAtomicTxnBatch { batches }];
         let stats = BamReceiveAndBuffer::batch_verify(
             &thread_pool,
             &mut batches,
@@ -1153,7 +1160,7 @@ mod tests {
     #[test_case(setup_bam_receive_and_buffer; "testcase-bam")]
     fn test_receive_and_buffer_simple_transfer<R: ReceiveAndBuffer>(
         setup_receive_and_buffer: impl FnOnce(
-            Receiver<AtomicTxnBatch>,
+            Receiver<MultipleAtomicTxnBatch>,
             Arc<RwLock<BankForks>>,
             HashSet<Pubkey>,
         ) -> (
@@ -1182,7 +1189,11 @@ mod tests {
             }],
             max_schedule_slot: Slot::MAX,
         };
-        sender.send(bundle).unwrap();
+        sender
+            .send(MultipleAtomicTxnBatch {
+                batches: vec![bundle],
+            })
+            .unwrap();
 
         let start = Instant::now();
         while start.elapsed() < Duration::from_secs(2) {
@@ -1213,7 +1224,11 @@ mod tests {
             }],
             max_schedule_slot: Slot::MAX,
         };
-        sender.send(bundle).unwrap();
+        sender
+            .send(MultipleAtomicTxnBatch {
+                batches: vec![bundle],
+            })
+            .unwrap();
 
         let ReceivingStats { num_received, .. } = receive_and_buffer
             .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -309,8 +309,8 @@ fn create_test_cluster_info() -> Arc<ClusterInfo> {
 }
 
 fn create_channels() -> (
-    crossbeam_channel::Sender<AtomicTxnBatch>,
-    crossbeam_channel::Receiver<AtomicTxnBatch>,
+    crossbeam_channel::Sender<MultipleAtomicTxnBatch>,
+    crossbeam_channel::Receiver<MultipleAtomicTxnBatch>,
     mpsc::Sender<BamOutboundMessage>,
     Option<mpsc::Receiver<BamOutboundMessage>>,
 ) {
@@ -584,7 +584,9 @@ mod bam_connection_tests {
 
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        let received = batch_rx.try_recv().expect("should receive batch");
+        let received_batches = batch_rx.try_recv().expect("should receive batch");
+        assert_eq!(received_batches.batches.len(), 1);
+        let received = &received_batches.batches[0];
         assert_eq!(received.seq_id, 42);
         assert_eq!(received.max_schedule_slot, 100);
 


### PR DESCRIPTION
#### Problem

BAM connection and scheduler paths did extra per-batch channel/metric work, and BAM manager reapplied builder config state even when the config had not changed.

#### Summary of Changes

- Send `MultipleAtomicTxnBatch` messages to scheduler instead of AtomicTxnBatch, reduces lock acquisition cost for channel
- Track builder config versions so BAM manager only reapplies TPU, shred socket, and block builder state when a new config arrives. Currently happens ~200x per second
- Keep BAM connection metrics as task-local counters where cross-task atomics are not needed.