### PR TITLE
fix(build): Clean up tagging mechanics

### DIFF
--- a/dev/BUILD.md
+++ b/dev/BUILD.md
@@ -15,20 +15,23 @@ through `dev/Dockerfile` (BuildKit multi-stage).
 ./f
 ```
 
-Release build of the current checkout. Artifacts land in `./dist/` and loose
-binaries in `./docker-output/` (repo root).
+Release build of the current checkout. On an untagged tree the channel
+defaults to `v<Cargo.toml version>_<shortsha>[-dirty]`. Artifacts land in
+`./dist/` and loose binaries in `./docker-output/` (repo root).
 
 ## Outputs
 
 | Path | Contents |
 |------|----------|
-| `dist/<basename>-<tag>-<target>.tar.bz2` | Release tarball |
-| `dist/<basename>-<tag>-<target>.yml` | Version manifest |
+| `dist/<basename>-<tag>_<target>.tar.bz2` | Release tarball |
+| `dist/<basename>-<tag>_<target>.yml` | Version manifest |
 | `docker-output/<bin>` | Loose binaries (legacy layout) |
 
-- **tag** -- from `--tag`, the `--checkout` ref, or `git describe`
-- **target** -- derived inside the container from the build platform
-  (e.g. `x86_64-unknown-linux-gnu` on `linux/amd64`)
+Example local artifact:
+
+```text
+dist/jito-solana-release-v4.3.0-alpha.0_abc1234_x86_64-unknown-linux-gnu.tar.bz2
+```
 
 Tarball binaries live under `jito-solana-release/bin/`.
 
@@ -36,15 +39,48 @@ Default curated set: `agave-validator`, `agave-ledger-tool`,
 `agave-watchtower`, `solana`, `solana-keygen`, `solana-genesis`,
 `solana-gossip`, `solana-faucet`.
 
+## Tag and filename rules
+
+Channel/tag embedded in `version.yml` and the artifact name (first match
+wins):
+
+1. `--tag VALUE` -- explicit channel/tag
+2. `--checkout REF` -- exact git tag at REF keeps the release name
+   (e.g. `v4.0.3-jito`); moving branches / other refs become
+   `<ref>-<shortsha>` (path separators become `_` in the filename)
+3. Exact git tag at HEAD -- standard release checkout
+4. Otherwise (local non-release) --
+   `v<Cargo.toml version>_<shortsha>[-dirty]`
+
+The platform target is joined with `_` (not `-`):
+
+```text
+<basename>-<tag>_<target>.tar.bz2
+```
+
+- **tag** -- see rules above
+- **target** -- derived inside the container from the build platform
+  (e.g. `x86_64-unknown-linux-gnu` on `linux/amd64`)
+
+Cargo workspace version is the tree's truth on master. Prefer it over
+`git describe`, which walks ancestor tags and often lands on ancient
+release-line tags that are not ancestors of later Jito cuts.
+
 ## Common invocations
 
 ```bash
+# Local untagged tree (Cargo version + short SHA [+ dirty])
+./f
+
 # Named release tag
 ./f --tag v4.0.3-jito
 
 # Build a tagged ref with current tooling (throwaway worktree)
 git fetch --tags origin
 ./f --checkout v4.0.3-jito
+
+# Build a moving branch (artifact tag includes short SHA)
+./f --checkout master
 
 # Debug build
 ./f --profile debug
@@ -59,8 +95,9 @@ git fetch --tags origin
    exporting the `export` stage to `./dist/` (or `--output`).
 2. **toolchain** -- Debian bookworm + Rust from `rust-toolchain.toml`.
 3. **builder** -- Patches upstream build scripts in-container only
-   (Jito binary set, DCOU excludes, no SBF SDK / spl-token / perf-libs),
-   runs `create-release-tarball.sh`, stages tarball + loose binaries.
+   (Jito binary set, DCOU excludes, no SBF SDK / spl-token / perf-libs,
+   `_` join before the target triple), runs
+   `create-release-tarball.sh`, stages tarball + loose binaries.
 4. **`f`** relocates `dist/docker-output/` to `./docker-output/` at the
    repo root for back-compat with existing deploy scripts.
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -15,7 +15,9 @@
 #   3. export     : FROM scratch. The host extracts /out via
 #                   `docker buildx build --output type=local,dest=...`.
 #
