### PR TITLE
Disable strict_nonce_size_check in replay because its a leader-only check

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4905,7 +4905,7 @@ impl Bank {
                 recording_config,
                 drop_on_failure: false,
                 all_or_nothing: false,
-                strict_nonce_size_check: true,
+                strict_nonce_size_check: false,
                 drop_noop_transactions: false,
             },
         );


### PR DESCRIPTION
#### Problem
Strict nonce size checks are leader-only checks. The checks for jito-solana replay should match what Agave has as this check should not be applied on the consensus codepath.

#### Summary of Changes
Set strict_nonce_size_check = false in replay codepath.