### PR TITLE
fix(bam): Fix flakey CI tests by signaling parsing thread shutdown

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -3885,7 +3885,7 @@ mod tests {
             .unwrap();
 
         let consumed = consumed_receiver
-            .recv_timeout(Duration::from_secs(1))
+            .recv_timeout(Duration::from_secs(30))
             .unwrap();
         assert_eq!(consumed.retryable_indexes.len(), 0);
         assert_eq!(consumed.work.transactions.len(), 1);

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -74,6 +74,9 @@ pub struct BamReceiveAndBuffer {
     parsed_batch_receiver: crossbeam_channel::Receiver<ParsedBatch>,
     recv_stats_receiver: crossbeam_channel::Receiver<ReceivingStats>,
     parsing_thread: Option<std::thread::JoinHandle<()>>,
+    /// Owned by this struct (unlike the shared `exit` flag) so `drop` can
+    /// stop the parsing thread without shutting anything else down.
+    shutdown: Arc<AtomicBool>,
     next_fifo_priority: u64,
 }
 
@@ -101,10 +104,13 @@ impl BamReceiveAndBuffer {
         let (recv_stats_sender, recv_stats_receiver) =
             crossbeam_channel::unbounded::<ReceivingStats>();
 
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
         let response_sender_clone = response_sender.clone();
         let parsing_thread = std::thread::spawn(move || {
             Self::run_parsing(
                 exit,
+                shutdown_clone,
                 bundle_receiver,
                 parsed_batch_sender,
                 recv_stats_sender,
@@ -121,12 +127,14 @@ impl BamReceiveAndBuffer {
             parsed_batch_receiver,
             recv_stats_receiver,
             parsing_thread: Some(parsing_thread),
+            shutdown,
             next_fifo_priority: u64::MAX,
         }
     }
 
     fn run_parsing(
         exit: Arc<AtomicBool>,
+        shutdown: Arc<AtomicBool>,
         bundle_receiver: crossbeam_channel::Receiver<MultipleAtomicTxnBatch>,
         parsed_batch_sender: crossbeam_channel::Sender<ParsedBatch>,
         recv_stats_sender: crossbeam_channel::Sender<ReceivingStats>,
@@ -150,7 +158,7 @@ impl BamReceiveAndBuffer {
         const METRICS_REPORT_INTERVAL: Duration = Duration::from_millis(20);
         let mut recv_buffer = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
 
-        while !exit.load(Ordering::Relaxed) {
+        while !exit.load(Ordering::Relaxed) && !shutdown.load(Ordering::Relaxed) {
             let loop_start = Instant::now();
             if loop_start.duration_since(last_metrics_report) > METRICS_REPORT_INTERVAL {
                 metrics.report();
@@ -850,6 +858,10 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
 
 impl Drop for BamReceiveAndBuffer {
     fn drop(&mut self) {
+        // Signal the parsing thread before joining: relying on the shared
+        // `exit` flag or channel disconnect deadlocks when this struct is
+        // dropped during a panic unwind (senders still alive on the stack).
+        self.shutdown.store(true, Ordering::Relaxed);
         if let Some(parsing_thread) = self.parsing_thread.take() {
             parsing_thread.join().unwrap();
         }
@@ -1196,7 +1208,7 @@ mod tests {
             .unwrap();
 
         let start = Instant::now();
-        while start.elapsed() < Duration::from_secs(2) {
+        while start.elapsed() < Duration::from_secs(30) {
             let ReceivingStats { num_received, .. } = receive_and_buffer
                 .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
                 .unwrap();


### PR DESCRIPTION
## Problem

`coverage-2` on the v4.3 rebase branch ([build 5093](https://buildkite.com/jito/jito-solana/builds/5093)) timed out three times in a row at the 60-minute job limit, with no failure output. Each time, the last thing in the log was:

```
test ...bam_receive_and_buffer::tests::test_receive_and_buffer_simple_transfer::testcase_bam has been running for over 60 seconds
```

This looked like a flaky/hanging test, but the test itself was actually **failing** — the failure just never surfaced.

## Root cause

`test_receive_and_buffer_simple_transfer` sends one transfer, polls `receive_and_buffer_packets` for 2 seconds, then asserts the transaction landed in the container. The `exit` flag is only set **after** the assertions:

1. On a slow machine (coverage CI runs with `-C instrument-coverage`, `RUST_LOG=solana=trace`, and the whole suite in parallel), the parsing thread misses the 2-second window.
2. `verify_container` panics (`0 != 1`), and the line that sets `exit` is never reached.
3. The panic unwinds the test frame, which drops `BamReceiveAndBuffer`. Its `Drop` impl joins the parsing thread.
4. The parsing thread has exactly two ways to exit: the `exit` flag (never set, see step 2) or its channel disconnecting. But the channel sender is a local declared *before* the struct in the test, so it is still alive on the panicking stack — it cannot drop until the frame finishes unwinding, and the unwind is stuck inside the join.
5. Deadlock. The panic message is never flushed, the test never "finishes", and the job burns its full 60-minute timeout.

So any failure of this test presents as a silent 60-minute hang instead of a normal red test. The same slowness also bites `test_handle_tip_programs` in `consume_worker.rs`, which fails its 1-second `recv_timeout` on ~1 in 4 recent master coverage-2 runs — that one at least fails cleanly (exit 101) because it has no join-in-Drop.

## Fix

- **`BamReceiveAndBuffer` gets its own `shutdown` flag**, set in `Drop` before joining. The parsing loop checks it alongside `exit`. We cannot just set `exit` in `Drop` — it is a shared flag owned by the caller, and setting it would shut down unrelated components. With this change, a failing assertion unwinds cleanly and the test reports the real panic. Production behavior is unchanged: `shutdown` is struct-owned, only written in `Drop`, and the external `exit` semantics are untouched.
- **Widen the two flaky test windows** (2s poll in the BAM test, 1s `recv_timeout` in `test_handle_tip_programs`) to 30s. Both are early-exit-on-success patterns, so the happy path stays fast — the extra time only matters on slow coverage boxes.

## Verification

Deterministic repro by shrinking the BAM test poll window to 1ms (forcing the assertion to fail):

- **without** the fix: assertion panic prints, then the test hangs forever — exactly the CI signature
- **with** the fix: test fails in 0.02s with the assertion visible

With the windows restored: all 11 `bam_receive_and_buffer` tests and `test_handle_tip_programs` pass on both master and the v4.3 rebase commit.