-# Driven by the `f` wrapper at the repo root.
+# Driven by the `f` wrapper at the repo root. Artifact names use
+# <basename>-<tag>_<target> (underscore before the platform triple).
+# See dev/BUILD.md for tag resolution and naming rules.
 
 # Pin the OS layer; the actual rustc/cargo version is resolved at build time
 # from rust-toolchain.toml (see the rustup step in the builder stage). We
@@ -170,10 +172,13 @@ sed -i "s#\"\${binArgs\[@\]}\" --workspace#\"\${binArgs[@]}\" --workspace${dcou_
 #        cargo-built binaries (no spl-token-cli install, no SBF SDK, no CUDA
 #        perf-libs fetch);
 #    (b) drop the line that copies bin/agave-install-init out alongside the
-#        tarball, since we don't build it anymore.
+#        tarball, since we don't build it anymore;
+#    (c) join basename and target with '_' so local tags like
+#        v4.3.0-alpha.0_<sha> stay readable before x86_64-unknown-linux-gnu.
 sed -i \
   -e 's#scripts/cargo-install-all.sh stable "${build_dir}"#scripts/cargo-install-all.sh --no-spl-token --no-build-platform-tools --no-perf-libs stable "${build_dir}"#' \
   -e '/agave-install-init/d' \
+  -e 's#"${tarball_basename}-${target}#"${tarball_basename}_${target}#g' \
   scripts/create-release-tarball.sh
 # ----------------------------------------------------------------------------
 
@@ -215,16 +220,16 @@ else
     done
   fi
 
-  cp "$build_dir/version.yml" "${TARBALL_BASENAME}-${TARGET_TRIPLE}.yml"
-  tar -cjvf "${TARBALL_BASENAME}-${TARGET_TRIPLE}.tar.bz2" \
+  cp "$build_dir/version.yml" "${TARBALL_BASENAME}_${TARGET_TRIPLE}.yml"
+  tar -cjvf "${TARBALL_BASENAME}_${TARGET_TRIPLE}.tar.bz2" \
     -X "$tmp_excludes" "$build_dir"
 fi
 
 # Stage outputs to a non-cache-mounted dir so the scratch export stage can
 # COPY them out.
 mkdir -p /out
-cp "${TARBALL_BASENAME}-${TARGET_TRIPLE}.tar.bz2" /out/
-cp "${TARBALL_BASENAME}-${TARGET_TRIPLE}.yml"     /out/
+cp "${TARBALL_BASENAME}_${TARGET_TRIPLE}.tar.bz2" /out/
+cp "${TARBALL_BASENAME}_${TARGET_TRIPLE}.yml"     /out/
 
 # Back-compat: also export loose binaries under docker-output/
 mkdir -p /out/docker-output

--- a/f
+++ b/f
@@ -3,7 +3,7 @@
 # Build jito-solana release artifacts inside a container and export them to
 # the host. See dev/BUILD.md for the full workflow.
 #
-# Bundled binaries (in <basename>-<tag>-<target>.tar.bz2 under bin/):
+# Bundled binaries (in <basename>-<tag>_<target>.tar.bz2 under bin/):
 #   agave-validator          [Jito-patched: BAM, bundles, tip-distribution]
 #   agave-ledger-tool        [Jito-patched ledger inspection]
 #   agave-watchtower         monitoring
@@ -14,20 +14,22 @@
 #   solana-keygen            keypair tooling
 #
 # Output (default ./dist/):
-#   <basename>-<tag>-<target>.tar.bz2   release tarball (bzip2)
-#   <basename>-<tag>-<target>.yml       version manifest: channel, commit,
+#   <basename>-<tag>_<target>.tar.bz2   release tarball (bzip2)
+#   <basename>-<tag>_<target>.yml       version manifest: channel, commit,
 #                                       target
 #
 # The <target> triple is derived inside the container from the platform the
