### PR TITLE
Configurable faucet mint sol for local cluster

### DIFF
--- a/bam-local-cluster/README.md
+++ b/bam-local-cluster/README.md
@@ -44,6 +44,7 @@ Key configuration options:
 - `bam_url`: BAM service endpoint
 - `tip_payment_program_id` / `tip_distribution_program_id`: Tip manager programs
 - `faucet_address`: Faucet service for airdrops
+- `mint_sol`: Optional faucet genesis balance in SOL
 - `ledger_base_directory`: Base directory for validator ledgers
 - `validator_build_path`: Build output directory (e.g., "target/debug" or "target/release") - required
 - `ledger_tool_build_path`: Builder output for ledger tool (e.g., "target/debug" or "target/release") - required

--- a/bam-local-cluster/examples/example_config.toml
+++ b/bam-local-cluster/examples/example_config.toml
@@ -2,6 +2,7 @@ bam_url = "http://127.0.0.1:50055"
 tip_payment_program_id = "T1pyyaTNZsKv2WcRAB8oVnk93mLJw2XzjtVYqCsaHqt"
 tip_distribution_program_id = "4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7"
 faucet_address = "127.0.0.1:12345"
+mint_sol = 10000000000
 ledger_base_directory = "output/ledger"
 validator_build_path = "/path/to/jito-solana/target/release/"
 ledger_tool_build_path = "/path/to/jito-solana/dev-bins/target/release/"

--- a/bam-local-cluster/src/cluster_manager.rs
+++ b/bam-local-cluster/src/cluster_manager.rs
@@ -388,8 +388,17 @@ impl BamLocalCluster {
         }
 
         let stakes = vec![DEFAULT_NODE_STAKE; config.validators.len()];
+        let mint_lamports = config
+            .mint_sol
+            .map(|mint_sol| {
+                mint_sol.checked_mul(LAMPORTS_PER_SOL).ok_or_else(|| {
+                    anyhow::anyhow!("configured mint_sol ({mint_sol}) overflows lamports")
+                })
+            })
+            .transpose()?
+            .unwrap_or(solana_local_cluster::local_cluster::DEFAULT_MINT_LAMPORTS);
         let genesis_config_info = Self::create_genesis_config_with_vote_accounts_and_cluster_type(
-            solana_local_cluster::local_cluster::DEFAULT_MINT_LAMPORTS,
+            mint_lamports,
             &vote_keypairs,
             stakes,
             // Don't use mainnet, since we de-dupe local TVU IP addresses and every validator

--- a/bam-local-cluster/src/config.rs
+++ b/bam-local-cluster/src/config.rs
@@ -15,6 +15,9 @@ pub struct LocalClusterConfig {
     pub validators: Vec<CustomValidatorConfig>,
     pub dynamic_port_range_start: u16,
     pub hashes_per_tick: Option<u64>,
+    /// Faucet mint balance in SOL.
+    #[serde(default)]
+    pub mint_sol: Option<u64>,
     pub bind_address: Option<String>,
     pub gossip_host: Option<String>,
     pub limit_ledger_size: Option<u64>,


### PR DESCRIPTION
#### Problem
Some local cluster soak tests needs more than the DEFAULT_MINT_LAMPORTS for airdrops (long running tests with lots of key pairs in place)

#### Summary of Changes
Make the faucet mint sol configurable and make it a high value for local cluster configs

#### Testing


Fixes #
