### PR TITLE
Fail closed atomic transactions on sad handover

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -697,6 +697,7 @@ impl BankingStage {
                             finished_work_receiver,
                             bam_dependencies.outbound_sender.clone(),
                             bam_scheduler_bank_forks.clone(),
+                            bam_shared_leader_state.clone(),
                         );
                         let receive_and_buffer = BamReceiveAndBuffer::new(
                             bam_scheduler_exit.clone(),
@@ -1451,19 +1452,21 @@ mod tests {
             )),
         ];
 
-        let summary = recorder.record_transactions(bank.bank_id(), txs.clone());
+        let summary = recorder.record_transactions(bank.bank_id(), txs.clone(), true);
         assert!(summary.result.is_ok());
+        let record = record_receiver.try_recv().unwrap();
         assert_eq!(
-            record_receiver.try_recv().unwrap().transaction_batches,
-            vec![txs.clone()]
+            record.transaction_batches.as_slice(),
+            std::slice::from_ref(&txs)
         );
+        assert!(record.reschedule_on_sad_handover);
         assert!(record_receiver.try_recv().is_err());
 
         // Once bank is set to a new bank (setting bank id + 1 in record_transactions),
         // record_transactions should throw MaxHeightReached
         let next_bank_id = bank.bank_id() + 1;
         let RecordTransactionsSummary { result, .. } =
-            recorder.record_transactions(next_bank_id, txs);
+            recorder.record_transactions(next_bank_id, txs, true);
         assert_matches!(result, Err(PohRecorderError::MaxHeightReached));
         // Should receive nothing from PohRecorder b/c record failed
         assert!(record_receiver.try_recv().is_err());

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -207,16 +207,16 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
     /// Best-effort per-slot tip-program maintenance for batches that touch tip accounts.
     ///
     /// Returns `true` when tip deps are disabled, no tip account is touched, tips were already
-    /// updated for this slot, or the best-effort upkeep path reaches the end.
+    /// updated for this bank, or the best-effort upkeep path reaches the end.
     /// Bundle-construction errors from init/crank bundle creation are non-fatal (crank errors are
-    /// logged), and this path still sets `last_tip_updated_slot = bank.slot()`.
+    /// logged), and this path still records the bank as updated.
     ///
     /// Returns `false` when required upkeep transactions fail to commit, or when block-builder
     /// info is unavailable.
     fn maybe_run_tip_programs(&self, bank: &Arc<Bank>, txs: &[impl TransactionWithMeta]) -> bool {
         let Some(TipProcessingDependencies {
             tip_manager,
-            last_tip_updated_slot,
+            last_tip_updated_bank,
             block_builder_fee_info,
             cluster_info,
             bundle_account_locker,
@@ -235,8 +235,8 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             return true;
         }
 
-        let mut last_tip_updated_slot_guard = last_tip_updated_slot.lock().unwrap();
-        if bank.slot() == *last_tip_updated_slot_guard {
+        let mut last_tip_updated_bank_guard = last_tip_updated_bank.lock().unwrap();
+        if *last_tip_updated_bank_guard == Some((bank.slot(), bank.bank_id())) {
             return true;
         }
 
@@ -293,7 +293,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             }
         }
 
-        *last_tip_updated_slot_guard = bank.slot();
+        *last_tip_updated_bank_guard = Some((bank.slot(), bank.bank_id()));
         true
     }
 
@@ -3327,7 +3327,7 @@ mod tests {
                         commission_bps: 0,
                     },
                 }),