-# build actually runs as, so it always matches the binaries. Use --platform
-# to build for a non-native platform (needs emulation or a builder node for
-# that platform).
+# build actually runs as, so it always matches the binaries. It is joined
+# to the basename/tag with '_' (e.g. ..._<sha>_x86_64-unknown-linux-gnu).
+# Use --platform to build for a non-native platform (needs emulation or a
+# builder node for that platform).
 #
 # Back-compat output (always at the repo root, regardless of --output):
 #   docker-output/<bin>             loose binaries, old pipeline layout
 #
 # Examples:
-#   ./f                                          # release build, tag from git
+#   ./f                                          # local: v<version>_<sha>
+#                                                # [-dirty]
 #   ./f --profile debug
 #   ./f --profile release-with-lto --tag v3.0.1
 #   ./f --output ./out
@@ -38,6 +40,8 @@
 #                                                # the *current* checkout's
 #                                                # tooling (worktree-based; no
 #                                                # mutation to your HEAD)
+#   ./f --checkout master                        # moving branch ->
+#                                                # master-<shortsha>
 #
 # Requires: docker with buildx (Docker Engine >=23 or buildx plugin installed).
 
@@ -69,11 +73,13 @@ Drives Agave's upstream scripts/create-release-tarball.sh through dev/Dockerfile
 with a Jito-curated operator binary set.
 
 Output (default ./dist/):
-  <basename>-<tag>-<target>.tar.bz2   release tarball (bzip2)
-  <basename>-<tag>-<target>.yml       version manifest: channel, commit, target
+  <basename>-<tag>_<target>.tar.bz2   release tarball (bzip2)
+  <basename>-<tag>_<target>.yml       version manifest: channel, commit, target
 
 The <target> triple is derived inside the container from the actual build
-platform, so it always matches the binaries.
+platform, so it always matches the binaries. The platform suffix is joined
+with '_', for example:
+  jito-solana-release-v4.3.0-alpha.0_<sha>_x86_64-unknown-linux-gnu
 
 Back-compat output (always at the repo root, regardless of --output):
   docker-output/<bin>             loose binaries, old pipeline layout
@@ -84,21 +90,24 @@ Options:
   --profile PROFILE       release | release-with-debug | release-with-lto | debug
                           (default: release)
   --tag VALUE             channel/tag to embed in version.yml
-                          (default: --checkout value, or
-                          `git describe --tags --always --dirty`)
+                          (default: --checkout-derived tag; else the exact git
+                          tag at HEAD when present; else
+                          v<Cargo.toml version>_<shortsha>[-dirty])
   --checkout REF          build a specific git ref (tag/branch/SHA) using a
                           throwaway worktree. The current checkout's f and
                           dev/Dockerfile drive the build, but the source being
                           compiled comes from REF. Your working tree and HEAD
                           are not modified. The ref must already exist locally
                           (run `git fetch --tags origin` first if needed).
