### PR TITLE
Simplify bundle recording after SIMD-0083

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -3248,7 +3248,6 @@ mod tests {
     }
 
     fn setup_test_frame(
-        _relax_intrabatch_account_locks: bool,
         default_rent: bool,
     ) -> (
         TestFrame,
@@ -3347,7 +3346,7 @@ mod tests {
 
     #[test]
     fn test_worker_consume_no_bank() {
-        let (test_frame, worker) = setup_test_frame(true, false);
+        let (test_frame, worker) = setup_test_frame(false);
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -3397,7 +3396,7 @@ mod tests {
 
     #[test]
     fn test_worker_consume_no_bank_drains_queue() {
-        let (test_frame, worker) = setup_test_frame(true, false);
+        let (test_frame, worker) = setup_test_frame(false);
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -3452,7 +3451,7 @@ mod tests {
 
     #[test]
     fn test_worker_consume_simple() {
-        let (mut test_frame, worker) = setup_test_frame(true, false);
+        let (mut test_frame, worker) = setup_test_frame(false);
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -3508,7 +3507,7 @@ mod tests {
 
     #[test]
     fn test_worker_consume_self_conflicting() {
-        let (mut test_frame, worker) = setup_test_frame(true, false);
+        let (mut test_frame, worker) = setup_test_frame(false);
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -3568,7 +3567,7 @@ mod tests {
 
     #[test]
     fn test_worker_consume_multiple_messages() {
-        let (mut test_frame, worker) = setup_test_frame(true, false);
+        let (mut test_frame, worker) = setup_test_frame(false);
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -3653,7 +3652,7 @@ mod tests {
 
     #[test]
     fn test_worker_ttl() {
-        let (mut test_frame, worker) = setup_test_frame(true, false);
+        let (mut test_frame, worker) = setup_test_frame(false);
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -3837,7 +3836,7 @@ mod tests {
 
     #[test]
     fn test_handle_tip_programs() {
-        let (mut test_frame, worker) = setup_test_frame(true, true);
+        let (mut test_frame, worker) = setup_test_frame(true);
         let worker_thread = std::thread::spawn(move || worker.run());
         let TestFrame {
             mint_keypair,

--- a/core/src/bundle_stage/bundle_consumer.rs
+++ b/core/src/bundle_stage/bundle_consumer.rs
@@ -2,7 +2,7 @@ use {
     crate::banking_stage::{
         committer::{CommitTransactionDetails, Committer},
         consumer::{
-            ENTRY_OVERHEAD_BYTES, ExecuteAndCommitTransactionsOutput, ExecutionFlags,
+            ENTRY_OVERHEAD_BYTES, ExecuteAndCommitTransactionsOutput,
             LeaderProcessedTransactionCounts, ProcessTransactionBatchOutput, RetryableIndex,
         },
         leader_slot_timing_metrics::LeaderExecuteAndCommitTimings,
@@ -37,8 +37,6 @@ use {
     },
 };
 
-const SERIALIZED_ENTRIES_LENGTH_BYTES: u64 = 8;
-
 pub struct BundleConsumer {
     committer: Committer,
     transaction_recorder: TransactionRecorder,
@@ -46,7 +44,6 @@ pub struct BundleConsumer {
 }
 
 impl BundleConsumer {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         committer: Committer,
         transaction_recorder: TransactionRecorder,
@@ -236,16 +233,10 @@ impl BundleConsumer {
             };
         }
 
-        let execute_and_commit_transactions_output = self.execute_and_commit_transactions_locked(
-            bank,
-            &batch,
-            ExecutionFlags {
-                drop_on_failure: true,
-                all_or_nothing: true,
-            },
-        );
+        let execute_and_commit_transactions_output =
+            self.execute_and_commit_transactions_locked(bank, &batch);
 
-        // // Once the accounts are new transactions can enter the pipeline to process them
+        // Once the accounts are unlocked, new transactions can enter the pipeline.
         let (_, unlock_us) = measure_us!(drop(batch));
 
         let ExecuteAndCommitTransactionsOutput {
@@ -288,7 +279,7 @@ impl BundleConsumer {
     {
         let start = Instant::now();
         while start.elapsed() < max_bundle_duration {
-            let batch = bank.prepare_sanitized_batch_relax_intrabatch_account_locks(txs);
+            let batch = bank.prepare_sanitized_batch(txs);
             if let Some(err) = batch.lock_results().iter().find(|x| x.is_err()) {
                 if err.as_ref().unwrap_err() == &TransactionError::AccountInUse {
                     sleep(Duration::from_millis(1));
@@ -300,14 +291,13 @@ impl BundleConsumer {
             }
         }
 
-        bank.prepare_sanitized_batch_relax_intrabatch_account_locks(txs)
+        bank.prepare_sanitized_batch(txs)
     }
 
     fn execute_and_commit_transactions_locked(
         &self,
         bank: &Bank,
         batch: &TransactionBatch<impl TransactionWithMeta>,
-        flags: ExecutionFlags,
     ) -> ExecuteAndCommitTransactionsOutput {
         let transaction_status_sender_enabled = self.committer.transaction_status_sender_enabled();
         let mut execute_and_commit_timings = LeaderExecuteAndCommitTimings::default();
@@ -328,8 +318,8 @@ impl BundleConsumer {
                     recording_config: ExecutionRecordingConfig::new_single_setting(
                         transaction_status_sender_enabled
                     ),
-                    drop_on_failure: flags.drop_on_failure,
-                    all_or_nothing: flags.all_or_nothing,
+                    drop_on_failure: true,
+                    all_or_nothing: true,
                     strict_nonce_size_check: true,
                     drop_noop_transactions: true,
                 }
@@ -368,23 +358,6 @@ impl BundleConsumer {
             };
         }
 
-        let actual_execute_time = execute_and_commit_timings
-            .execute_timings
-            .execute_accessories
-            .process_instructions
-            .total_us
-            .0;
-        let actual_executed_cu: u64 = processing_results
-            .iter()
-            .map(|processing_result| {
-                processing_result
-                    .as_ref()
-                    .map_or(0, |pr| pr.executed_units())
-            })
-            .sum();
-        let _actual_executed_cu = actual_executed_cu;
-        let _actual_execute_time = actual_execute_time;
-
         let transaction_counts = LeaderProcessedTransactionCounts {
             processed_count: processed_counts.processed_transactions_count,
             processed_with_successful_result_count: processed_counts
@@ -392,14 +365,25 @@ impl BundleConsumer {
             attempted_processing_count: processing_results.len() as u64,
         };
 
-        // All processing results are successful here; failures bail out above. Therefore every
-        // transaction in the batch will be recorded as its own entry by record_bundle().
-        let entry_bytes = batch.sanitized_transactions().iter().fold(
-            SERIALIZED_ENTRIES_LENGTH_BYTES.saturating_add(
-                ENTRY_OVERHEAD_BYTES.saturating_mul(batch.sanitized_transactions().len() as u64),
-            ),
-            |entry_bytes, tx| entry_bytes.saturating_add(tx.serialized_size() as u64),
-        );
+        // All processing results are successful here; failures bail out above. Convert once and
+        // calculate the serialized size of the single entry before taking the freeze lock.
+        let ((processed_transactions, entry_bytes), processing_results_to_transactions_us) =
+            measure_us!({
+                let mut entry_bytes = ENTRY_OVERHEAD_BYTES + 8; // Vec<Entry> length
+                let processed_transactions = batch
+                    .sanitized_transactions()
+                    .iter()
+                    .map(|tx| {
+                        let tx = tx.to_versioned_transaction();
+                        entry_bytes = entry_bytes.saturating_add(
+                            wincode::serialized_size(&tx)
+                                .expect("versioned transaction serialization should succeed"),
+                        );
+                        tx
+                    })
+                    .collect_vec();
+                (processed_transactions, entry_bytes)
+            });
 
         let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
         execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
@@ -411,19 +395,9 @@ impl BundleConsumer {
 
         let (recording_result, starting_transaction_index, record_us) = match reservation {
             Ok(()) => {
-                let (processed_transactions, processing_results_to_transactions_us) = measure_us!(
-                    batch
-                        .sanitized_transactions()
-                        .iter()
-                        .map(|tx| tx.to_versioned_transaction())
-                        .collect_vec()
-                );
-
-                // BundleStage executes multiple transactions which may contain overlapping
-                // accounts. This is needed until relax_intrabatch_account_locks is enabled.
                 let (summary, record_us) = measure_us!(
                     self.transaction_recorder
-                        .record_bundle(bank.bank_id(), processed_transactions)
+                        .record_transactions(bank.bank_id(), processed_transactions)
                 );
                 execute_and_commit_timings.record_transactions_timings =
                     RecordTransactionsTimings {
@@ -871,14 +845,14 @@ mod tests {
                 genesis_config.hash(),
             ))
         });
-        let entries = transactions
-            .iter()
-            .map(|tx| Entry {
-                num_hashes: 0,
-                hash: genesis_config.hash(),
-                transactions: vec![tx.to_versioned_transaction()],
-            })
-            .collect::<Vec<_>>();
+        let entries = vec![Entry {
+            num_hashes: 0,
+            hash: genesis_config.hash(),
+            transactions: transactions
+                .iter()
+                .map(|tx| tx.to_versioned_transaction())
+                .collect(),
+        }];
         let entry_bytes = wincode::serialized_size(&entries).unwrap();
         let entry_bytes_limit = bank.entry_bytes_budget().slot_limit();
         let remaining_entry_bytes = entry_bytes_limit
@@ -935,12 +909,9 @@ mod tests {
             )));
             let record = record_receiver.try_recv().unwrap();
             assert_eq!(record.bank_id, bank.bank_id());
-            assert_eq!(record.transaction_batches.len(), transactions.len());
-            assert!(
-                record
-                    .transaction_batches
-                    .iter()
-                    .all(|transaction_batch| transaction_batch.len() == 1)
+            assert_eq!(
+                record.transaction_batches,
+                vec![entries[0].transactions.clone()]
             );
             assert!(record_receiver.try_recv().is_err());
             assert!(

--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -100,55 +100,6 @@ impl TransactionRecorder {
         }
     }
 
-    pub fn record_batch(
-        &self,
-        bank_id: BankId,
-        mixins: Vec<Hash>,
-        transaction_batches: Vec<Vec<VersionedTransaction>>,
-    ) -> RecordTransactionsSummary {
-        let mut record_transactions_timings = RecordTransactionsTimings::default();
-        let mut starting_transaction_index = None;
-
-        if !transaction_batches.is_empty() {
-            let (res, poh_record_us) =
-                measure_us!(self.record(bank_id, mixins, transaction_batches));
-            record_transactions_timings.poh_record_us = Saturating(poh_record_us);
-
-            match res {
-                Ok(starting_index) => {
-                    starting_transaction_index = starting_index;
-                }
-                Err(RecordSenderError::InactiveBankId | RecordSenderError::Shutdown) => {
-                    return RecordTransactionsSummary {
-                        record_transactions_timings,
-                        result: Err(PohRecorderError::MaxHeightReached),
-                        starting_transaction_index: None,
-                    };
-                }
-                Err(RecordSenderError::Full) => {
-                    return RecordTransactionsSummary {
-                        record_transactions_timings,
-                        result: Err(PohRecorderError::ChannelFull),
-                        starting_transaction_index: None,
-                    };
-                }
-                Err(RecordSenderError::Disconnected) => {
-                    return RecordTransactionsSummary {
-                        record_transactions_timings,
-                        result: Err(PohRecorderError::ChannelDisconnected),
-                        starting_transaction_index: None,
-                    };
-                }
-            }
-        }
-
-        RecordTransactionsSummary {
-            record_transactions_timings,
-            result: Ok(()),
-            starting_transaction_index,
-        }
-    }
-
     // Returns the index of `transactions.first()` in the slot, if being tracked by WorkingBank
     pub fn record(
         &self,
@@ -158,62 +109,5 @@ impl TransactionRecorder {
     ) -> Result<Option<usize>, RecordSenderError> {
         self.record_sender
             .try_send(Record::new(mixins, transaction_batches, bank_id))
-    }
-
-    pub fn record_bundle(
-        &self,
-        bank_id: BankId,
-        transactions: Vec<VersionedTransaction>,
-    ) -> RecordTransactionsSummary {
-        let mut record_transactions_timings = RecordTransactionsTimings::default();
-        let mut starting_transaction_index = None;
-
-        if !transactions.is_empty() {
-            let mut hashes = Vec::with_capacity(transactions.len());
-            let mut batches = Vec::with_capacity(transactions.len());
-            for tx in transactions {
-                let batch = vec![tx];
-                let (hash, hash_us) = measure_us!(hash_transactions(&batch));
-                record_transactions_timings.hash_us += hash_us;
-                hashes.push(hash);
-                batches.push(batch);
-            }
-
-            let (res, poh_record_us) = measure_us!(self.record(bank_id, hashes, batches));
-            record_transactions_timings.poh_record_us = Saturating(poh_record_us);
-
-            match res {
-                Ok(starting_index) => {
-                    starting_transaction_index = starting_index;
-                }
-                Err(RecordSenderError::InactiveBankId | RecordSenderError::Shutdown) => {
-                    return RecordTransactionsSummary {
-                        record_transactions_timings,
-                        result: Err(PohRecorderError::MaxHeightReached),
-                        starting_transaction_index: None,
-                    };
-                }
-                Err(RecordSenderError::Full) => {
-                    return RecordTransactionsSummary {
-                        record_transactions_timings,
-                        result: Err(PohRecorderError::ChannelFull),
-                        starting_transaction_index: None,
-                    };
-                }
-                Err(RecordSenderError::Disconnected) => {
-                    return RecordTransactionsSummary {
-                        record_transactions_timings,
-                        result: Err(PohRecorderError::ChannelDisconnected),
-                        starting_transaction_index: None,
-                    };
-                }
-            }
-        }
-
-        RecordTransactionsSummary {
-            record_transactions_timings,
-            result: Ok(()),
-            starting_transaction_index,
-        }
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3706,22 +3706,6 @@ impl Bank {
         self.prepare_sanitized_batch_with_results(txs, txs.iter().map(|_| Ok(())))
     }
 
-    /// Override the relax_intrabatch_account_locks feature flag and use the SIMD83 logic for bundle execution
-    pub fn prepare_sanitized_batch_relax_intrabatch_account_locks<
-        'a,
-        'b,
-        Tx: TransactionWithMeta,
-    >(
-        &'a self,
-        transactions: &'b [Tx],
-    ) -> TransactionBatch<'a, 'b, Tx> {
-        TransactionBatch::new(
-            self.try_lock_accounts_with_results(transactions, transactions.iter().map(|_| Ok(()))),
-            self,
-            OwnedOrBorrowed::Borrowed(transactions),
-        )
-    }
-
     /// Prepare a locked transaction batch from a list of sanitized transactions, and their cost
     /// limited packing status
     pub fn prepare_sanitized_batch_with_results<'a, 'b, Tx: TransactionWithMeta>(

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -114,13 +114,10 @@ impl<Tx: SVMMessage> Drop for TransactionBatch<'_, '_, Tx> {
 mod tests {
     use {
         super::*,
-        crate::genesis_utils::{
-            GenesisConfigInfo, create_genesis_config, create_genesis_config_with_leader,
-        },
+        crate::genesis_utils::{GenesisConfigInfo, create_genesis_config_with_leader},
         solana_keypair::Keypair,
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
-        solana_signer::Signer,
-        solana_system_transaction::{self as system_transaction, transfer},
+        solana_system_transaction as system_transaction,
         solana_transaction::sanitized::SanitizedTransaction,
         solana_transaction_error::TransactionError,
     };
@@ -215,65 +212,5 @@ mod tests {
         ));
 
         (bank, txs)
-    }
-
-    #[test]
-    fn test_prepare_sanitized_batch_relax_intrabatch_account_locks() {
-        let GenesisConfigInfo {
-            genesis_config,
-            mint_keypair,
-            ..
-        } = create_genesis_config(500);
-        let bank = Bank::new_for_tests(&genesis_config);
-
-        let kp1 = Keypair::new();
-        let kp2 = Keypair::new();
-        let kp3 = Keypair::new();
-
-        let tx_batch_1 = vec![
-            RuntimeTransaction::from_transaction_for_tests(transfer(
-                &mint_keypair,
-                &kp1.pubkey(),
-                1,
-                genesis_config.hash(),
-            )),
-            RuntimeTransaction::from_transaction_for_tests(transfer(
-                &kp1,
-                &kp2.pubkey(),
-                1,
-                genesis_config.hash(),
-            )),
-        ];
-
-        let tx_batch_2 = vec![RuntimeTransaction::from_transaction_for_tests(transfer(
-            &kp2,
-            &kp3.pubkey(),
-            1,
-            genesis_config.hash(),
-        ))];
-
-        // overlapping batch should lock ok
-        let batch_1 = bank.prepare_sanitized_batch_relax_intrabatch_account_locks(&tx_batch_1);
-        assert!(batch_1.lock_results().iter().all(|x| x.is_ok()));
-
-        // trying to lock another batch with overlapping accounts should fail
-        let batch_2 = bank.prepare_sanitized_batch(&tx_batch_2);
-        assert_eq!(
-            batch_2.lock_results()[0],
-            Err(TransactionError::AccountInUse)
-        );
-        drop(batch_1);
-        drop(batch_2);
-
-        // locking in one batch then trying to lock overlapping accounts in another batch should fail
-        let batch_2 = bank.prepare_sanitized_batch(&tx_batch_2);
-        assert!(batch_2.lock_results().iter().all(|x| x.is_ok()));
-        let batch_1 = bank.prepare_sanitized_batch_relax_intrabatch_account_locks(&tx_batch_1);
-        assert_eq!(
-            batch_1.lock_results()[1],
-            Err(TransactionError::AccountInUse)
-        );
-        drop(batch_1);
-        drop(batch_2);
     }
 }


### PR DESCRIPTION
Follow-up to [comment](https://github.com/jito-foundation/jito-solana/pull/1536#discussion_r3767186584) in  #1536.

## Summary

- Record each bundle as a single transaction entry.
- Convert bundle transactions once and calculate exact single-entry bytes before taking the freeze lock.
- Remove the Jito-only batched recorder APIs and redundant SIMD-0083 locking wrapper.
- Remove stale bundle execution plumbing, dead calculations, and obsolete tests.

## Motivation

Bundle recording retained a pre-SIMD-0083 workaround that emitted one entry per transaction so transactions with overlapping accounts could coexist in a bundle. SIMD-0083 now permits intrabatch account conflicts and preserves transaction order, so the separate entries and special locking path are no longer necessary.

## Impact

- Reduces bundle record-channel insertions and PoH mixins from as many as five to one.
- Saves 48 bytes of entry overhead for every bundle transaction after the first.
- Avoids converting successful bundle transactions twice and shortens the freeze-lock critical section.
- Removes 215 net lines from the Jito patch.
- Preserves bundle order, all-or-nothing admission, retry behavior, and transaction indexes.