### PR TITLE
Reject IPv6 shred receiver addresses

### DIFF
--- a/validator/src/shred_receiver_addresses.rs
+++ b/validator/src/shred_receiver_addresses.rs
@@ -7,6 +7,11 @@ fn push_unique_addr(
     addrs: &mut ShredReceiverAddresses,
     socket_addr: SocketAddr,
 ) -> Result<(), String> {
+    if socket_addr.is_ipv6() {
+        return Err(format!(
+            "IPv6 shred receiver addresses are not supported: {socket_addr}"
+        ));
+    }
     if addrs.contains(&socket_addr) {
         return Ok(());
     }
@@ -91,11 +96,9 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_explicit_ipv6_socket_addr() {
-        let addrs = parse_shred_receiver_addresses(["[::1]:9003"]).unwrap();
-        assert_eq!(addrs.len(), 1);
-        assert!(addrs[0].is_ipv6());
-        assert_eq!(addrs[0].port(), 9003);
+    fn test_parse_explicit_ipv6_socket_addr_rejected() {
+        let err = parse_shred_receiver_addresses(["[::1]:9003"]).unwrap_err();
+        assert!(err.contains("IPv6 shred receiver addresses are not supported"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject literal IPv6 shred receiver addresses before adding them to the configured receiver list
- update the parser regression test to require IPv6 rejection

## Rationale

Hostname resolution already filters for IPv4, but direct socket-address parsing accepted IPv6 literals. Those addresses can reach the IPv4-only XDP transmit path, where they cause the transmit worker to panic.