### PR TITLE
Fix BAM Block Engine cutover

### DIFF
--- a/core/src/bam_connection.rs
+++ b/core/src/bam_connection.rs
@@ -233,8 +233,11 @@ impl BamConnection {
                                 };
                                 match result {
                                     Ok(Ok(response)) => {
-                                        *config.lock().unwrap() = Some(response.into_inner());
-                                        config_version.fetch_add(1, Relaxed);
+                                        let mut config = config.lock().unwrap();
+                                        if config.as_ref() != Some(response.get_ref()) {
+                                            *config = Some(response.into_inner());
+                                            config_version.fetch_add(1, Relaxed);
+                                        }
                                         builder_config_received.fetch_add(1, Relaxed);
                                     }
                                     Ok(Err(e)) => error!("Failed to get config: {e:?}"),

--- a/core/src/bam_dependencies.rs
+++ b/core/src/bam_dependencies.rs
@@ -26,14 +26,18 @@ pub enum BamOutboundMessage {
 pub enum BamConnectionState {
     Disconnected = 0,
     Connecting = 1,
-    Connected = 2,
+    DrainingBlockEngine = 2,
+    BlockEngineDrained = 3,
+    Connected = 4,
 }
 
 impl BamConnectionState {
     pub fn from_u8(state: u8) -> Self {
         match state {
             1 => Self::Connecting,
-            2 => Self::Connected,
+            2 => Self::DrainingBlockEngine,
+            3 => Self::BlockEngineDrained,
+            4 => Self::Connected,
             _ => Self::Disconnected,
         }
     }
@@ -41,7 +45,7 @@ impl BamConnectionState {
 
 #[derive(Clone)]
 pub struct BamDependencies {
-    /// 0 = disconnected, 1 = connecting, 2 = connected
+    /// Also carries the internal Block Engine drain state during BAM cutover.
     pub bam_enabled: Arc<AtomicU8>,
 
     pub batch_sender: crossbeam_channel::Sender<bam_types::MultipleAtomicTxnBatch>,

--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -3,7 +3,7 @@
 /// - Sends leader state to BAM
 /// - Updates TPU config
 /// - Updates block builder fee info
-/// - Sets `bam_enabled` flag that is used everywhere
+/// - Coordinates the switch between Block Engine bundle processing and BAM
 use std::{
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     str::FromStr,
@@ -125,8 +125,7 @@ impl BamManager {
 
         let mut current_connection = None;
         let mut outbound_receiver = Some(outbound_receiver);
-        let mut cached_builder_config = None;
-        let mut cached_builder_config_version = 0;
+        let mut builder_config_version = 0;
         let mut last_observed_bam_url = bam_url.load_full();
         let shared_leader_state = poh_recorder.read().unwrap().shared_leader_state();
 
@@ -154,10 +153,8 @@ impl BamManager {
                         &new_identity,
                         &dependencies,
                         &exit,
-                        &mut cached_builder_config,
                         true,
                     ) {
-                        cached_builder_config_version = 0;
                         continue;
                     }
 
@@ -176,8 +173,8 @@ impl BamManager {
 
                     dependencies
                         .bam_enabled
-                        .store(BamConnectionState::Connecting as u8, Ordering::Relaxed);
-                    cached_builder_config_version = 0;
+                        .store(BamConnectionState::Connecting as u8, Ordering::Release);
+                    builder_config_version = 0;
                     let result = runtime.block_on(BamConnection::try_init(
                         url.clone(),
                         dependencies.cluster_info.clone(),
@@ -204,8 +201,6 @@ impl BamManager {
                              {MAX_DURATION_BETWEEN_NODE_HEARTBEATS:?}, disconnecting and will \
                              retry",
                         );
-                        cached_builder_config = None;
-                        cached_builder_config_version = 0;
                         Self::set_bam_disconnected(&dependencies);
                         outbound_receiver = Some(runtime.block_on(connection.shutdown()));
                         std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
@@ -213,29 +208,16 @@ impl BamManager {
                     }
 
                     info!("BAM connection established");
-                    if let Some(builder_config) =
-                        connection.get_latest_config_if_changed(&mut cached_builder_config_version)
-                    {
-                        Self::update_tpu_config(&builder_config, &dependencies);
-                        Self::update_shred_socks_config(&builder_config, &dependencies);
-                        Self::update_block_engine_key_and_commission(
-                            &builder_config,
-                            &dependencies.block_builder_fee_info,
-                        );
-                        Self::update_bam_recipient_and_commission(
-                            &builder_config,
-                            &dependencies.bam_node_pubkey,
-                        );
-                        cached_builder_config = Some(builder_config);
-                    }
+                    dependencies.bam_enabled.store(
+                        BamConnectionState::DrainingBlockEngine as u8,
+                        Ordering::Release,
+                    );
 
                     connection
                 }
             };
 
             let disconnect = if !connection.is_healthy() {
-                cached_builder_config = None;
-                cached_builder_config_version = 0;
                 Self::set_bam_disconnected(&dependencies);
                 warn!("BAM connection unhealthy");
                 true
@@ -244,17 +226,13 @@ impl BamManager {
                 &new_identity,
                 &dependencies,
                 &exit,
-                &mut cached_builder_config,
                 false,
             ) {
-                cached_builder_config_version = 0;
                 true
             } else {
                 if configured_bam_url.as_deref() == Some(connection.url()) {
                     false
                 } else {
-                    cached_builder_config = None;
-                    cached_builder_config_version = 0;
                     Self::set_bam_disconnected(&dependencies);
                     true
                 }
@@ -265,32 +243,21 @@ impl BamManager {
                 continue;
             }
 
-            // Check if block builder info has changed
-            if let Some(builder_config) =
-                connection.get_latest_config_if_changed(&mut cached_builder_config_version)
-                && Some(&builder_config) != cached_builder_config.as_ref()
+            let bam_state =
+                BamConnectionState::from_u8(dependencies.bam_enabled.load(Ordering::Acquire));
+            if matches!(
+                bam_state,
+                BamConnectionState::BlockEngineDrained | BamConnectionState::Connected
+            ) && let Some(builder_config) =
+                connection.get_latest_config_if_changed(&mut builder_config_version)
             {
-                Self::update_tpu_config(&builder_config, &dependencies);
-                Self::update_shred_socks_config(&builder_config, &dependencies);
-                Self::update_block_engine_key_and_commission(
-                    &builder_config,
-                    &dependencies.block_builder_fee_info,
-                );
-                Self::update_bam_recipient_and_commission(
-                    &builder_config,
-                    &dependencies.bam_node_pubkey,
-                );
-                cached_builder_config = Some(builder_config);
+                Self::apply_builder_config(&builder_config, &dependencies);
+                if bam_state == BamConnectionState::BlockEngineDrained {
+                    dependencies
+                        .bam_enabled
+                        .store(BamConnectionState::Connected as u8, Ordering::Release);
+                }
             }
-            let bam_state = if cached_builder_config.is_some() {
-                BamConnectionState::Connected
-            } else {
-                BamConnectionState::Connecting
-            };
-            dependencies
-                .bam_enabled
-                .store(bam_state as u8, Ordering::Relaxed);
-
             // Send leader state if we are in a leader slot
             if let Some(bank) = shared_leader_state.load().working_bank()
                 && !bank.is_frozen()
@@ -319,14 +286,12 @@ impl BamManager {
         new_identity: &ArcSwap<Option<Pubkey>>,
         dependencies: &BamDependencies,
         exit: &AtomicBool,
-        cached_builder_config: &mut Option<ConfigResponse>,
         wait_for_identity: bool,
     ) -> bool {
         if !identity_changed.swap(false, Ordering::AcqRel) {
             return false;
         }
 
-        *cached_builder_config = None;
         Self::set_bam_disconnected(dependencies);
 
         // When we are still holding a live connection, disconnect first and wait in the
@@ -377,6 +342,13 @@ impl BamManager {
         )))
     }
 
+    fn apply_builder_config(config: &ConfigResponse, dependencies: &BamDependencies) {
+        Self::update_tpu_config(config, dependencies);
+        Self::update_shred_socks_config(config, dependencies);
+        Self::update_block_engine_key_and_commission(config, &dependencies.block_builder_fee_info);
+        Self::update_bam_recipient_and_commission(config, &dependencies.bam_node_pubkey);
+    }
+
     fn update_tpu_config(config: &ConfigResponse, dependencies: &BamDependencies) {
         let Some(tpu_info) = config.bam_config.as_ref() else {
             return;
@@ -397,7 +369,7 @@ impl BamManager {
     fn set_bam_disconnected(dependencies: &BamDependencies) {
         dependencies
             .bam_enabled
-            .store(BamConnectionState::Disconnected as u8, Ordering::Relaxed);
+            .store(BamConnectionState::Disconnected as u8, Ordering::Release);
         Self::clear_bam_shred_receiver_addresses(dependencies);
     }
 

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -748,19 +748,15 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
             stats.accumulate(batch_stats);
         }
 
-        // Preserve batches during the short Block Engine handoff. Connecting may be long-lived,
-        // so retain the existing drain behavior for that state.
-        if matches!(
-            decision,
-            BufferedPacketsDecision::Consume(_) | BufferedPacketsDecision::Hold
-        ) && matches!(
-            bam_state,
-            BamConnectionState::DrainingBlockEngine | BamConnectionState::BlockEngineDrained
-        ) {
-            return Ok(stats);
-        }
-
         match decision {
+            // Preserve batches during the short Block Engine handoff. Connecting may be
+            // long-lived, so retain the existing drain behavior for that state.
+            BufferedPacketsDecision::Consume(_) | BufferedPacketsDecision::Hold
+                if matches!(
+                    bam_state,
+                    BamConnectionState::DrainingBlockEngine
+                        | BamConnectionState::BlockEngineDrained
+                ) => {}
             BufferedPacketsDecision::Consume(_) | BufferedPacketsDecision::Hold => loop {
                 let batch = match self.parsed_batch_receiver.try_recv() {
                     Ok(batch) => batch,

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -740,7 +740,7 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
         container: &mut Self::Container,
         decision: &BufferedPacketsDecision,
     ) -> Result<ReceivingStats, DisconnectedError> {
-        let is_bam_enabled = BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Relaxed))
+        let is_bam_enabled = BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Acquire))
             == BamConnectionState::Connected;
 
         // Receive all stats

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -740,13 +740,24 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
         container: &mut Self::Container,
         decision: &BufferedPacketsDecision,
     ) -> Result<ReceivingStats, DisconnectedError> {
-        let is_bam_enabled = BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Acquire))
-            == BamConnectionState::Connected;
+        let bam_state = BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Acquire));
 
         // Receive all stats
         let mut stats = ReceivingStats::default();
         while let Ok(batch_stats) = self.recv_stats_receiver.try_recv() {
             stats.accumulate(batch_stats);
+        }
+
+        // Preserve batches during the short Block Engine handoff. Connecting may be long-lived,
+        // so retain the existing drain behavior for that state.
+        if matches!(
+            decision,
+            BufferedPacketsDecision::Consume(_) | BufferedPacketsDecision::Hold
+        ) && matches!(
+            bam_state,
+            BamConnectionState::DrainingBlockEngine | BamConnectionState::BlockEngineDrained
+        ) {
+            return Ok(stats);
         }
 
         match decision {
@@ -761,7 +772,7 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
                 };
 
                 // If BAM is not enabled, drain the channel
-                if !is_bam_enabled {
+                if bam_state != BamConnectionState::Connected {
                     stats.num_dropped_without_parsing += batch.txns_max_age.len();
                     continue;
                 }
@@ -786,7 +797,7 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
                     stats.num_dropped_on_capacity += 1;
                     self.send_container_full_txn_batch_result(seq_id);
                     continue;
-                };
+                }
                 self.next_fifo_priority = self.next_fifo_priority.saturating_sub(1);
             },
             BufferedPacketsDecision::ForwardAndHold | BufferedPacketsDecision::Forward => {
@@ -1033,7 +1044,7 @@ mod tests {
             },
         },
         ahash::HashSetExt,
-        crossbeam_channel::{Receiver, unbounded},
+        crossbeam_channel::unbounded,
         jito_protos::proto::bam_types::AtomicTxnBatch,
         solana_keypair::Keypair,
         solana_ledger::genesis_utils::GenesisConfigInfo,
@@ -1045,7 +1056,6 @@ mod tests {
         solana_system_transaction::transfer,
         solana_transaction::{Transaction, versioned::VersionedTransaction},
         std::sync::atomic::AtomicU8,
-        test_case::test_case,
     };
 
     fn test_bank_forks() -> (Arc<RwLock<BankForks>>, Keypair) {
@@ -1164,52 +1174,65 @@ mod tests {
         (results, stats)
     }
 
-    #[test_case(setup_bam_receive_and_buffer; "testcase-bam")]
-    fn test_receive_and_buffer_simple_transfer<R: ReceiveAndBuffer>(
-        setup_receive_and_buffer: impl FnOnce(
-            Receiver<MultipleAtomicTxnBatch>,
-            Arc<RwLock<BankForks>>,
-            HashSet<Pubkey>,
-        ) -> (
-            Arc<AtomicBool>,
-            R,
-            R::Container,
-            tokio::sync::mpsc::Receiver<BamOutboundMessage>,
-        ),
-    ) {
+    #[test]
+    fn test_receive_and_buffer_simple_transfer_across_bam_handoff() {
         let (sender, receiver) = unbounded();
         let (bank_forks, mint_keypair) = test_bank_forks();
-        let (exit, mut receive_and_buffer, mut container, _response_sender) =
-            setup_receive_and_buffer(receiver, bank_forks.clone(), HashSet::new());
+        let (exit, mut receive_and_buffer, mut container, _response_receiver) =
+            setup_bam_receive_and_buffer(receiver, bank_forks.clone(), HashSet::new());
+        let bam_enabled = receive_and_buffer.bam_enabled.clone();
+        bam_enabled.store(
+            BamConnectionState::DrainingBlockEngine as u8,
+            Ordering::Release,
+        );
         let transaction = transfer(
             &mint_keypair,
             &Pubkey::new_unique(),
             1,
             bank_forks.read().unwrap().root_bank().last_blockhash(),
         );
-        let data = bincode::serialize(&transaction).expect("serializes");
-        let bundle = AtomicTxnBatch {
-            seq_id: 1,
-            packets: vec![Packet {
-                data: data.into(),
-                meta: None,
-            }],
-            max_schedule_slot: Slot::MAX,
-        };
         sender
             .send(MultipleAtomicTxnBatch {
-                batches: vec![bundle],
+                batches: vec![AtomicTxnBatch {
+                    seq_id: 1,
+                    packets: vec![Packet {
+                        data: wincode::serialize(&transaction).unwrap().into(),
+                        meta: None,
+                    }],
+                    max_schedule_slot: Slot::MAX,
+                }],
             })
             .unwrap();
 
         let start = Instant::now();
-        while start.elapsed() < Duration::from_secs(30) {
-            let ReceivingStats { num_received, .. } = receive_and_buffer
+        loop {
+            if receive_and_buffer
                 .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
-                .unwrap();
-            if num_received > 0 {
+                .unwrap()
+                .num_received
+                > 0
+            {
                 break;
             }
+            assert!(start.elapsed() < Duration::from_secs(30));
+        }
+        assert!(container.is_empty());
+
+        bam_enabled.store(
+            BamConnectionState::BlockEngineDrained as u8,
+            Ordering::Release,
+        );
+        receive_and_buffer
+            .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
+            .unwrap();
+        assert!(container.is_empty());
+
+        bam_enabled.store(BamConnectionState::Connected as u8, Ordering::Release);
+        let start = Instant::now();
+        while container.is_empty() && start.elapsed() < Duration::from_secs(30) {
+            receive_and_buffer
+                .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
+                .unwrap();
         }
 
         verify_container(&mut container, 1);

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -602,7 +602,7 @@ where
     }
 
     fn scheduling_enabled(&self) -> bool {
-        let bam_connected = BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Relaxed))
+        let bam_connected = BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Acquire))
             == BamConnectionState::Connected;
         self.bam_controller == bam_connected
     }

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -3,6 +3,7 @@
 
 use {
     crate::{
+        bam_dependencies::BamConnectionState,
         banking_stage::{
             committer::{CommitTransactionDetails, Committer},
             consume_worker::ConsumeWorkerMetrics,
@@ -40,7 +41,7 @@ use {
         ops::Deref,
         sync::{
             Arc, RwLock,
-            atomic::{AtomicBool, Ordering},
+            atomic::{AtomicBool, AtomicU8, Ordering},
         },
         thread::{self, Builder, JoinHandle},
         time::{Duration, Instant},
@@ -342,6 +343,7 @@ impl BundleStage {
         tip_manager: TipManager,
         bundle_account_locker: BundleAccountLocker,
         block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
+        bam_enabled: Arc<AtomicU8>,
         prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
         blacklisted_accounts: HashSet<Pubkey>,
     ) -> Self {
@@ -358,6 +360,7 @@ impl BundleStage {
             tip_manager,
             bundle_account_locker,
             block_builder_fee_info,
+            bam_enabled,
             prioritization_fee_cache,
             blacklisted_accounts,
         )
@@ -381,6 +384,7 @@ impl BundleStage {
         tip_manager: TipManager,
         bundle_account_locker: BundleAccountLocker,
         block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
+        bam_enabled: Arc<AtomicU8>,
         prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
         blacklisted_accounts: HashSet<Pubkey>,
     ) -> Self {
@@ -409,6 +413,7 @@ impl BundleStage {
                     bundle_account_locker,
                     tip_manager,
                     block_builder_fee_info,
+                    bam_enabled,
                     cluster_info,
                 );
             })
@@ -428,6 +433,7 @@ impl BundleStage {
         bundle_account_locker: BundleAccountLocker,
         tip_manager: TipManager,
         block_builder_fee_info: Arc<ArcSwap<BlockBuilderFeeInfo>>,
+        bam_enabled: Arc<AtomicU8>,
         cluster_info: Arc<ClusterInfo>,
     ) {
         let mut last_metrics_update = Instant::now();
@@ -437,10 +443,13 @@ impl BundleStage {
         let consume_worker_metrics = ConsumeWorkerMetrics::new(10_000);
 
         let mut last_tip_update_slot = Slot::MAX;
-
         while !exit.load(Ordering::Relaxed) {
-            if bundle_storage.unprocessed_bundles_len() > 0
-                || last_metrics_update.elapsed() >= SLOT_BOUNDARY_CHECK_PERIOD
+            let block_engine_processing =
+                Self::block_engine_processing_enabled(&bam_enabled, &mut bundle_storage);
+
+            if block_engine_processing
+                && (bundle_storage.unprocessed_bundles_len() > 0
+                    || last_metrics_update.elapsed() >= SLOT_BOUNDARY_CHECK_PERIOD)
             {
                 let (_, process_buffered_packets_time_us) =
                     measure_us!(Self::process_buffered_bundles(
@@ -471,6 +480,9 @@ impl BundleStage {
             ) {
                 break;
             }
+            if !block_engine_processing {
+                bundle_storage.clear();
+            }
             let elapsed = start.elapsed();
 
             bundle_stage_metrics
@@ -487,6 +499,23 @@ impl BundleStage {
 
             bundle_stage_metrics.maybe_report(20);
         }
+    }
+
+    fn block_engine_processing_enabled(
+        bam_enabled: &AtomicU8,
+        bundle_storage: &mut BundleStorage,
+    ) -> bool {
+        if bam_enabled.load(Ordering::Acquire) <= BamConnectionState::Connecting as u8 {
+            return true;
+        }
+        bundle_storage.clear();
+        let _ = bam_enabled.compare_exchange(
+            BamConnectionState::DrainingBlockEngine as u8,
+            BamConnectionState::BlockEngineDrained as u8,
+            Ordering::Release,
+            Ordering::Relaxed,
+        );
+        false
     }
 
     fn receive_and_buffer_bundles(
@@ -920,6 +949,7 @@ mod tests {
         solana_cluster_type::ClusterType,
         solana_entry::entry_or_marker::EntryOrMarker,
         solana_fee_calculator::{DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE, FeeRateGovernor},
+        solana_genesis_config::GenesisConfig,
         solana_gossip::contact_info::ContactInfo,
         solana_keypair::Keypair,
         solana_leader_schedule::SlotLeader,
@@ -988,6 +1018,73 @@ mod tests {
     }
 
     #[test]
+    fn test_bam_handoff_clears_block_engine_bundles_before_connected() {
+        let bank = Bank::new_for_tests(&GenesisConfig::default());
+        let mut bundle_storage = BundleStorage::with_capacity(2);
+        let bam_enabled = AtomicU8::new(BamConnectionState::Disconnected as u8);
+        let insert_bundle = |storage: &mut BundleStorage| {
+            storage
+                .insert_bundle(
+                    VerifiedPacketBundle::new(PacketBatch::from(vec![
+                        BytesPacket::from_data(test_tx()).unwrap(),
+                    ])),
+                    &bank,
+                    &bank,
+                    &HashSet::default(),
+                )
+                .unwrap();
+        };
+
+        for _ in 0..2 {
+            insert_bundle(&mut bundle_storage);
+        }
+        let retryable_bundle = bundle_storage.pop_bundle(bank.slot()).unwrap();
+        bundle_storage.retry_bundle(retryable_bundle);
+
+        std::thread::scope(|scope| {
+            let manager = scope.spawn(|| {
+                bam_enabled.store(
+                    BamConnectionState::DrainingBlockEngine as u8,
+                    Ordering::Release,
+                );
+                let start = Instant::now();
+                while bam_enabled.load(Ordering::Acquire)
+                    != BamConnectionState::BlockEngineDrained as u8
+                {
+                    assert!(start.elapsed() < Duration::from_secs(1));
+                    std::thread::yield_now();
+                }
+                bam_enabled.store(BamConnectionState::Connected as u8, Ordering::Release);
+            });
+
+            while bam_enabled.load(Ordering::Acquire)
+                != BamConnectionState::DrainingBlockEngine as u8
+            {
+                std::thread::yield_now();
+            }
+            assert_eq!(bundle_storage.unprocessed_bundles_len(), 1);
+            assert_eq!(bundle_storage.cost_model_buffered_bundles_len(), 1);
+            let block_engine_processing =
+                BundleStage::block_engine_processing_enabled(&bam_enabled, &mut bundle_storage);
+            assert!(!block_engine_processing);
+
+            // A stream response received during this iteration must also be discarded.
+            insert_bundle(&mut bundle_storage);
+            if !block_engine_processing {
+                bundle_storage.clear();
+            }
+            manager.join().unwrap();
+        });
+
+        assert_eq!(bundle_storage.unprocessed_bundles_len(), 0);
+        assert_eq!(bundle_storage.cost_model_buffered_bundles_len(), 0);
+        assert_eq!(
+            bam_enabled.load(Ordering::Acquire),
+            BamConnectionState::Connected as u8
+        );
+    }
+
+    #[test]
     fn test_tip_programs_initialized_with_no_bundles() {
         agave_logger::setup();
         let TestFixture {
@@ -1050,6 +1147,7 @@ mod tests {
                 block_builder: genesis_config_info.validator_pubkey,
                 block_builder_commission: 10,
             })),
+            Arc::new(AtomicU8::new(BamConnectionState::Disconnected as u8)),
             Some(Arc::new(PrioritizationFeeCache::new(0u64))),
             HashSet::default(),
         );
@@ -1188,6 +1286,7 @@ mod tests {
                 block_builder: genesis_config_info.validator_pubkey,
                 block_builder_commission: 10,
             })),
+            Arc::new(AtomicU8::new(BamConnectionState::Disconnected as u8)),
             Some(Arc::new(PrioritizationFeeCache::new(0u64))),
             HashSet::default(),
         );
@@ -1278,6 +1377,7 @@ mod tests {
                 block_builder: genesis_config_info.validator_pubkey,
                 block_builder_commission: 10,
             })),
+            Arc::new(AtomicU8::new(BamConnectionState::Disconnected as u8)),
             Some(Arc::new(PrioritizationFeeCache::new(0u64))),
             HashSet::default(),
         );
@@ -1394,6 +1494,7 @@ mod tests {
                 block_builder: genesis_config_info.validator_pubkey,
                 block_builder_commission: 10,
             })),
+            Arc::new(AtomicU8::new(BamConnectionState::Disconnected as u8)),
             Some(Arc::new(PrioritizationFeeCache::new(0u64))),
             HashSet::default(),
         );
@@ -1509,6 +1610,7 @@ mod tests {
                 block_builder: genesis_config_info.validator_pubkey,
                 block_builder_commission: 10,
             })),
+            Arc::new(AtomicU8::new(BamConnectionState::Disconnected as u8)),
             Some(Arc::new(PrioritizationFeeCache::new(0u64))),
             HashSet::default(),
         );

--- a/core/src/proxy/block_engine_stage.rs
+++ b/core/src/proxy/block_engine_stage.rs
@@ -244,9 +244,7 @@ impl BlockEngineStage {
         local_block_engine_config: &BlockEngineConfig,
         bam_enabled: &Arc<AtomicU8>,
     ) -> crate::proxy::Result<()> {
-        if BamConnectionState::from_u8(bam_enabled.load(Ordering::Relaxed))
-            == BamConnectionState::Connected
-        {
+        if bam_enabled.load(Ordering::Acquire) > BamConnectionState::Connecting as u8 {
             tokio::time::sleep(Duration::from_millis(1000)).await;
             return Ok(());
         }
@@ -446,11 +444,12 @@ impl BlockEngineStage {
     }
 
     fn map_bam_enabled(bam_enabled: &Arc<AtomicU8>, err: ProxyError) -> ProxyError {
-        match BamConnectionState::from_u8(bam_enabled.load(Ordering::Relaxed)) {
+        match BamConnectionState::from_u8(bam_enabled.load(Ordering::Acquire)) {
             BamConnectionState::Disconnected => err,
-            BamConnectionState::Connecting | BamConnectionState::Connected => {
-                ProxyError::BamEnabled
-            }
+            BamConnectionState::Connecting
+            | BamConnectionState::DrainingBlockEngine
+            | BamConnectionState::BlockEngineDrained
+            | BamConnectionState::Connected => ProxyError::BamEnabled,
         }
     }
 
@@ -857,9 +856,7 @@ impl BlockEngineStage {
         info!("connected to packet and bundle stream");
 
         while !exit.load(Ordering::Relaxed) {
-            if BamConnectionState::from_u8(bam_enabled.load(Ordering::Relaxed))
-                == BamConnectionState::Connected
-            {
+            if bam_enabled.load(Ordering::Acquire) > BamConnectionState::Connecting as u8 {
                 info!("bam enabled, exiting block engine stage");
                 return Ok(());
             }

--- a/core/src/proxy/fetch_stage_manager.rs
+++ b/core/src/proxy/fetch_stage_manager.rs
@@ -256,7 +256,7 @@ impl FetchStageTpuStateMachine {
     }
 
     fn is_bam_connected(&self) -> bool {
-        BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Relaxed))
+        BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Acquire))
             == BamConnectionState::Connected
     }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -494,6 +494,7 @@ impl Tpu {
             tip_manager,
             bundle_account_locker,
             &block_builder_fee_info,
+            bam_enabled,
             prioritization_fee_cache.clone(),
             filter_keys.iter().copied().collect::<AHashSet<_>>(),
         );

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -654,7 +654,6 @@ mod bam_manager_tests {
     ) -> (BamDependencies, mpsc::Receiver<BamOutboundMessage>) {
         let (batch_tx, batch_rx) = crossbeam_channel::unbounded();
         let (outbound_tx, outbound_rx) = mpsc::channel(100_000);
-
         let dependencies = BamDependencies {
             bam_enabled: Arc::new(AtomicU8::new(BamConnectionState::Disconnected as u8)),
             batch_sender: batch_tx,
@@ -670,13 +669,31 @@ mod bam_manager_tests {
         (dependencies, outbound_rx)
     }
 
-    fn bam_is_connected(bam_enabled: &Arc<AtomicU8>) -> bool {
+    fn bam_is_connected(bam_enabled: &AtomicU8) -> bool {
         BamConnectionState::from_u8(bam_enabled.load(Ordering::Relaxed))
             == BamConnectionState::Connected
     }
 
-    fn bam_state(bam_enabled: &Arc<AtomicU8>) -> BamConnectionState {
+    fn bam_state(bam_enabled: &AtomicU8) -> BamConnectionState {
         BamConnectionState::from_u8(bam_enabled.load(Ordering::Relaxed))
+    }
+
+    async fn wait_for_bam_connection(bam_enabled: &AtomicU8) {
+        let start = std::time::Instant::now();
+        while start.elapsed() < Duration::from_secs(15) {
+            // These tests omit BundleStage, so acknowledge its side of the cutover.
+            let _ = bam_enabled.compare_exchange(
+                BamConnectionState::DrainingBlockEngine as u8,
+                BamConnectionState::BlockEngineDrained as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            );
+            if bam_is_connected(bam_enabled) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        panic!("BAM did not connect");
     }
 
     #[allow(clippy::type_complexity)]
@@ -728,15 +745,7 @@ mod bam_manager_tests {
             identity_notifiers,
         );
 
-        let start = std::time::Instant::now();
-        while start.elapsed() < Duration::from_secs(15) {
-            if bam_is_connected(&bam_enabled) {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-
-        assert!(bam_is_connected(&bam_enabled), "bam_enabled should be true");
+        wait_for_bam_connection(&bam_enabled).await;
 
         exit.store(true, Ordering::Relaxed);
         poh_service.join().unwrap();
@@ -770,14 +779,7 @@ mod bam_manager_tests {
             identity_notifiers,
         );
 
-        let start = std::time::Instant::now();
-        while start.elapsed() < Duration::from_secs(15) {
-            if bam_is_connected(&bam_enabled) {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        assert!(bam_is_connected(&bam_enabled));
+        wait_for_bam_connection(&bam_enabled).await;
 
         server.send_heartbeats.store(false, Ordering::Relaxed);
 
@@ -860,23 +862,13 @@ mod bam_manager_tests {
             identity_notifiers,
         );
 
-        let start = std::time::Instant::now();
-        while start.elapsed() < Duration::from_secs(15) {
-            if bam_is_connected(&bam_enabled) {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        assert!(bam_is_connected(&bam_enabled));
+        wait_for_bam_connection(&bam_enabled).await;
 
         bam_url.store(Arc::new(Some(format!("http://{}", server2.addr))));
 
         tokio::time::sleep(Duration::from_secs(3)).await;
 
-        assert!(
-            bam_is_connected(&bam_enabled),
-            "bam_enabled should be true after URL change"
-        );
+        wait_for_bam_connection(&bam_enabled).await;
 
         exit.store(true, Ordering::Relaxed);
         poh_service.join().unwrap();
@@ -910,14 +902,7 @@ mod bam_manager_tests {
             identity_notifiers.clone(),
         );
 
-        let start = std::time::Instant::now();
-        while start.elapsed() < Duration::from_secs(15) {
-            if bam_is_connected(&bam_enabled) {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        assert!(bam_is_connected(&bam_enabled));
+        wait_for_bam_connection(&bam_enabled).await;
 
         let new_identity = Keypair::new();
         {
@@ -946,17 +931,7 @@ mod bam_manager_tests {
 
         cluster_info.set_keypair(Arc::new(new_identity));
 
-        let start = std::time::Instant::now();
-        while start.elapsed() < Duration::from_secs(15) {
-            if bam_is_connected(&bam_enabled) {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        assert!(
-            bam_is_connected(&bam_enabled),
-            "bam_enabled should reconnect after cluster_info reflects the new identity"
-        );
+        wait_for_bam_connection(&bam_enabled).await;
 
         exit.store(true, Ordering::Relaxed);
         poh_service.join().unwrap();
@@ -991,21 +966,19 @@ mod bam_manager_tests {
             identity_notifiers,
         );
 
+        wait_for_bam_connection(&bam_enabled).await;
+        assert_eq!(block_builder_fee_info.load().block_builder_commission, 10);
+
+        server.config.lock().unwrap().builder_commission = 20;
         let start = std::time::Instant::now();
-        while start.elapsed() < Duration::from_secs(15) {
-            if bam_is_connected(&bam_enabled) {
-                break;
-            }
+        while start.elapsed() < Duration::from_secs(5)
+            && block_builder_fee_info.load().block_builder_commission != 20
+        {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
-
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        let fee_info = block_builder_fee_info.load();
-        assert_eq!(fee_info.block_builder_commission, 10);
+        assert_eq!(block_builder_fee_info.load().block_builder_commission, 20);
 
         exit.store(true, Ordering::Relaxed);
-        drop(fee_info);
         poh_service.join().unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- coordinate the transition from Block Engine bundle processing to BAM through the existing shared state
- clear buffered Block Engine bundles before BAM configuration becomes active
- acknowledge the drain before publishing BAM as connected
- use acquire reads for every production consumer of the published BAM state
- prevent bundles received while BAM is active from executing after a later disconnect

## Root cause

BAM could publish the connected state while BundleStage still retained bundles accepted through the Block Engine path. Those bundles could execute after the BAM path became active.

## Impact

The handoff is now ordered as Connecting -> Draining Block Engine -> Block Engine Drained -> Connected. The release/acquire chain also publishes BAM configuration consistently to state-dependent consumers.