-                last_tip_updated_slot: Arc::new(Mutex::new(0)),
+                last_tip_updated_bank: Arc::new(Mutex::new(None)),
                 block_builder_fee_info: Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
                     block_builder: mint_keypair.pubkey(),
                     block_builder_commission: 0,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -18,6 +18,7 @@ use {
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     solana_time_utils::AtomicInterval,
     std::{
+        marker::PhantomData,
         sync::{
             Arc,
             atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
@@ -31,8 +32,14 @@ use {
 pub enum ConsumeWorkerError<Tx> {
     #[error("Failed to receive work from scheduler: {0}")]
     Recv(#[from] TryRecvError),
-    #[error("Failed to send finalized consume work to scheduler: {0}")]
-    Send(#[from] SendError<FinishedConsumeWork<Tx>>),
+    #[error("Scheduler channel disconnected")]
+    Send(PhantomData<Tx>),
+}
+
+impl<Tx> From<SendError<FinishedConsumeWork<Tx>>> for ConsumeWorkerError<Tx> {
+    fn from(_: SendError<FinishedConsumeWork<Tx>>) -> Self {
+        Self::Send(PhantomData)
+    }
 }
 
 enum ProcessingStatus<Tx> {

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -12,6 +12,7 @@ use {
     arc_swap::ArcSwap,
     smallvec::SmallVec,
     solana_accounts_db::accounts::TransactionAccountLocksIterator,
+    solana_clock::{BankId, Slot},
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure_us,
     solana_poh::{
@@ -115,7 +116,7 @@ pub struct LeaderProcessedTransactionCounts {
 #[derive(Clone)]
 pub struct TipProcessingDependencies {
     pub tip_manager: TipManager,
-    pub last_tip_updated_slot: Arc<Mutex<u64>>,
+    pub last_tip_updated_bank: Arc<Mutex<Option<(Slot, BankId)>>>,
     pub block_builder_fee_info: Arc<ArcSwap<BlockBuilderFeeInfo>>,
     pub cluster_info: Arc<ClusterInfo>,
     pub bundle_account_locker: BundleAccountLocker,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -488,8 +488,11 @@ impl Consumer {
                     EntryBytesReserveError::ExceedsSlotLimit => PohRecorderError::MaxHeightReached,
                 });
         let (record_transactions_summary, record_us) = measure_us!(reserved_bytes.map(|_| {
-            self.transaction_recorder
-                .record_transactions(bank.bank_id(), processed_transactions)
+            self.transaction_recorder.record_transactions(
+                bank.bank_id(),
+                processed_transactions,
+                !revert_on_error,
+            )
         }));
         execute_and_commit_timings.record_us = record_us;
 
@@ -771,8 +774,9 @@ mod tests {
         account
     }
 
-    #[test]
-    fn test_bank_process_and_record_transactions() {
+    #[test_case(false; "ordinary")]
+    #[test_case(true; "revert_on_error")]
+    fn test_bank_process_and_record_transactions(revert_on_error: bool) {
         let TestFrame {
             mint_keypair,
             bank,
@@ -793,7 +797,7 @@ mod tests {
             &bank,
             &transactions,
             &BundleAccountLocker::default(),
-            false,
+            revert_on_error,
         );
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -816,6 +820,7 @@ mod tests {
 
         let record = record_receiver.drain().next().unwrap();
         assert_eq!(record.bank_id, bank.bank_id());
+        assert_eq!(record.reschedule_on_sad_handover, !revert_on_error);
         assert_eq!(record.transaction_batches.len(), 1);
         let transaction_batch = record.transaction_batches[0].clone();
         assert_eq!(transaction_batch.len(), 1);

--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -59,12 +59,12 @@ impl DecisionMaker {
         require_atomic_bank: bool,
     ) -> BufferedPacketsDecision {
         let state = self.shared_leader_state.load();
-        if require_atomic_bank && !state.atomic_batches_enabled() {
-            return BufferedPacketsDecision::Hold;
-        }
-
         if let Some(working_bank) = state.working_bank() {
-            BufferedPacketsDecision::Consume(working_bank.clone())
+            if require_atomic_bank && !state.atomic_batches_enabled() {
+                BufferedPacketsDecision::Hold
+            } else {
+                BufferedPacketsDecision::Consume(working_bank.clone())
+            }
         } else if let Some(leader_first_tick_height) = state.leader_first_tick_height() {
             let current_tick_height = state.tick_height();
             let ticks_until_leader = leader_first_tick_height.saturating_sub(current_tick_height);
@@ -117,6 +117,13 @@ mod tests {
         // No active bank, no leader first tick height.
         assert_matches!(
             decision_maker.make_consume_or_forward_decision(),
+            BufferedPacketsDecision::Forward
+        );
+        shared_leader_state.store(Arc::new(LeaderState::new_with_atomic_batches_enabled(
+            None, 0, None, None, false,
+        )));
+        assert_matches!(
+            decision_maker.make_atomic_consume_or_forward_decision(),
             BufferedPacketsDecision::Forward
         );
 

--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -44,8 +44,24 @@ impl DecisionMaker {
         }
     }
 
+    #[inline]
     pub(crate) fn make_consume_or_forward_decision(&self) -> BufferedPacketsDecision {
+        self.make_consume_or_forward_decision_inner(false)
+    }
+
+    #[inline]
+    pub(crate) fn make_atomic_consume_or_forward_decision(&self) -> BufferedPacketsDecision {
+        self.make_consume_or_forward_decision_inner(true)
+    }
+
+    fn make_consume_or_forward_decision_inner(
+        &self,
+        require_atomic_bank: bool,
+    ) -> BufferedPacketsDecision {
         let state = self.shared_leader_state.load();
+        if require_atomic_bank && !state.atomic_batches_enabled() {
+            return BufferedPacketsDecision::Hold;
+        }
 
         if let Some(working_bank) = state.working_bank() {
             BufferedPacketsDecision::Consume(working_bank.clone())
@@ -112,8 +128,24 @@ mod tests {
             None,
         )));
         assert_matches!(
+            decision_maker.make_atomic_consume_or_forward_decision(),
+            BufferedPacketsDecision::Consume(_)
+        );
+
+        shared_leader_state.store(Arc::new(LeaderState::new_with_atomic_batches_enabled(
+            Some(bank.clone()),
+            0,
+            None,
+            None,
+            false,
+        )));
+        assert_matches!(
             decision_maker.make_consume_or_forward_decision(),
             BufferedPacketsDecision::Consume(_)
+        );
+        assert_matches!(
+            decision_maker.make_atomic_consume_or_forward_decision(),
+            BufferedPacketsDecision::Hold
         );
         shared_leader_state.store(Arc::new(LeaderState::new(None, 0, None, None)));
 

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -63,6 +63,14 @@ fn passthrough_priority(
 
 pub const MAX_PACKETS_PER_BUNDLE: usize = 5; // copied from BundleStorage::MAX_PACKETS_PER_BUNDLE
 
+// Sized from 30 days of mainnet data ending 2026-08-18. Atomic-only ClickHouse counts of distinct
+// `(source, seq_id)` batches per validator-slot had p99=149, p99.9=236, 99.94% <=256, and max=540.
+// The full-slot count conservatively upper-bounds the pre-ParentReady subset stored here.
+// Mainnet-validator Influx `bam_connection-metrics.bundle_received` active 25 ms samples, which
+// also include non-atomic batches, had p99=183, p99.9=272, 99.86% <=256, and max=881. Thus 256
+// keeps the atomic p99.9 inline in 4 KiB while rarer bursts spill safely.
+const DEFERRED_ATOMIC_BATCHES_INLINE_CAPACITY: usize = 256;
+
 pub struct BamScheduler<Tx: TransactionWithMeta> {
     consume_work_sender: Sender<ConsumeWork<Tx>>,
     finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
@@ -81,7 +89,8 @@ pub struct BamScheduler<Tx: TransactionWithMeta> {
 
     // Reusable objects to avoid allocations
     reusable_consume_work: Vec<ConsumeWork<Tx>>,
-    deferred_atomic_batches: SmallVec<[TransactionPriorityId; 8]>,
+    deferred_atomic_batches:
+        SmallVec<[TransactionPriorityId; DEFERRED_ATOMIC_BATCHES_INLINE_CAPACITY]>,
 
     extra_checks_enabled: bool,
     bank_forks: Arc<RwLock<BankForks>>,

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -31,6 +31,7 @@ use {
     smallvec::SmallVec,
     solana_clock::{MAX_PROCESSING_AGE, Slot},
     solana_nohash_hasher::IntMap,
+    solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -80,9 +81,11 @@ pub struct BamScheduler<Tx: TransactionWithMeta> {
 
     // Reusable objects to avoid allocations
     reusable_consume_work: Vec<ConsumeWork<Tx>>,
+    deferred_atomic_batches: SmallVec<[TransactionPriorityId; 8]>,
 
     extra_checks_enabled: bool,
     bank_forks: Arc<RwLock<BankForks>>,
+    shared_leader_state: SharedLeaderState,
 }
 
 // A structure to hold information about inflight batches.
@@ -101,6 +104,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
         response_sender: TokioSender<BamOutboundMessage>,
         bank_forks: Arc<RwLock<BankForks>>,
+        shared_leader_state: SharedLeaderState,
     ) -> Self {
         Self {
             consume_work_sender,
@@ -116,8 +120,10 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             last_schedule_time: Instant::now(),
             slot: None,
             reusable_consume_work: Vec::new(),
+            deferred_atomic_batches: SmallVec::new(),
             extra_checks_enabled: true,
             bank_forks,
+            shared_leader_state,
         }
     }
 
@@ -143,15 +149,22 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         };
 
         let working_bank = self.bank_forks.read().unwrap().working_bank();
+        let atomic_batches_enabled = self.shared_leader_state.load().atomic_batches_enabled();
+        self.deferred_atomic_batches.clear();
 
         while let Some(next_batch_id) = container.pop() {
-            let Some((batch_ids, _, max_schedule_slot, seq_id)) =
+            let Some((batch_ids, revert_on_error, max_schedule_slot, seq_id)) =
                 container.get_batch(next_batch_id.id)
             else {
                 error!("Batch {} not found in container", next_batch_id.id);
                 container.remove_by_id(next_batch_id.id);
                 continue;
             };
+
+            if revert_on_error && !atomic_batches_enabled {
+                self.deferred_atomic_batches.push(next_batch_id);
+                continue;
+            }
 
             if max_schedule_slot < slot {
                 // If the slot has changed, we cannot schedule this batch
@@ -204,6 +217,10 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                 Self::get_transactions_account_access(txns.into_iter()),
             );
         }
+
+        // Atomic batches must wait until ParentReady confirms or replaces the provisional bank.
+        // Non-atomic batches can still be rescheduled after sad handover.
+        container.push_ids_into_queue(self.deferred_atomic_batches.drain(..));
     }
 
     fn send_to_workers(
@@ -819,6 +836,7 @@ mod tests {
         solana_keypair::Keypair,
         solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_message::Message,
+        solana_poh::poh_recorder::SharedLeaderState,
         solana_pubkey::Pubkey,
         solana_runtime::{bank::Bank, bank_forks::BankForks},
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
@@ -853,6 +871,7 @@ mod tests {
             finished_consume_work_receiver,
             response_sender,
             bank_forks.clone(),
+            SharedLeaderState::new(0, None, None),
         );
         TestScheduler {
             scheduler,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -1272,6 +1272,7 @@ mod tests {
             finished_work_receiver,
             response_sender,
             bank_forks.clone(),
+            shared_leader_state.clone(),
         );
 
         let mut scheduler_controller = SchedulerController::new(

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -571,6 +571,7 @@ fn produce_window(
         start_slot,
         parent_block.slot,
         Some(parent_block.block_id),
+        !fast_leader_handover,
         block_timer,
         ctx,
     )?;
@@ -622,7 +623,8 @@ fn produce_window(
 
         // Although `slot - 1`has been cleared from `poh_recorder`, it might not have finished processing in
         // `replay_stage`, which is why we use `start_leader_retry_replay`
-        working_bank = start_leader_wait_for_parent_replay(slot, slot - 1, None, block_timer, ctx)?;
+        working_bank =
+            start_leader_wait_for_parent_replay(slot, slot - 1, None, true, block_timer, ctx)?;
     }
 
     window_production_start.stop();
@@ -707,7 +709,7 @@ fn record_and_complete_block(
                 ctx.record_receiver
                     .on_received_record(record.transaction_batches.len() as u64);
 
-                if optimistic_parent.is_some() {
+                if optimistic_parent.is_some() && record.reschedule_on_sad_handover {
                     record.transaction_batches.iter().for_each(|batch| {
                         accumulated_txs.extend(batch.iter().cloned());
                     });
@@ -908,6 +910,12 @@ fn handle_parent_ready(
 ) -> Result<Option<Arc<Bank>>, PohRecorderError> {
     if leader_window_info.parent_block == optimistic_parent_block {
         // Happy path: optimistic parent matches the one from ParentReady
+        ctx.poh_recorder
+            .read()
+            .unwrap()
+            .shared_leader_state()
+            .load()
+            .enable_atomic_batches();
         return Ok(None);
     }
 
@@ -959,6 +967,7 @@ fn handle_parent_ready(
         slot,
         new_parent_slot,
         Some(new_parent_hash),
+        true,
         *block_timer,
         ctx,
     )
@@ -1014,7 +1023,9 @@ fn shutdown_and_drain_record_receiver(
     record_receiver.shutdown();
 
     for record in record_receiver.drain_after_shutdown() {
-        if let Some(accumulated_txs) = accumulated_txs.as_deref_mut() {
+        if record.reschedule_on_sad_handover
+            && let Some(accumulated_txs) = accumulated_txs.as_deref_mut()
+        {
             record.transaction_batches.iter().for_each(|batch| {
                 accumulated_txs.extend(batch.iter().cloned());
             });
@@ -1041,6 +1052,7 @@ fn start_leader_wait_for_parent_replay(
     slot: Slot,
     parent_slot: Slot,
     parent_hash: Option<Hash>,
+    atomic_batches_enabled: bool,
     block_timer: Instant,
     ctx: &mut LeaderContext,
 ) -> Result<Arc<Bank>, StartLeaderError> {
@@ -1070,7 +1082,7 @@ fn start_leader_wait_for_parent_replay(
             ));
         }
 
-        match maybe_start_leader(slot, parent_slot, parent_hash, ctx) {
+        match maybe_start_leader(slot, parent_slot, parent_hash, atomic_batches_enabled, ctx) {
             Ok(()) => {
                 slot_delay_start.stop();
                 let _ = ctx
@@ -1177,6 +1189,7 @@ fn maybe_start_leader(
     slot: Slot,
     parent_slot: Slot,
     parent_hash: Option<Hash>,
+    atomic_batches_enabled: bool,
     ctx: &mut LeaderContext,
 ) -> Result<(), StartLeaderError> {
     if ctx.bank_forks.read().unwrap().get(slot).is_some() {
@@ -1207,7 +1220,7 @@ fn maybe_start_leader(
     }
 
     // Create and insert the bank
-    create_and_insert_leader_bank(slot, parent_bank, ctx)
+    create_and_insert_leader_bank(slot, parent_bank, atomic_batches_enabled, ctx)
 }
 
 /// Creates and inserts the leader bank `slot` of this window with
@@ -1215,6 +1228,7 @@ fn maybe_start_leader(
 fn create_and_insert_leader_bank(
     slot: Slot,
     parent_bank: Arc<Bank>,
+    atomic_batches_enabled: bool,
     ctx: &mut LeaderContext,
 ) -> Result<(), StartLeaderError> {
     let parent_slot = parent_bank.slot();
@@ -1288,7 +1302,10 @@ fn create_and_insert_leader_bank(
     let tpu_bank = ctx.bank_forks_controller.insert_bank(tpu_bank)?;
 
     let bank_id = tpu_bank.bank_id();
-    ctx.poh_recorder.write().unwrap().set_bank(tpu_bank);
+    ctx.poh_recorder
+        .write()
+        .unwrap()
+        .set_bank_with_atomic_batches_enabled(tpu_bank, atomic_batches_enabled);
 
     // If this is the first alpenglow block, emit the genesis certificate marker.
     // This happens before record intake restarts, so a send failure can be
@@ -1351,9 +1368,25 @@ fn should_include_genesis_certificate(
 mod tests {
     use {
         super::*,
-        crate::banking_trace::BankingTracer,
+        crate::{
+            bam_dependencies::BamOutboundMessage,
+            banking_stage::{
+                committer::Committer,
+                consume_worker::ConsumeWorker,
+                consumer::Consumer,
+                decision_maker::BufferedPacketsDecision,
+                scheduler_messages::MaxAge,
+                transaction_scheduler::{
+                    bam_scheduler::BamScheduler,
+                    scheduler::Scheduler,
+                    transaction_state_container::{StateContainer, TransactionStateContainer},
+                },
+            },
+            banking_trace::BankingTracer,
+        },
         agave_banking_stage_ingress_types::BankingPacketReceiver,
-        crossbeam_channel::bounded,
+        crossbeam_channel::{bounded, unbounded},
+        jito_protos::proto::bam_types::atomic_txn_batch_result::Result::NotCommitted,
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_entry::{block_component::VersionedUpdateParent, entry_or_marker::EntryOrMarker},
         solana_keypair::Keypair,
@@ -1362,12 +1395,17 @@ mod tests {
         solana_poh::{
             poh_recorder::{PohRecorder, Record, WorkingBankEntryOrMarker},
             record_channels::record_channels,
+            transaction_recorder::TransactionRecorder,
         },
         solana_poh_config::PohConfig,
         solana_runtime::{
-            bank::Bank, bank_forks::BankForks, genesis_utils::create_genesis_config_with_leader,
+            bank::{Bank, test_utils},
+            bank_forks::BankForks,
+            genesis_utils::create_genesis_config_with_leader,
             installed_scheduler_pool::BankWithScheduler,
         },
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_signer::Signer,
         solana_system_transaction as system_transaction,
         std::num::NonZeroUsize,
     };
@@ -1582,7 +1620,7 @@ mod tests {
             genesis_cert_block_marker: test_genesis_cert_block_marker(),
         };
 
-        create_and_insert_leader_bank(1, root_bank.clone(), &mut ctx).unwrap();
+        create_and_insert_leader_bank(1, root_bank.clone(), true, &mut ctx).unwrap();
         assert!(ctx.poh_recorder.read().unwrap().has_bank());
         assert!(ctx.bank_forks.read().unwrap().get(1).is_some());
 
@@ -1611,7 +1649,7 @@ mod tests {
                 .recv_timeout(Duration::from_secs(1))
                 .unwrap();
         });
-        create_and_insert_leader_bank(1, root_bank, &mut ctx).unwrap();
+        create_and_insert_leader_bank(1, root_bank, true, &mut ctx).unwrap();
         assert!(ctx.poh_recorder.read().unwrap().has_bank());
         assert!(ctx.bank_forks.read().unwrap().get(1).is_some());
 
@@ -1700,7 +1738,7 @@ mod tests {
             genesis_cert_block_marker,
         };
 
-        let err = create_and_insert_leader_bank(2, parent_bank, &mut ctx).unwrap_err();
+        let err = create_and_insert_leader_bank(2, parent_bank, true, &mut ctx).unwrap_err();
         assert!(matches!(
             err,
             StartLeaderError::PohRecorder(PohRecorderError::SendError(_))
@@ -1775,13 +1813,14 @@ mod tests {
             genesis_cert_block_marker: test_genesis_cert_block_marker(),
         };
 
-        create_and_insert_leader_bank(1, root_bank, &mut ctx).unwrap();
+        create_and_insert_leader_bank(1, root_bank, true, &mut ctx).unwrap();
         let bank_id = ctx.poh_recorder.read().unwrap().bank().unwrap().bank_id();
         record_sender
             .try_send(Record::new(
                 vec![Hash::new_unique()],
                 vec![vec![versioned_transfer(1)]],
                 bank_id,
+                true,
             ))
             .unwrap();
 
@@ -1829,6 +1868,10 @@ mod tests {
             SlotLeader::new_unique(),
             optimistic_parent_slot,
         );
+        let fork_payer = Keypair::new();
+        let ordinary_payer = Keypair::new();
+        test_utils::deposit(&optimistic_parent, &fork_payer.pubkey(), 1_000_000).unwrap();
+        test_utils::deposit(&optimistic_parent, &ordinary_payer.pubkey(), 1_000_000).unwrap();
         optimistic_parent.freeze();
         optimistic_parent.set_block_id(Some(optimistic_parent_hash));
 
@@ -1885,16 +1928,86 @@ mod tests {
         };
 
         let leader_slot = 4;
-        create_and_insert_leader_bank(leader_slot, optimistic_parent, &mut ctx).unwrap();
-        let optimistic_bank_id = ctx.poh_recorder.read().unwrap().bank().unwrap().bank_id();
+        create_and_insert_leader_bank(leader_slot, optimistic_parent, false, &mut ctx).unwrap();
+        let optimistic_bank = ctx.poh_recorder.read().unwrap().bank().unwrap();
+        let optimistic_bank_id = optimistic_bank.bank_id();
+        let shared_leader_state = ctx.poh_recorder.read().unwrap().shared_leader_state();
+        let optimistic_leader_state = shared_leader_state.load();
+
+        // Both atomic transactions are valid on the optimistic fork, while the second fee payer
+        // exists only there. The scheduler must hold them until ParentReady resolves the fork.
+        let first_recipient = Pubkey::new_unique();
+        let recent_blockhash = root_bank.last_blockhash();
+        let runtime_transfer = |payer, recipient| {
+            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+                payer,
+                &recipient,
+                1,
+                recent_blockhash,
+            ))
+        };
+        let txns_max_age = [
+            runtime_transfer(&genesis.mint_keypair, first_recipient),
+            runtime_transfer(&fork_payer, Pubkey::new_unique()),
+        ]
+        .into_iter()
+        .map(|transaction| (transaction, MaxAge::MAX))
+        .collect();
+        let mut container = TransactionStateContainer::with_capacity(8);
+        container
+            .insert_new_batch(txns_max_age, u64::MAX, true, leader_slot, 71)
+            .unwrap();
+        container
+            .insert_new_batch(
+                [(
+                    runtime_transfer(&ordinary_payer, Pubkey::new_unique()),
+                    MaxAge::MAX,
+                )]
+                .into_iter()
+                .collect(),
+                u64::MAX - 1,
+                false,
+                leader_slot,
+                72,
+            )
+            .unwrap();
+
+        let (consume_work_sender, consume_work_receiver) = unbounded();
+        let (finished_work_sender, finished_work_receiver) = unbounded();
+        let (response_sender, mut response_receiver) = tokio::sync::mpsc::channel(1);
+        let mut bam_scheduler = BamScheduler::new(
+            consume_work_sender,
+            finished_work_receiver,
+            response_sender,
+            ctx.bank_forks.clone(),
+            shared_leader_state.clone(),
+        );
+        let optimistic_decision = BufferedPacketsDecision::Consume(optimistic_bank);
+        bam_scheduler
+            .receive_completed(&mut container, &optimistic_decision)
+            .unwrap();
+        bam_scheduler.schedule(&mut container, u64::MAX).unwrap();
+        assert_eq!(container.queue_size(), 1);
+        assert!(!consume_work_receiver.try_recv().unwrap().revert_on_error);
+        assert!(response_receiver.try_recv().is_err());
 
         let accumulated_tx = versioned_transfer(1);
         let drained_tx = versioned_transfer(2);
+        let protected_txs = vec![versioned_transfer(3), versioned_transfer(4)];
         record_sender
             .try_send(Record::new(
                 vec![Hash::new_unique()],
                 vec![vec![drained_tx.clone()]],
                 optimistic_bank_id,
+                true,
+            ))
+            .unwrap();
+        record_sender
+            .try_send(Record::new(
+                vec![Hash::new_unique()],
+                vec![protected_txs],
+                optimistic_bank_id,
+                false,
             ))
             .unwrap();
 
@@ -1922,6 +2035,64 @@ mod tests {
 
         assert_eq!(new_bank.slot(), leader_slot);
         assert_eq!(new_bank.parent_slot(), new_parent_slot);
+        assert!(!optimistic_leader_state.atomic_batches_enabled());
+        assert!(
+            ctx.poh_recorder
+                .read()
+                .unwrap()
+                .shared_leader_state()
+                .load()
+                .atomic_batches_enabled()
+        );
+
+        // The replacement fork does not contain `fork_payer`. Verify the real consume worker
+        // rejects the entire atomic batch rather than committing its valid prefix.
+        let (replay_vote_sender, _replay_vote_receiver) = bounded(1);
+        let worker_exit = Arc::new(AtomicBool::default());
+        let worker = ConsumeWorker::new(
+            0,
+            worker_exit.clone(),
+            consume_work_receiver,
+            Consumer::new(
+                Committer::new(None, replay_vote_sender, None),
+                TransactionRecorder::new(record_sender),
+                None,
+            ),
+            finished_work_sender,
+            shared_leader_state,
+        );
+        let worker_handle = thread::spawn(move || worker.run());
+
+        let replacement_decision = BufferedPacketsDecision::Consume(new_bank.clone());
+        bam_scheduler
+            .receive_completed(&mut container, &replacement_decision)
+            .unwrap();
+        bam_scheduler.schedule(&mut container, u64::MAX).unwrap();
+
+        let result_deadline = Instant::now() + Duration::from_secs(5);
+        let response = loop {
+            bam_scheduler
+                .receive_completed(&mut container, &replacement_decision)
+                .unwrap();
+            if let Ok(response) = response_receiver.try_recv() {
+                break response;
+            }
+            assert!(
+                Instant::now() < result_deadline,
+                "timed out waiting for atomic batch result"
+            );
+            thread::sleep(Duration::from_millis(1));
+        };
+        worker_exit.store(true, Ordering::Relaxed);
+        worker_handle.join().unwrap().unwrap();
+
+        let BamOutboundMessage::AtomicTxnBatchResult(result) = response else {
+            panic!("expected atomic transaction batch result");
+        };
+        assert_eq!(result.seq_id, 71);
+        assert!(matches!(result.result, Some(NotCommitted(_))));
+        assert_eq!(new_bank.get_balance(&first_recipient), 0);
+
         assert_eq!(
             ctx.bank_forks
                 .read()

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -576,7 +576,7 @@ impl BundleStage {
         cluster_info: &Arc<ClusterInfo>,
         consume_worker_metrics: &ConsumeWorkerMetrics,
     ) {
-        match decision_maker.make_consume_or_forward_decision() {
+        match decision_maker.make_atomic_consume_or_forward_decision() {
             // BufferedPacketsDecision::Consume means this leader is scheduled to be running at the moment.
             // Execute, record, and commit as many bundles possible given time, compute, and other constraints.
             BufferedPacketsDecision::Consume(bank) => {
@@ -669,7 +669,7 @@ impl BundleStage {
         loop {
             // Always ensure the window is filled with bundles, breaking out when the bundle deque is full or no more bundles are available to pop
             while bundles.len() < BUNDLE_WINDOW_SIZE.get() {
-                let Some(bundle) = bundle_storage.pop_bundle(bank.slot()) else {
+                let Some(bundle) = bundle_storage.pop_bundle(bank.slot(), bank.bank_id()) else {
                     break;
                 };
 

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -1121,7 +1121,9 @@ mod tests {
         for _ in 0..2 {
             insert_bundle(&mut bundle_storage);
         }
-        let retryable_bundle = bundle_storage.pop_bundle(bank.slot()).unwrap();
+        let retryable_bundle = bundle_storage
+            .pop_bundle(bank.slot(), bank.bank_id())
+            .unwrap();
         bundle_storage.retry_bundle(retryable_bundle);
 
         std::thread::scope(|scope| {

--- a/core/src/bundle_stage/bundle_consumer.rs
+++ b/core/src/bundle_stage/bundle_consumer.rs
@@ -380,10 +380,12 @@ impl BundleConsumer {
 
         let (recording_result, starting_transaction_index, record_us) = match reservation {
             Ok(()) => {
-                let (summary, record_us) = measure_us!(
-                    self.transaction_recorder
-                        .record_transactions(bank.bank_id(), processed_transactions)
-                );
+                let (summary, record_us) =
+                    measure_us!(self.transaction_recorder.record_transactions(
+                        bank.bank_id(),
+                        processed_transactions,
+                        false
+                    ));
                 execute_and_commit_timings.record_transactions_timings =
                     RecordTransactionsTimings {
                         processing_results_to_transactions_us: Saturating(
@@ -961,6 +963,7 @@ mod tests {
             )));
             let record = record_receiver.try_recv().unwrap();
             assert_eq!(record.bank_id, bank.bank_id());
+            assert!(!record.reschedule_on_sad_handover);
             assert_eq!(
                 record.transaction_batches,
                 vec![entries[0].transactions.clone()]

--- a/core/src/bundle_stage/bundle_storage.rs
+++ b/core/src/bundle_stage/bundle_storage.rs
@@ -13,7 +13,8 @@ use {
     },
     ahash::HashSet,
     arrayvec::ArrayVec,
-    solana_clock::Slot,
+    smallvec::SmallVec,
+    solana_clock::{BankId, Slot},
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_runtime_transaction::{
@@ -33,13 +34,17 @@ pub enum BundleStorageError {
 }
 
 struct BundleTransactionId {
-    container_ids: Vec<usize>,
+    container_ids: SmallVec<[usize; 5]>,
+    sanitized_bank_id: BankId,
+    sanitized_bank_slot: Slot,
 }
 
 pub struct BundleStorageEntry {
-    pub container_ids: Vec<usize>,
-    pub transactions: Vec<RuntimeTransactionView>,
-    pub max_ages: Vec<MaxAge>,
+    pub container_ids: SmallVec<[usize; 5]>,
+    pub transactions: SmallVec<[RuntimeTransactionView; 5]>,
+    pub max_ages: SmallVec<[MaxAge; 5]>,
+    sanitized_bank_id: BankId,
+    sanitized_bank_slot: Slot,
 }
 
 /// Bundle storage has two deques: one for unprocessed bundles and another for ones that exceeded
@@ -94,6 +99,8 @@ impl BundleStorage {
         self.cost_model_buffered_bundles
             .push_back(BundleTransactionId {
                 container_ids: bundle.container_ids,
+                sanitized_bank_id: bundle.sanitized_bank_id,
+                sanitized_bank_slot: bundle.sanitized_bank_slot,
             });
     }
 
@@ -109,7 +116,7 @@ impl BundleStorage {
 
     /// Pops a bundle from the unprocessed_bundles queue and returns it as a BundleStorageEntry.
     /// Returns None if there are no bundles to pop.
-    pub fn pop_bundle(&mut self, slot: Slot) -> Option<BundleStorageEntry> {
+    pub fn pop_bundle(&mut self, slot: Slot, bank_id: BankId) -> Option<BundleStorageEntry> {
         if slot != self.last_slot {
             // the cost_model_buffered_bundles has the oldest bundles at the front of the queue
             // we need to pop from the back of that queue and insert to the front of the unprocessed_bundles queue so by the time we reach the front,
@@ -122,10 +129,19 @@ impl BundleStorage {
         }
 
         // only want to pop from the unprocessed bundles queue and wait for slot boundary to refresh from cost_model_buffered_bundles
-        let bundle = self.unprocessed_bundles.pop_front()?;
+        while let Some(bundle) = self.unprocessed_bundles.pop_front() {
+            if bundle.sanitized_bank_slot == slot && bundle.sanitized_bank_id != bank_id {
+                for container_id in bundle.container_ids {
+                    self.transaction_view_state_container
+                        .remove_by_id(container_id);
+                }
+                continue;
+            }
 
-        let (bundle_transactions, bundle_max_ages): (Vec<RuntimeTransactionView>, Vec<MaxAge>) =
-            bundle
+            let (bundle_transactions, bundle_max_ages): (
+                SmallVec<[RuntimeTransactionView; 5]>,
+                SmallVec<[MaxAge; 5]>,
+            ) = bundle
                 .container_ids
                 .iter()
                 .map(|id| {
@@ -134,13 +150,18 @@ impl BundleStorage {
                         .unwrap()
                         .take_transaction_for_scheduling()
                 })
-                .collect();
+                .unzip();
 
-        Some(BundleStorageEntry {
-            container_ids: bundle.container_ids,
-            transactions: bundle_transactions,
-            max_ages: bundle_max_ages,
-        })
+            return Some(BundleStorageEntry {
+                container_ids: bundle.container_ids,
+                transactions: bundle_transactions,
+                max_ages: bundle_max_ages,
+                sanitized_bank_id: bundle.sanitized_bank_id,
+                sanitized_bank_slot: bundle.sanitized_bank_slot,
+            });
+        }
+
+        None
     }
 
     pub fn insert_bundle(
@@ -177,7 +198,7 @@ impl BundleStorage {
             return Err(BundleStorageError::ContainerFull);
         }
 
-        let mut container_ids: Vec<usize> = Vec::with_capacity(batch.len());
+        let mut container_ids = SmallVec::<[usize; 5]>::new();
         let mut maybe_error = Ok(());
         let sanitize_config = sanitize_config(
             working_bank
@@ -236,8 +257,11 @@ impl BundleStorage {
             return Err(BundleStorageError::DuplicateTransaction);
         }
 
-        self.unprocessed_bundles
-            .push_back(BundleTransactionId { container_ids });
+        self.unprocessed_bundles.push_back(BundleTransactionId {
+            container_ids,
+            sanitized_bank_id: working_bank.bank_id(),
+            sanitized_bank_slot: working_bank.slot(),
+        });
 
         Ok(())
     }
@@ -492,16 +516,17 @@ mod tests {
         let mut bundle_storage = BundleStorage::with_capacity(10);
 
         let bank = Bank::new_for_tests(&GenesisConfig::default());
+        let bank_id = bank.bank_id();
         let packet_1 = BytesPacket::from_data(test_tx()).unwrap();
         let packet_2 = BytesPacket::from_data(test_tx()).unwrap();
         let bundle = VerifiedPacketBundle::new(PacketBatch::from(vec![packet_1, packet_2]));
         let result = bundle_storage.insert_bundle(bundle, &bank, &bank, &HashSet::new());
         assert!(result.is_ok());
 
-        let bundle_storage_entry = bundle_storage.pop_bundle(bank.slot()).unwrap();
+        let bundle_storage_entry = bundle_storage.pop_bundle(bank.slot(), bank_id).unwrap();
         bundle_storage.retry_bundle(bundle_storage_entry);
 
-        assert!(bundle_storage.pop_bundle(bank.slot()).is_none());
+        assert!(bundle_storage.pop_bundle(bank.slot(), bank_id).is_none());
         assert!(bundle_storage.unprocessed_bundles.is_empty());
         assert_eq!(bundle_storage.cost_model_buffered_bundles.len(), 1);
         assert_eq!(
@@ -511,7 +536,25 @@ mod tests {
             2
         );
 
-        bundle_storage.pop_bundle(bank.slot() + 1).unwrap();
+        let bundle = bundle_storage.pop_bundle(bank.slot() + 1, bank_id).unwrap();
+        bundle_storage.destroy_bundle(bundle);
+
+        let packet = BytesPacket::from_data(test_tx()).unwrap();
+        bundle_storage
+            .insert_bundle(
+                VerifiedPacketBundle::new(PacketBatch::from(vec![packet])),
+                &bank,
+                &bank,
+                &HashSet::new(),
+            )
+            .unwrap();
+
+        assert!(
+            bundle_storage
+                .pop_bundle(bank.slot(), bank.bank_id() + 1)
+                .is_none()
+        );
+        assert!(bundle_storage.transaction_view_state_container.is_empty());
     }
 
     #[test]
@@ -537,6 +580,7 @@ mod tests {
     fn test_retry_bundle_ordering_preserved() {
         let mut bundle_storage = BundleStorage::with_capacity(100);
         let bank = Bank::new_for_tests(&GenesisConfig::default());
+        let bank_id = bank.bank_id();
 
         let tx_1 = test_tx();
         let tx_2 = test_tx();
@@ -569,12 +613,12 @@ mod tests {
             .insert_bundle(packet_batch_4, &bank, &bank, &HashSet::new())
             .unwrap();
 
-        let bundle_storage_entry_1 = bundle_storage.pop_bundle(bank.slot()).unwrap();
+        let bundle_storage_entry_1 = bundle_storage.pop_bundle(bank.slot(), bank_id).unwrap();
         assert_eq!(
             bundle_storage_entry_1.transactions[0].signatures()[0],
             tx_1.signatures[0]
         );
-        let bundle_storage_entry_2 = bundle_storage.pop_bundle(bank.slot()).unwrap();
+        let bundle_storage_entry_2 = bundle_storage.pop_bundle(bank.slot(), bank_id).unwrap();
         assert_eq!(
             bundle_storage_entry_2.transactions[0].signatures()[0],
             tx_2.signatures[0]
@@ -583,17 +627,17 @@ mod tests {
         bundle_storage.retry_bundle(bundle_storage_entry_1);
         bundle_storage.destroy_bundle(bundle_storage_entry_2);
 
-        let bundle_storage_entry_1 = bundle_storage.pop_bundle(bank.slot() + 1).unwrap();
+        let bundle_storage_entry_1 = bundle_storage.pop_bundle(bank.slot() + 1, bank_id).unwrap();
         assert_eq!(
             bundle_storage_entry_1.transactions[0].signatures()[0],
             tx_1.signatures[0]
         );
-        let bundle_storage_entry_3 = bundle_storage.pop_bundle(bank.slot() + 1).unwrap();
+        let bundle_storage_entry_3 = bundle_storage.pop_bundle(bank.slot() + 1, bank_id).unwrap();
         assert_eq!(
             bundle_storage_entry_3.transactions[0].signatures()[0],
             tx_3.signatures[0]
         );
-        let bundle_storage_entry_4 = bundle_storage.pop_bundle(bank.slot() + 1).unwrap();
+        let bundle_storage_entry_4 = bundle_storage.pop_bundle(bank.slot() + 1, bank_id).unwrap();
         assert_eq!(
             bundle_storage_entry_4.transactions[0].signatures()[0],
             tx_4.signatures[0]
@@ -604,6 +648,7 @@ mod tests {
     fn test_destroy_bundle() {
         let mut bundle_storage = BundleStorage::with_capacity(100);
         let bank = Bank::new_for_tests(&GenesisConfig::default());
+        let bank_id = bank.bank_id();
 
         let tx_1 = test_tx();
         let tx_2 = test_tx();
@@ -622,7 +667,7 @@ mod tests {
             .insert_bundle(packet_batch_2, &bank, &bank, &HashSet::new())
             .unwrap();
 
-        let bundle_storage_entry_1 = bundle_storage.pop_bundle(bank.slot()).unwrap();
+        let bundle_storage_entry_1 = bundle_storage.pop_bundle(bank.slot(), bank_id).unwrap();
         bundle_storage.destroy_bundle(bundle_storage_entry_1);
         assert!(
             bundle_storage
@@ -630,7 +675,7 @@ mod tests {
                 .buffer_size()
                 == 1
         );
-        let bundle_storage_entry_2 = bundle_storage.pop_bundle(bank.slot()).unwrap();
+        let bundle_storage_entry_2 = bundle_storage.pop_bundle(bank.slot(), bank_id).unwrap();
         bundle_storage.destroy_bundle(bundle_storage_entry_2);
         assert!(
             bundle_storage

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -455,7 +455,7 @@ impl Tpu {
             bundle_account_locker.clone(),
             Some(TipProcessingDependencies {
                 tip_manager: tip_manager.clone(),
-                last_tip_updated_slot: Arc::new(Mutex::new(0)),
+                last_tip_updated_bank: Arc::new(Mutex::new(None)),
                 block_builder_fee_info: bam_block_builder_fee_info,
                 cluster_info: cluster_info.clone(),
                 bundle_account_locker: bundle_account_locker.clone(),

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -122,7 +122,8 @@ fn bench_record_transactions(c: &mut Criterion) {
 
                 let start = Instant::now();
                 for txs in tx_batches {
-                    let summary = transaction_recorder.record_transactions(bank.bank_id(), txs);
+                    let summary =
+                        transaction_recorder.record_transactions(bank.bank_id(), txs, true);
                     assert!(summary.result.is_ok());
                 }
                 let elapsed = start.elapsed();

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -108,6 +108,9 @@ pub struct Record {
     pub mixins: Vec<Hash>,
     pub transaction_batches: Vec<Vec<VersionedTransaction>>,
     pub bank_id: BankId,
+    /// Whether transactions from this record may be replayed individually if its bank is
+    /// abandoned during sad leader handover.
+    pub reschedule_on_sad_handover: bool,
 }
 
 impl Record {
@@ -115,11 +118,13 @@ impl Record {
         mixins: Vec<Hash>,
         transaction_batches: Vec<Vec<VersionedTransaction>>,
         bank_id: BankId,
+        reschedule_on_sad_handover: bool,
     ) -> Self {
         Self {
             mixins,
             transaction_batches,
             bank_id,
+            reschedule_on_sad_handover,
         }
     }
 }
@@ -463,6 +468,14 @@ impl PohRecorder {
     }
 
     pub fn set_bank(&mut self, bank: BankWithScheduler) {
+        self.set_bank_with_atomic_batches_enabled(bank, true);
+    }
+
+    pub fn set_bank_with_atomic_batches_enabled(
+        &mut self,
+        bank: BankWithScheduler,
+        atomic_batches_enabled: bool,
+    ) {
         assert!(self.working_bank.is_none());
         let working_bank = WorkingBank {
             min_tick_height: bank.tick_height(),
@@ -490,12 +503,14 @@ impl PohRecorder {
         let leader_first_tick_height = leader_state.leader_first_tick_height();
         let next_leader_slot = leader_state.next_leader_slot_range();
         drop(leader_state);
-        self.shared_leader_state.store(Arc::new(LeaderState::new(
-            Some(working_bank.bank.clone_without_scheduler()),
-            tick_height,
-            leader_first_tick_height,
-            next_leader_slot,
-        )));
+        self.shared_leader_state
+            .store(Arc::new(LeaderState::new_with_atomic_batches_enabled(
+                Some(working_bank.bank.clone_without_scheduler()),
+                tick_height,
+                leader_first_tick_height,
+                next_leader_slot,
+                atomic_batches_enabled,
+            )));
         self.working_bank = Some(working_bank);
 
         // TODO: adjust the working_bank.start time based on number of ticks
@@ -539,12 +554,17 @@ impl PohRecorder {
             // Only update if `set_shared_state` is true.
             // If `false` it is the caller's responsibility to set the shared state.
             if set_shared_state {
-                self.shared_leader_state.store(Arc::new(LeaderState::new(
-                    None,
-                    self.tick_height(),
-                    leader_first_tick_height,
-                    next_leader_slot,
-                )));
+                let atomic_batches_enabled =
+                    self.shared_leader_state.load().atomic_batches_enabled();
+                self.shared_leader_state.store(Arc::new(
+                    LeaderState::new_with_atomic_batches_enabled(
+                        None,
+                        self.tick_height(),
+                        leader_first_tick_height,
+                        next_leader_slot,
+                        atomic_batches_enabled,
+                    ),
+                ));
             }
 
             datapoint_info!(
@@ -1184,6 +1204,7 @@ impl SharedLeaderState {
     ) -> Self {
         let inner = LeaderState {
             working_bank: None,
+            atomic_batches_enabled: AtomicBool::new(true),
             tick_height: AtomicU64::new(tick_height),
             leader_first_tick_height,
             next_leader_slot_range,
@@ -1209,6 +1230,7 @@ impl SharedLeaderState {
 
 pub struct LeaderState {
     working_bank: Option<Arc<Bank>>,
+    atomic_batches_enabled: AtomicBool,
     tick_height: AtomicU64,
     leader_first_tick_height: Option<u64>,
     next_leader_slot_range: Option<(Slot, Slot)>,
@@ -1222,8 +1244,26 @@ impl LeaderState {
         leader_first_tick_height: Option<u64>,
         next_leader_slot_range: Option<(u64, u64)>,
     ) -> Self {
+        Self::new_with_atomic_batches_enabled(
+            working_bank,
+            tick_height,
+            leader_first_tick_height,
+            next_leader_slot_range,
+            true,
+        )
+    }
+
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    fn new_with_atomic_batches_enabled(
+        working_bank: Option<Arc<Bank>>,
+        tick_height: u64,
+        leader_first_tick_height: Option<u64>,
+        next_leader_slot_range: Option<(u64, u64)>,
+        atomic_batches_enabled: bool,
+    ) -> Self {
         Self {
             working_bank,
+            atomic_batches_enabled: AtomicBool::new(atomic_batches_enabled),
             tick_height: AtomicU64::new(tick_height),
             leader_first_tick_height,
             next_leader_slot_range,
@@ -1232,6 +1272,14 @@ impl LeaderState {
 
     pub fn working_bank(&self) -> Option<&Arc<Bank>> {
         self.working_bank.as_ref()
+    }
+
+    pub fn atomic_batches_enabled(&self) -> bool {
+        self.atomic_batches_enabled.load(Ordering::Acquire)
+    }
+
+    pub fn enable_atomic_batches(&self) {
+        self.atomic_batches_enabled.store(true, Ordering::Release);
     }
 
     pub fn tick_height(&self) -> u64 {
@@ -1365,10 +1413,19 @@ mod tests {
             Arc::new(AtomicBool::default()),
         );
 
-        poh_recorder.set_bank_for_test(bank);
+        poh_recorder.set_bank_with_atomic_batches_enabled(
+            BankWithScheduler::new_without_scheduler(bank),
+            false,
+        );
         assert!(poh_recorder.working_bank.is_some());
         poh_recorder.clear_bank(true);
         assert!(poh_recorder.working_bank.is_none());
+        assert!(
+            !poh_recorder
+                .shared_leader_state
+                .load()
+                .atomic_batches_enabled()
+        );
     }
 
     #[test]

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -776,6 +776,7 @@ mod tests {
                 mixins: vec![Hash::new_unique()],
                 transaction_batches: vec![vec![VersionedTransaction::from(test_tx())]],
                 bank_id: bank.bank_id(),
+                reschedule_on_sad_handover: true,
             })
             .unwrap();
 

--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -388,6 +388,7 @@ mod tests {
                 .map(|_| vec![VersionedTransaction::default()])
                 .collect(),
             mixins: (0..num_batches).map(|_| Hash::default()).collect(),
+            reschedule_on_sad_handover: true,
         }
     }
 

--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -49,10 +49,13 @@ impl TransactionRecorder {
 
     /// Hashes `transactions` and sends to PoH service for recording. Waits for response up to 1s.
     /// Panics on unexpected (non-`MaxHeightReached`) errors.
+    /// `reschedule_on_sad_handover` must be false when the transactions have all-or-nothing
+    /// execution semantics that ordinary ingress cannot preserve.
     pub fn record_transactions(
         &self,
         bank_id: BankId,
         transactions: Vec<VersionedTransaction>,
+        reschedule_on_sad_handover: bool,
     ) -> RecordTransactionsSummary {
         let mut record_transactions_timings = RecordTransactionsTimings::default();
         let mut starting_transaction_index = None;
@@ -61,8 +64,12 @@ impl TransactionRecorder {
             let (hash, hash_us) = measure_us!(hash_transactions(&transactions));
             record_transactions_timings.hash_us = Saturating(hash_us);
 
-            let (res, poh_record_us) =
-                measure_us!(self.record(bank_id, vec![hash], vec![transactions]));
+            let (res, poh_record_us) = measure_us!(self.record(
+                bank_id,
+                vec![hash],
+                vec![transactions],
+                reschedule_on_sad_handover,
+            ));
             record_transactions_timings.poh_record_us = Saturating(poh_record_us);
 
             match res {
@@ -106,8 +113,13 @@ impl TransactionRecorder {
         bank_id: BankId,
         mixins: Vec<Hash>,
         transaction_batches: Vec<Vec<VersionedTransaction>>,
+        reschedule_on_sad_handover: bool,
     ) -> Result<Option<usize>, RecordSenderError> {
-        self.record_sender
-            .try_send(Record::new(mixins, transaction_batches, bank_id))
+        self.record_sender.try_send(Record::new(
+            mixins,
+            transaction_batches,
+            bank_id,
+            reschedule_on_sad_handover,
+        ))
     }
 }


### PR DESCRIPTION
#### Problem

During an Alpenglow sad leader handover, transactions recorded against an abandoned optimistic parent are re-injected through ordinary ingress. This loses the all-or-nothing semantics of BAM `revert_on_error` batches and BundleStage bundles. If the replacement parent has different state, only a prefix of an atomic batch can be included.

The initial fix prevented protected records from being flattened and re-injected, but exposed a follow-up gap: BAM could already have received a `Committed` result for an atomic batch executed on the optimistic bank even though a later sad handover discarded that bank and neither transaction landed on the selected fork.

#### Summary of Changes

- Add explicit sad-handover rescheduling metadata to each PoH record.
- Mark ordinary transaction records as independently reschedulable.
- Mark BAM `revert_on_error` records and BundleStage records as protected so they are never flattened into ordinary ingress during sad handover.
- Start optimistic leader banks with atomic-batch scheduling disabled.
- Hold BAM atomic batches without executing or responding while the leader bank is provisional.
- Enable atomic batches only after ParentReady resolves the parent:
  - on the happy path, execute them on the confirmed optimistic bank;
  - on sad handover, recreate the leader bank on the ParentReady parent, then execute them atomically on that selected bank.
- Continue rescheduling eligible ordinary transactions across sad handover.
- Extend handover coverage through the BAM scheduler, real consume worker, PoH recorder, and replacement bank.

BAM now reports the atomic result only after the batch has executed against the ParentReady-selected bank. If the replacement fork invalidates any member, the batch returns `NotCommitted` and no valid prefix is committed.

#### Validation

- The sad-handover regression test verifies that an atomic batch receives no result before ParentReady, is retained across a conflicting ParentReady, executes against the replacement bank, returns `NotCommitted` when a fork-only payer is absent, and leaves the otherwise-valid first transaction uncommitted.
- Both live-validator PoCs—the original partial-commit scenario and the follow-up “reported Committed but neither landed” scenario—were run against head `4c72c9e`. In both cases the atomic batch was delivered, but BAM did not report `Committed` during the full pre-ParentReady assertion window.
