### PR TITLE
v4.3: Relax nonce size check for simulation (backport of #1557)

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3861,7 +3861,7 @@ impl Bank {
                 },
                 drop_on_failure: false,
                 all_or_nothing: false,
-                strict_nonce_size_check: true,
+                strict_nonce_size_check: false,
                 drop_noop_transactions: true,
             },
         );

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12011,6 +12011,45 @@ fn test_failed_simulation_load_error() {
 }
 
 #[test]
+fn test_simulate_transaction_unchecked_allows_oversized_nonce_account() {
+    let (bank, _mint_keypair, custodian_keypair, nonce_keypair, _bank_forks) =
+        setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000, None).unwrap();
+    let nonce_pubkey = nonce_keypair.pubkey();
+    let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
+
+    let nonce_account = bank.get_account(&nonce_pubkey).unwrap();
+    let mut resized_nonce_account = AccountSharedData::new(
+        nonce_account.lamports(),
+        nonce::state::State::size() + 1,
+        nonce_account.owner(),
+    );
+    resized_nonce_account.data_as_mut_slice()[..nonce_account.data().len()]
+        .copy_from_slice(nonce_account.data());
+    bank.store_account(&nonce_pubkey, &resized_nonce_account);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
+            system_instruction::transfer(
+                &custodian_keypair.pubkey(),
+                &Pubkey::new_unique(),
+                100_000,
+            ),
+        ],
+        Some(&custodian_keypair.pubkey()),
+        &[&custodian_keypair, &nonce_keypair],
+        nonce_hash,
+    );
+    let sanitized = RuntimeTransaction::from_transaction_for_tests(transaction);
+
+    assert_eq!(
+        bank.simulate_transaction_unchecked(&sanitized, false)
+            .result,
+        Ok(())
+    );
+}
+
+#[test]
 fn test_filter_program_errors_and_collect_fee_details() {
     // TX  | PROCESSING RESULT           | COLLECT            | COLLECT
     //     |                             | (TX_FEE, PRIO_FEE) | RESULT


### PR DESCRIPTION
Origin: [Jito #1557](https://github.com/jito-foundation/jito-solana/pull/1557)

## Issue

[MEV-12350](https://linear.app/jito/issue/MEV-12350/simulate-transaction-unchecked-set-strict-nonce-check-to-true-in-jito) tracks restoring Jito v4.2's permissive simulation behavior on v4.3. With the strict check enabled, noncanonical-sized nonce accounts fail simulation with `BlockhashNotFound`.

## Fix

Backport #1557 by setting `strict_nonce_size_check` to `false` in `simulate_transaction_unchecked` and adding the same regression coverage.