### PR TITLE
(v4.2 backport): Disable strict_nonce_size_check in replay because its a leader-only check

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4871,13 +4871,8 @@ impl Bank {
                 recording_config,
                 drop_on_failure: false,
                 all_or_nothing: false,
-                // Jito: deliberately stricter than upstream, which passes
-                // false here because this path serves block replay
-                // (blockstore_processor). Replaying a block that contains a
-                // nonce tx with a non-canonical nonce account size errors
-                // here where vanilla agave accepts it. Kept true by explicit
-                // decision; see jito-foundation/jito-solana#1489.
-                strict_nonce_size_check: true,
+                strict_nonce_size_check: false,
+                drop_noop_transactions: false,
             },
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4872,7 +4872,6 @@ impl Bank {
                 drop_on_failure: false,
                 all_or_nothing: false,
                 strict_nonce_size_check: false,
-                drop_noop_transactions: false,
             },
         );
 


### PR DESCRIPTION
Backport #1525 to v4.2
