### PR TITLE
Report missing nonce authority as instruction error in BAM

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -8,7 +8,10 @@ use {
             TransactionResult,
         },
     },
-    crate::banking_stage::consumer::{ExecutionFlags, RetryableIndex, TipProcessingDependencies},
+    crate::banking_stage::{
+        consumer::{ExecutionFlags, RetryableIndex, TipProcessingDependencies},
+        transaction_scheduler::bam_utils::get_nonce_authority_error,
+    },
     crossbeam_channel::{Receiver, SendError, Sender, TryRecvError},
     jito_protos::proto::bam_types::TransactionCommittedResult,
     solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
@@ -185,7 +188,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
 
         let extra_info = work
             .respond_with_extra_info
-            .then(|| Self::build_finished_consume_work_extra_info(&output, &work));
+            .then(|| Self::build_finished_consume_work_extra_info(&output, &work, bank));
 
         self.consumed_sender.send(FinishedConsumeWork {
             work,
@@ -299,6 +302,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
     fn build_finished_consume_work_extra_info(
         output: &ProcessTransactionBatchOutput,
         work: &ConsumeWork<Tx>,
+        bank: &Bank,
     ) -> FinishedConsumeWorkExtraInfo {
         let Ok(commit_transactions_result) = output
             .execute_and_commit_transactions_output
@@ -316,7 +320,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
         };
 
         let mut processed_results = Vec::with_capacity(commit_transactions_result.len());
-        for commit_info in commit_transactions_result.iter() {
+        for (index, commit_info) in commit_transactions_result.iter().enumerate() {
             match commit_info {
                 CommitTransactionDetails::Committed {
                     compute_units,
@@ -335,7 +339,11 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
                 }
                 CommitTransactionDetails::NotCommitted(err) => {
                     processed_results.push(TransactionResult::NotCommitted(
-                        NotCommittedReason::Error(err.clone()),
+                        NotCommittedReason::Error(get_nonce_authority_error(
+                            bank,
+                            &work.transactions[index],
+                            err.clone(),
+                        )),
                     ));
                 }
             }

--- a/core/src/banking_stage/transaction_scheduler/bam_utils.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_utils.rs
@@ -1,7 +1,44 @@
 use {
     jito_protos::proto::bam_types::TransactionErrorReason,
+    solana_account::{ReadableAccount, state_traits::StateMut},
+    solana_instruction::error::InstructionError,
+    solana_nonce::{
+        NONCED_TX_MARKER_IX_INDEX,
+        state::{DurableNonce, State as NonceState},
+        versions::Versions as NonceVersions,
+    },
+    solana_runtime::bank::Bank,
+    solana_sdk_ids::system_program,
+    solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction_error::TransactionError,
 };
+
+pub(crate) fn get_nonce_authority_error(
+    bank: &Bank,
+    transaction: &impl SVMMessage,
+    err: TransactionError,
+) -> TransactionError {
+    transaction
+        .get_durable_nonce()
+        .filter(|_| err == TransactionError::BlockhashNotFound)
+        .and_then(|address| bank.get_account(address))
+        .filter(|account| {
+            account.owner() == &system_program::id() && account.data().len() == NonceState::size()
+        })
+        .and_then(|account| {
+            let versions: NonceVersions = account.state().ok()?;
+            let data = versions.verify_recent_blockhash(transaction.recent_blockhash())?;
+            (data.durable_nonce != DurableNonce::from_blockhash(&bank.last_blockhash())
+                && transaction
+                    .get_ix_signers(NONCED_TX_MARKER_IX_INDEX as usize)
+                    .all(|signer| signer != &data.authority))
+            .then_some(TransactionError::InstructionError(
+                NONCED_TX_MARKER_IX_INDEX,
+                InstructionError::MissingRequiredSignature,
+            ))
+        })
+        .unwrap_or(err)
+}
 
 pub fn convert_txn_error_to_proto(err: TransactionError) -> TransactionErrorReason {
     match err {
@@ -80,5 +117,69 @@ pub fn convert_txn_error_to_proto(err: TransactionError) -> TransactionErrorReas
             TransactionErrorReason::ProgramCacheHitMaxLimit
         }
         TransactionError::CommitCancelled => TransactionErrorReason::CommitCancelled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_account::AccountSharedData,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_nonce::{state::Data as NonceData, versions::Versions as NonceVersions},
+        solana_signer::Signer,
+        solana_system_interface::instruction::advance_nonce_account,
+        solana_transaction::{Transaction, sanitized::SanitizedTransaction},
+    };
+
+    #[test]
+    fn test_get_nonce_authority_error() {
+        let bank = Bank::new_for_tests(&solana_genesis_config::create_genesis_config(10).0);
+        let nonce_address = solana_pubkey::Pubkey::new_unique();
+        let nonce_authority = solana_pubkey::Pubkey::new_unique();
+        let signer = Keypair::new();
+        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
+        let nonce_state =
+            NonceState::Initialized(NonceData::new(nonce_authority, durable_nonce, 5_000));
+        let nonce_account = AccountSharedData::new_data(
+            1,
+            &NonceVersions::new(nonce_state),
+            &solana_sdk_ids::system_program::id(),
+        )
+        .unwrap();
+        bank.store_account(&nonce_address, &nonce_account);
+
+        let transaction =
+            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
+                &[advance_nonce_account(&nonce_address, &signer.pubkey())],
+                Some(&signer.pubkey()),
+                &[&signer],
+                *durable_nonce.as_hash(),
+            ));
+
+        assert_eq!(
+            get_nonce_authority_error(&bank, &transaction, TransactionError::BlockhashNotFound,),
+            TransactionError::InstructionError(
+                NONCED_TX_MARKER_IX_INDEX,
+                InstructionError::MissingRequiredSignature,
+            ),
+        );
+
+        let non_nonce_transaction =
+            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
+                &[],
+                Some(&signer.pubkey()),
+                &[&signer],
+                Hash::new_unique(),
+            ));
+        assert_eq!(
+            get_nonce_authority_error(
+                &bank,
+                &non_nonce_transaction,
+                TransactionError::BlockhashNotFound,
+            ),
+            TransactionError::BlockhashNotFound,
+        );
     }
 }


### PR DESCRIPTION
## Summary

Report a missing durable-nonce authority signature as an instruction error in the BAM completion path.

| Before | After |
| --- | --- |
| A durable-nonce transaction with a valid nonce account and matching nonce, but no authority signature, was reported as `BLOCKHASH_NOT_FOUND`. | The same failure is reported as `INSTRUCTION_ERROR` with `MissingRequiredSignature`. |
| Genuine missing, stale, mismatched, or non-advanceable nonce failures were reported as `BLOCKHASH_NOT_FOUND`. | Those failures remain `BLOCKHASH_NOT_FOUND`. |

## Why

`BLOCKHASH_NOT_FOUND` suggests that the nonce is missing or invalid. In this case the nonce is valid—the transaction is missing authorization. Reporting `MissingRequiredSignature` identifies the actual problem and tells callers what they need to fix.

The reclassification is deliberately narrow and only happens when the transaction and bank state confirm this exact case.
