### PR TITLE
Avoid duplicate BAM transaction parsing

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -581,8 +581,9 @@ impl BamReceiveAndBuffer {
         atomic_txn_batch_groups: &[MultipleAtomicTxnBatch],
         current_slot: Slot,
         prevalidated: &mut Vec<PrevalidationResult>,
-    ) -> ReceivingStats {
+    ) -> (ReceivingStats, usize) {
         let mut stats = ReceivingStats::default();
+        let mut packet_count = 0;
 
         prevalidated.clear();
         for atomic_txn_batch_group in atomic_txn_batch_groups {
@@ -648,8 +649,10 @@ impl BamReceiveAndBuffer {
                     continue;
                 };
 
+                let batch_packet_count = atomic_txn_batch.packets.len();
+                packet_count += batch_packet_count;
                 prevalidated.push(Ok((
-                    atomic_txn_batch.packets.len(),
+                    batch_packet_count,
                     revert_on_error,
                     atomic_txn_batch.seq_id,
                     atomic_txn_batch.max_schedule_slot,
@@ -657,7 +660,7 @@ impl BamReceiveAndBuffer {
             }
         }
 
-        stats
+        (stats, packet_count)
     }
 
     fn batch_verify(
@@ -669,13 +672,10 @@ impl BamReceiveAndBuffer {
         packet_data: &mut Vec<Bytes>,
         verification_results: &mut Vec<PacketVerificationResult>,
     ) -> ReceivingStats {
-        let stats = Self::prevalidate_batches(atomic_txn_batches, current_slot, prevalidated);
+        let (stats, packet_count) =
+            Self::prevalidate_batches(atomic_txn_batches, current_slot, prevalidated);
 
         packet_data.clear();
-        let packet_count = prevalidated
-            .iter()
-            .filter_map(|result| result.as_ref().ok().map(|result| result.0))
-            .sum();
         packet_data.reserve(packet_count);
         atomic_txn_batches
             .iter_mut()

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -37,15 +37,12 @@ use {
         DeserializationErrorReason, MultipleAtomicTxnBatch, Packet, SchedulingError,
         TransactionErrorReason, atomic_txn_batch_result, not_committed::Reason,
     },
+    rayon::prelude::*,
     smallvec::SmallVec,
     solana_accounts_db::account_locks::validate_account_locks,
     solana_clock::{MAX_PROCESSING_AGE, Slot},
     solana_measure::{measure::Measure, measure_us},
-    solana_packet::{Meta, PACKET_DATA_SIZE, PacketFlags},
-    solana_perf::{
-        packet::{BytesPacket, BytesPacketBatch},
-        sigverify::ed25519_verify,
-    },
+    solana_perf::sigverify::verify_transaction_view,
     solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
@@ -65,8 +62,8 @@ use {
     tokio::sync::mpsc::Sender as TokioSender,
 };
 
-type PrevalidationResult = Result<(bool, u32, u64), (Reason, u32)>;
-type VerifyResult = Result<(Vec<Bytes>, bool, u32, u64), (Reason, u32)>;
+type PrevalidationResult = Result<(usize, bool, u32, u64), (Reason, u32)>;
+type PacketVerificationResult = Option<(SanitizedTransactionView<Bytes>, bool)>;
 
 pub struct BamReceiveAndBuffer {
     bam_enabled: Arc<AtomicU8>,
@@ -153,8 +150,8 @@ impl BamReceiveAndBuffer {
         let mut metrics = BamReceiveAndBufferMetrics::default();
         let mut stats = ReceivingStats::default();
         let mut prevalidated = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
-        let mut packet_batches = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
-        let mut verify_results = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
+        let mut packet_data = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
+        let mut verification_results = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
         const METRICS_REPORT_INTERVAL: Duration = Duration::from_millis(20);
         let mut recv_buffer = Vec::with_capacity(ATOMIC_TXN_BATCH_BURST);
 
@@ -196,19 +193,44 @@ impl BamReceiveAndBuffer {
                 current_slot,
                 &mut metrics,
                 &mut prevalidated,
-                &mut packet_batches,
-                &mut verify_results,
+                &mut packet_data,
+                &mut verification_results,
             ));
             stats.accumulate(deserialize_stats);
             metrics.increment_total_us(duration_us);
             recv_buffer.clear();
 
-            for result in verify_results.drain(..) {
-                let parsed_batch = match result.and_then(
-                    |(verified_batch, revert_on_error, seq_id, max_schedule_slot)| {
+            let mut verification_result_offset = 0;
+            for prevalidation_result in prevalidated.drain(..) {
+                let result = prevalidation_result.and_then(
+                    |(packet_count, revert_on_error, seq_id, max_schedule_slot)| {
+                        let batch_end = verification_result_offset + packet_count;
+                        let verified_batch =
+                            &mut verification_results[verification_result_offset..batch_end];
+                        verification_result_offset = batch_end;
+
+                        if let Some(index) = verified_batch.iter().position(Option::is_none) {
+                            metrics
+                                .sigverify_metrics
+                                .increment_total_packets_verified(index);
+                            return Err((
+                                Reason::DeserializationError(
+                                    jito_protos::proto::bam_types::DeserializationError {
+                                        index: index as u32,
+                                        reason: DeserializationErrorReason::SanitizeError as i32,
+                                    },
+                                ),
+                                seq_id,
+                            ));
+                        }
+
+                        metrics
+                            .sigverify_metrics
+                            .increment_total_packets_verified(packet_count);
                         metrics
                             .sigverify_metrics
                             .increment_total_batches_verified(1);
+
                         let ((parse_result, parse_stats), duration_us) =
                             measure_us!(Self::parse_batch(
                                 verified_batch,
@@ -223,7 +245,9 @@ impl BamReceiveAndBuffer {
                         metrics.increment_total_us(duration_us);
                         parse_result.map_err(|reason| (reason, seq_id))
                     },
-                ) {
+                );
+
+                let parsed_batch = match result {
                     Ok(batch) => batch,
                     Err((reason, seq_id)) => {
                         let _ = response_sender.try_send(BamOutboundMessage::AtomicTxnBatchResult(
@@ -245,6 +269,8 @@ impl BamReceiveAndBuffer {
                     .saturating_add(parsed_batch.txns_max_age.len());
                 let _ = parsed_batch_sender.try_send(parsed_batch);
             }
+            debug_assert_eq!(verification_result_offset, verification_results.len());
+            verification_results.clear();
         }
     }
 
@@ -283,7 +309,7 @@ impl BamReceiveAndBuffer {
     }
 
     fn parse_batch(
-        verified_batch: Vec<Bytes>,
+        verified_batch: &mut [PacketVerificationResult],
         seq_id: u32,
         revert_on_error: bool,
         max_schedule_slot: u64,
@@ -303,9 +329,6 @@ impl BamReceiveAndBuffer {
         let sanitized_epoch = root_bank.epoch();
         let transaction_account_lock_limit = working_bank.get_transaction_account_lock_limit();
         let vote_only = working_bank.vote_only_bank();
-        let enable_instruction_accounts_limit = root_bank
-            .feature_set
-            .is_active(&agave_feature_set::limit_instruction_accounts::ID);
         let mut txns_max_age = SmallVec::with_capacity(verified_batch.len());
 
         if vote_only {
@@ -322,30 +345,17 @@ impl BamReceiveAndBuffer {
 
         // Checks are taken from receive_and_buffer.rs:
         // SanitizedTransactionReceiveAndBuffer::buffer_packets
-        for (index, verified_packet) in verified_batch.into_iter().enumerate() {
-            // Parsing and basic sanitization checks
+        for (index, verified_packet) in verified_batch.iter_mut().enumerate() {
+            // Load static runtime metadata from the view retained by sigverify.
             let sanitization_start = Instant::now();
-            let Ok(view) = SanitizedTransactionView::try_new_sanitized(
-                verified_packet,
-                &solana_runtime_transaction::sanitize_config::sanitize_config(
-                    enable_instruction_accounts_limit,
-                ),
-            ) else {
-                return (
-                    Err(Reason::DeserializationError(
-                        jito_protos::proto::bam_types::DeserializationError {
-                            index: index as u32,
-                            reason: DeserializationErrorReason::SanitizeError as i32,
-                        },
-                    )),
-                    stats,
-                );
-            };
+            let (view, is_simple_vote_transaction) = verified_packet
+                .take()
+                .expect("signature failures are handled before parsing");
 
             let Ok(view) = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 view,
                 MessageHash::Compute,
-                None,
+                Some(is_simple_vote_transaction),
             ) else {
                 return (
                     Err(Reason::DeserializationError(
@@ -639,6 +649,7 @@ impl BamReceiveAndBuffer {
                 };
 
                 prevalidated.push(Ok((
+                    atomic_txn_batch.packets.len(),
                     revert_on_error,
                     atomic_txn_batch.seq_id,
                     atomic_txn_batch.max_schedule_slot,
@@ -655,60 +666,51 @@ impl BamReceiveAndBuffer {
         current_slot: Slot,
         metrics: &mut BamReceiveAndBufferMetrics,
         prevalidated: &mut Vec<PrevalidationResult>,
-        packet_batches: &mut Vec<solana_perf::packet::PacketBatch>,
-        results: &mut Vec<VerifyResult>,
+        packet_data: &mut Vec<Bytes>,
+        verification_results: &mut Vec<PacketVerificationResult>,
     ) -> ReceivingStats {
         let stats = Self::prevalidate_batches(atomic_txn_batches, current_slot, prevalidated);
 
-        packet_batches.clear();
-        packet_batches.reserve(prevalidated.len());
-        let mut packet_count = 0;
+        packet_data.clear();
+        let packet_count = prevalidated
+            .iter()
+            .filter_map(|result| result.as_ref().ok().map(|result| result.0))
+            .sum();
+        packet_data.reserve(packet_count);
         atomic_txn_batches
             .iter_mut()
             .flat_map(|group| group.batches.iter_mut())
             .zip(prevalidated.iter())
             .filter(|(_, pre_result)| pre_result.is_ok())
             .for_each(|(atomic_txn_batch, _)| {
-                let solana_packet_batch: Vec<_> = atomic_txn_batch
-                    .packets
-                    .drain(..)
-                    .map(|from_packet| {
-                        let Packet { data, meta } = from_packet;
-                        let data_len = data.len();
-                        if data_len > PACKET_DATA_SIZE {
-                            let mut to_packet = BytesPacket::new(Bytes::new(), Meta::default());
-                            to_packet.meta_mut().set_discard(true);
-                            return to_packet;
-                        }
-
-                        let mut to_packet = BytesPacket::new(data, Meta::default());
-                        to_packet.meta_mut().size = data_len;
-
-                        if let Some(meta) = meta
-                            && meta.flags.is_some_and(|flags| flags.simple_vote_tx)
-                        {
-                            to_packet
-                                .meta_mut()
-                                .flags
-                                .insert(PacketFlags::SIMPLE_VOTE_TX);
-                        }
-                        to_packet
-                    })
-                    .collect();
-                packet_count += solana_packet_batch.len();
-                packet_batches.push(solana_perf::packet::PacketBatch::Bytes(
-                    BytesPacketBatch::from(solana_packet_batch),
-                ));
+                packet_data.extend(
+                    atomic_txn_batch
+                        .packets
+                        .drain(..)
+                        .map(|Packet { data, .. }| data),
+                );
             });
 
         let mut verify_packet_batch_time_us = Measure::start("verify_packet_batch_time_us");
-        ed25519_verify(
-            sigverify_thread_pool,
-            packet_batches,
-            false,
-            packet_count,
-            false,
-        );
+        verification_results.reserve(packet_count);
+        let sanitize_config = solana_runtime_transaction::sanitize_config::sanitize_config(true);
+        sigverify_thread_pool.install(|| {
+            packet_data
+                .par_iter_mut()
+                .map(|data| {
+                    let data = core::mem::take(data);
+                    let view =
+                        SanitizedTransactionView::try_new_sanitized(data, &sanitize_config).ok()?;
+                    let (is_simple_vote_transaction, is_valid) =
+                        verify_transaction_view(&view, false, false);
+                    if !is_valid {
+                        return None;
+                    }
+
+                    Some((view, is_simple_vote_transaction))
+                })
+                .collect_into_vec(verification_results);
+        });
         verify_packet_batch_time_us.stop();
 
         metrics
@@ -720,42 +722,6 @@ impl BamReceiveAndBuffer {
         metrics
             .sigverify_metrics
             .increment_total_verify_time(verify_packet_batch_time_us.as_us());
-
-        results.clear();
-        results.reserve(prevalidated.len());
-        let mut packet_batch_iter = packet_batches.drain(..);
-        for pre_result in prevalidated.drain(..) {
-            let result = pre_result.and_then(|(revert_on_error, seq_id, max_schedule_slot)| {
-                let batch = packet_batch_iter.next().unwrap();
-                let solana_perf::packet::PacketBatch::Bytes(batch) = batch else {
-                    unreachable!("BAM sigverify builds Bytes packet batches");
-                };
-
-                let mut deserialized = Vec::with_capacity(batch.len());
-                for (i, pkt) in batch.iter().enumerate() {
-                    if pkt.meta().discard() {
-                        return Err((
-                            Reason::DeserializationError(
-                                jito_protos::proto::bam_types::DeserializationError {
-                                    index: i as u32,
-                                    reason: DeserializationErrorReason::SanitizeError as i32,
-                                },
-                            ),
-                            seq_id,
-                        ));
-                    }
-
-                    metrics
-                        .sigverify_metrics
-                        .increment_total_packets_verified(1);
-
-                    deserialized.push(pkt.buffer().clone());
-                }
-
-                Ok((deserialized, revert_on_error, seq_id, max_schedule_slot))
-            });
-            results.push(result);
-        }
 
         stats
     }
@@ -1144,18 +1110,20 @@ mod tests {
         assert_eq!(actual_length, expected_length);
     }
 
+    type TestVerifyResult = Result<(Vec<PacketVerificationResult>, bool, u32, u64), (Reason, u32)>;
+
     fn run_batch_verify(
         batches: Vec<AtomicTxnBatch>,
         current_slot: Slot,
         metrics: &mut BamReceiveAndBufferMetrics,
-    ) -> (Vec<VerifyResult>, ReceivingStats) {
+    ) -> (Vec<TestVerifyResult>, ReceivingStats) {
         let thread_pool = rayon::ThreadPoolBuilder::new()
             .num_threads(1)
             .build()
             .expect("new rayon threadpool");
         let mut prevalidated = Vec::new();
-        let mut packet_batches = Vec::new();
-        let mut results = Vec::new();
+        let mut packet_data = Vec::new();
+        let mut verification_results = Vec::new();
         let mut batches = vec![MultipleAtomicTxnBatch { batches }];
         let stats = BamReceiveAndBuffer::batch_verify(
             &thread_pool,
@@ -1163,9 +1131,36 @@ mod tests {
             current_slot,
             metrics,
             &mut prevalidated,
-            &mut packet_batches,
-            &mut results,
+            &mut packet_data,
+            &mut verification_results,
         );
+
+        let mut verification_results = verification_results.into_iter();
+        let results = prevalidated
+            .into_iter()
+            .map(|prevalidation_result| {
+                prevalidation_result.and_then(
+                    |(packet_count, revert_on_error, seq_id, max_schedule_slot)| {
+                        let batch_results = verification_results
+                            .by_ref()
+                            .take(packet_count)
+                            .collect::<Vec<_>>();
+                        if let Some(index) = batch_results.iter().position(Option::is_none) {
+                            return Err((
+                                Reason::DeserializationError(
+                                    jito_protos::proto::bam_types::DeserializationError {
+                                        index: index as u32,
+                                        reason: DeserializationErrorReason::SanitizeError as i32,
+                                    },
+                                ),
+                                seq_id,
+                            ));
+                        }
+                        Ok((batch_results, revert_on_error, seq_id, max_schedule_slot))
+                    },
+                )
+            })
+            .collect();
         (results, stats)
     }
 
@@ -1315,7 +1310,7 @@ mod tests {
         let batch = AtomicTxnBatch {
             seq_id: 1,
             packets: vec![Packet {
-                data: vec![0; PACKET_DATA_SIZE + 1].into(),
+                data: vec![0; solana_packet::PACKET_DATA_SIZE + 1].into(),
                 meta: None,
             }],
             max_schedule_slot: Slot::MAX,
@@ -1358,13 +1353,14 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
 
-        if let Ok((deserialized_packets, revert_on_error, seq_id, max_schedule_slot)) = &results[0]
+        if let Ok((mut verified_packets, revert_on_error, seq_id, max_schedule_slot)) =
+            results.into_iter().next().unwrap()
         {
             let (result, stats) = BamReceiveAndBuffer::parse_batch(
-                deserialized_packets.clone(),
-                *seq_id,
-                *revert_on_error,
-                *max_schedule_slot,
+                &mut verified_packets,
+                seq_id,
+                revert_on_error,
+                max_schedule_slot,
                 &bank_forks,
                 &HashSet::new(),
                 &mut stats,
@@ -1415,13 +1411,14 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
 
-        if let Ok((deserialized_packets, revert_on_error, seq_id, max_schedule_slot)) = &results[0]
+        if let Ok((mut verified_packets, revert_on_error, seq_id, max_schedule_slot)) =
+            results.into_iter().next().unwrap()
         {
             let (result, stats) = BamReceiveAndBuffer::parse_batch(
-                deserialized_packets.clone(),
-                *seq_id,
-                *revert_on_error,
-                *max_schedule_slot,
+                &mut verified_packets,
+                seq_id,
+                revert_on_error,
+                max_schedule_slot,
                 &bank_forks,
                 &HashSet::new(),
                 &mut stats,
@@ -1511,13 +1508,14 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
 
-        if let Ok((deserialized_packets, revert_on_error, seq_id, max_schedule_slot)) = &results[0]
+        if let Ok((mut verified_packets, revert_on_error, seq_id, max_schedule_slot)) =
+            results.into_iter().next().unwrap()
         {
             let (result, stats) = BamReceiveAndBuffer::parse_batch(
-                deserialized_packets.clone(),
-                *seq_id,
-                *revert_on_error,
-                *max_schedule_slot,
+                &mut verified_packets,
+                seq_id,
+                revert_on_error,
+                max_schedule_slot,
                 &bank_forks,
                 &blacklisted_accounts,
                 &mut stats,
@@ -1553,19 +1551,11 @@ mod tests {
 
         let vote_data = bincode::serialize(&VersionedTransaction::from(vote_tx)).unwrap();
 
-        let meta = jito_protos::proto::bam_types::Meta {
-            flags: Some(jito_protos::proto::bam_types::PacketFlags {
-                simple_vote_tx: true,
-                ..Default::default()
-            }),
-            size: vote_data.len() as u64,
-        };
-
         let batch = AtomicTxnBatch {
             seq_id: 1,
             packets: vec![Packet {
                 data: vote_data.into(),
-                meta: Some(meta),
+                meta: None,
             }],
             max_schedule_slot: Slot::MAX,
         };
@@ -1576,13 +1566,14 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
 
-        if let Ok((deserialized_packets, revert_on_error, seq_id, max_schedule_slot)) = &results[0]
+        if let Ok((mut verified_packets, revert_on_error, seq_id, max_schedule_slot)) =
+            results.into_iter().next().unwrap()
         {
             let (result, stats) = BamReceiveAndBuffer::parse_batch(
-                deserialized_packets.clone(),
-                *seq_id,
-                *revert_on_error,
-                *max_schedule_slot,
+                &mut verified_packets,
+                seq_id,
+                revert_on_error,
+                max_schedule_slot,
                 &bank_forks,
                 &HashSet::new(),
                 &mut stats,

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -1306,9 +1306,13 @@ mod tests {
         verified_bundle_sender.send(verified_bundle).unwrap();
 
         let start = Instant::now();
+        const PROCESSING_TIMEOUT: Duration = Duration::from_secs(10);
         const MAX_EXPECTED_TXS: usize = 6; // 4 initial for tips + 2 transfers
+        let expected_balance = genesis_config_info.genesis_config.rent.minimum_balance(0);
         let mut tx_count = 0;
-        while start.elapsed() < Duration::from_secs(2) {
+        while (tx_count < MAX_EXPECTED_TXS || bank.get_balance(&kp2.pubkey()) != expected_balance)
+            && start.elapsed() < PROCESSING_TIMEOUT
+        {
             if let Ok((_bank, (EntryOrMarker::Entry(entry), _tick_height))) =
                 entry_receiever.recv_timeout(Duration::from_millis(1))
             {
@@ -1318,15 +1322,9 @@ mod tests {
         }
 
         let balance = bank.get_balance(&kp1.pubkey());
-        assert_eq!(
-            balance,
-            genesis_config_info.genesis_config.rent.minimum_balance(0)
-        );
+        assert_eq!(balance, expected_balance);
         let balance = bank.get_balance(&kp2.pubkey());
-        assert_eq!(
-            balance,
-            genesis_config_info.genesis_config.rent.minimum_balance(0)
-        );
+        assert_eq!(balance, expected_balance);
 
         exit.store(true, Ordering::Relaxed);
         bundle_stage.join().unwrap();

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -14,6 +14,29 @@ use {
 // Empirically derived to constrain max verify latency to ~8ms at lower packet counts
 pub const VERIFY_PACKET_CHUNK_SIZE: usize = 128;
 
+/// Returns `(is_simple_vote_transaction, is_valid)` for a sanitized transaction view.
+#[must_use]
+pub fn verify_transaction_view<D: TransactionData>(
+    view: &SanitizedTransactionView<D>,
+    reject_non_vote: bool,
+    enable_tx_v1: bool,
+) -> (bool, bool) {
+    if !enable_tx_v1 && matches!(view.version(), TransactionVersion::V1) {
+        return (false, false);
+    }
+
+    let is_simple_vote_transaction = is_simple_vote_transaction_view(view);
+    let message = view.message_data();
+    let is_valid = (!reject_non_vote || is_simple_vote_transaction)
+        && view
+            .signatures()
+            .iter()
+            .zip(view.static_account_keys())
+            .all(|(signature, pubkey)| signature.verify(pubkey.as_ref(), message));
+
+    (is_simple_vote_transaction, is_valid)
+}
+
 /// Returns true if the signature on the packet verifies.
 /// Caller must do packet.set_discard(true) if this returns false.
 #[must_use]
@@ -27,40 +50,17 @@ pub fn verify_packet(packet: &mut PacketRefMut, reject_non_vote: bool, enable_tx
         return false;
     };
 
-    let (is_simple_vote_tx, verified) = {
-        let Ok(view) = SanitizedTransactionView::try_new_sanitized(data, &sanitize_config(true))
-        else {
-            return false;
-        };
-
-        if !enable_tx_v1 && matches!(view.version(), TransactionVersion::V1) {
-            return false;
-        }
-
-        let is_simple_vote_tx = is_simple_vote_transaction_view(&view);
-        if reject_non_vote && !is_simple_vote_tx {
-            (is_simple_vote_tx, false)
-        } else {
-            let signatures = view.signatures();
-            if signatures.is_empty() {
-                (is_simple_vote_tx, false)
-            } else {
-                let message = view.message_data();
-                let static_account_keys = view.static_account_keys();
-                let verified = signatures
-                    .iter()
-                    .zip(static_account_keys.iter())
-                    .all(|(signature, pubkey)| signature.verify(pubkey.as_ref(), message));
-                (is_simple_vote_tx, verified)
-            }
-        }
+    let Ok(view) = SanitizedTransactionView::try_new_sanitized(data, &sanitize_config(true)) else {
+        return false;
     };
+    let (is_simple_vote_transaction, is_valid) =
+        verify_transaction_view(&view, reject_non_vote, enable_tx_v1);
 
-    if is_simple_vote_tx {
+    if is_simple_vote_transaction {
         packet.meta_mut().flags |= PacketFlags::SIMPLE_VOTE_TX;
     }
 
-    verified
+    is_valid
 }
 
 pub fn count_packets_in_batches(batches: &[PacketBatch]) -> usize {


### PR DESCRIPTION

## Summary
- The PR removes two heap allocations per prevalidated bundle
-- retain the `SanitizedTransactionView<Bytes>` produced during parallel signature verification
- pass the retained view directly into runtime transaction construction
-- remove per-bundle packet adapters, the second `Vec<Bytes>`, byte-buffer clones, and the duplicate parse/sanitize pass
- reuse flat buffers while preserving bundle order and error indices

## Data flow

| Stage | Before | After |
| --- | --- | --- |
| Input | Protobuf `Bytes` | Protobuf `Bytes` |
| Buffering | Allocate `Vec<BytesPacket>` per bundle | Move into one reusable flat `Vec<Bytes>` |
| Verification | In parallel across packets, parse, sanitize, and verify signatures; discard the sanitized view | In parallel across packets, parse, sanitize, and verify signatures; retain the sanitized view |
| Handoff | Allocate `Vec<Bytes>` and clone each `Bytes` handle | Retain `SanitizedTransactionView<Bytes>` |
| Runtime construction | Parse and sanitize again in `parse_batch`, then build `RuntimeTransaction` | Build `RuntimeTransaction` directly from the retained view |

## Impact

This is allocation and architecture cleanup, not a measurable ingest-throughput optimization. It reduces allocation and reference-count churn while preserving transaction-version policy, vote classification, validation ordering, and metrics behavior.