+                          When --tag is omitted: exact tags keep their release
+                          name; moving branches / other refs append -<shortsha>.
   --platform PLATFORM     docker platform to build as, e.g. linux/amd64
                           (default: the builder's native platform). Single
                           platform only. Non-native platforms need QEMU
                           emulation (slow) or a buildx builder node of that
                           platform.
   --basename NAME         tarball/yml base name (default: jito-solana-release);
-                          the channel/tag is appended automatically
+                          channel/tag and _<target> are appended automatically
   --no-val-bins           drop validator/operator binaries from the tarball
                           (defaults to including them, since they are the point
                           of a Jito release artifact)
@@ -235,15 +244,42 @@ if [[ -n "$checkout" ]]; then
   git -C "$worktree_dir" submodule update --init --recursive --quiet
 
   build_context="$worktree_dir"
-  : "${tag:=$checkout}"
   ci_commit="$resolved_sha"
+
+  # Channel tag from --checkout when --tag was omitted:
+  #   - Exact tag at REF (e.g. v4.0.3-jito) -> keep the release tag name
+  #   - Moving branch / SHA / other ref -> append short SHA so the artifact
+  #     stays unique as the branch tip moves
+  if [[ -z "$tag" ]]; then
+    if tag="$(git describe --exact-match --tags "$resolved_sha" 2>/dev/null)"; then
+      :
+    else
+      short_sha="$(git rev-parse --short "$resolved_sha")"
+      tag="${checkout}-${short_sha}"
+    fi
+  fi
 fi
 
+# shellcheck source=scripts/read-cargo-variable.sh
+source "$SCRIPT_DIR/scripts/read-cargo-variable.sh"
+
+# Channel/tag for version.yml and artifact names (when still unset):
+#   1. Exact git tag at HEAD -- standard release builds on a tagged commit
+#   2. Local non-release: v<Cargo.toml version>_<shortsha>[-dirty]
+#      Cargo workspace version is the tree's truth on master; git describe
+#      walks ancestor tags and often lands on ancient release-line tags that
+#      are not ancestors of later Jito cuts. Underscore separates version from
+#      SHA so semver prerelease hyphens (e.g. 4.3.0-alpha.0) stay unambiguous.
 if [[ -z "$tag" ]]; then
-  if tag="$(git -C "$build_context" describe --tags --always --dirty 2>/dev/null)"; then
+  if tag="$(git -C "$build_context" describe --exact-match --tags HEAD 2>/dev/null)"; then
     :
   else
-    tag="$(git -C "$build_context" rev-parse --short HEAD)"
+    version="$(readCargoVariable version "$build_context/Cargo.toml")"
+    short_sha="$(git -C "$build_context" rev-parse --short HEAD)"
+    tag="v${version}_${short_sha}"
+    if [[ -n "$(git -C "$build_context" status --porcelain)" ]]; then
+      tag="${tag}-dirty"
+    fi
   fi
 fi
 
@@ -251,16 +287,14 @@ fi
 # self-identifying on disk. Tags can be branch names (user/branch); replace
 # path separators to keep the result a single filename component. The
 # tarball's internal jito-solana-release/ prefix is unaffected (it comes
-# from --build-dir, not the basename). The target triple suffix is appended
-# inside the container, derived from the actual build platform.
+# from --build-dir, not the basename). The target triple is joined with '_'
+# inside the container (e.g. ..._<sha>_x86_64-unknown-linux-gnu).
 artifact_basename="${basename}-${tag//\//_}"
 
 # Read rust-toolchain.toml from the build context (worktree if --checkout was
 # used, else the current checkout) just for the informational banner. The
 # Dockerfile resolves the actual toolchain via rustup against the same file
 # inside the container.
-# shellcheck source=scripts/read-cargo-variable.sh
-source "$SCRIPT_DIR/scripts/read-cargo-variable.sh"
 rust_version="$(readCargoVariable channel "$build_context/rust-toolchain.toml")"
 
 : "${ci_commit:=${CI_COMMIT:-$(git rev-parse HEAD)}}"


### PR DESCRIPTION
#### Problem

Tarballs from the `./f` build script are tagged with an inaccurate version if not passing `--checkout` or `--tag`.

#### Summary of Changes

- Replace `git describe` tarball tag defaults with Cargo workspace version + short SHA (`v<version>-<sha>[-dirty]`), since describe often picks ancient non-ancestor tags on master
- Keep exact release tags for tagged HEAD / `--checkout` of a tag; append `-<shortsha>` for moving branch checkouts
- Document the resolution order in `dev/BUILD.md`

Example outputs:

- `./f`: jito-solana-release-v4.3.0-alpha.0_e0fe51e10f_x86_64-unknown-linux-gnu.tar.bz2
- `./f --tag v4.1.1-jito`: jito-solana-release-v4.1.1-jito_x86_64-unknown-linux-gnu.tar.bz2
- `./f --checkout master`: jito-solana-release-master-3ab6016b82_x86_64-unknown-linux-gnu.tar.bz2
