### PR TITLE
Prevent stale tip-crank configuration across BAM/Block Engine transitions

### DIFF
--- a/core/src/bam_manager.rs
+++ b/core/src/bam_manager.rs
@@ -251,7 +251,18 @@ impl BamManager {
             ) && let Some(builder_config) =
                 connection.get_latest_config_if_changed(&mut builder_config_version)
             {
-                Self::apply_builder_config(&builder_config, &dependencies);
+                if !Self::apply_builder_config(&builder_config, &dependencies)
+                    && bam_state == BamConnectionState::BlockEngineDrained
+                {
+                    error!(
+                        "BAM initial builder config could not publish a fee snapshot; falling \
+                         back to Block Engine"
+                    );
+                    Self::set_bam_disconnected(&dependencies);
+                    outbound_receiver = Some(runtime.block_on(connection.shutdown()));
+                    std::thread::sleep(WAIT_TO_RECONNECT_DURATION);
+                    continue;
+                }
                 if bam_state == BamConnectionState::BlockEngineDrained {
                     dependencies
                         .bam_enabled
@@ -342,11 +353,15 @@ impl BamManager {
         )))
     }
 
-    fn apply_builder_config(config: &ConfigResponse, dependencies: &BamDependencies) {
+    fn apply_builder_config(config: &ConfigResponse, dependencies: &BamDependencies) -> bool {
         Self::update_tpu_config(config, dependencies);
         Self::update_shred_socks_config(config, dependencies);
-        Self::update_block_engine_key_and_commission(config, &dependencies.block_builder_fee_info);
+        let block_builder_updated = Self::update_block_engine_key_and_commission(
+            config,
+            &dependencies.block_builder_fee_info,
+        );
         Self::update_bam_recipient_and_commission(config, &dependencies.bam_node_pubkey);
+        block_builder_updated
     }
 
     fn update_tpu_config(config: &ConfigResponse, dependencies: &BamDependencies) {
@@ -367,6 +382,13 @@ impl BamManager {
     }
 
     fn set_bam_disconnected(dependencies: &BamDependencies) {
+        // Require Block Engine to publish a fresh snapshot after any cutover or BAM session.
+        // Failed connection attempts leave the current Block Engine snapshot intact.
+        if dependencies.bam_enabled.load(Ordering::Acquire) > BamConnectionState::Connecting as u8 {
+            dependencies
+                .block_builder_fee_info
+                .store(Arc::new(BlockBuilderFeeInfo::default()));
+        }
         dependencies
             .bam_enabled
             .store(BamConnectionState::Disconnected as u8, Ordering::Release);
@@ -420,34 +442,36 @@ impl BamManager {
     fn update_block_engine_key_and_commission(
         config: &ConfigResponse,
         block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
-    ) {
+    ) -> bool {
         let Some(builder_info) = config.block_engine_config.as_ref() else {
-            return;
+            return false;
         };
         if builder_info.builder_commission > 100 {
             error!("Block builder commission must be <= 100");
-            return;
+            return false;
         }
 
-        let pubkey = Pubkey::from_str(&builder_info.builder_pubkey).unwrap_or_else(|e| {
+        let Some(pubkey) = Pubkey::from_str(&builder_info.builder_pubkey)
+            .ok()
+            .filter(|pubkey| *pubkey != Pubkey::default())
+        else {
             error!(
-                "Failed to parse builder pubkey {}. Error: {e}",
+                "Invalid block builder pubkey: {}",
                 builder_info.builder_pubkey
             );
             datapoint_warn!(
                 "bam_manager-pubkey_error",
                 ("count", 1, i64),
                 ("pubkey", builder_info.builder_pubkey, String),
-                ("error", e.to_string(), String),
             );
-            <arc_swap::ArcSwapAny<Arc<BlockBuilderFeeInfo>>>::load(block_builder_fee_info)
-                .block_builder
-        });
+            return false;
+        };
 
         block_builder_fee_info.store(Arc::new(BlockBuilderFeeInfo {
             block_builder: pubkey,
             block_builder_commission: builder_info.builder_commission as u64,
         }));
+        true
     }
 
     fn update_bam_recipient_and_commission(

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -8,7 +8,10 @@ use {
             TransactionResult,
         },
     },
-    crate::banking_stage::consumer::{ExecutionFlags, RetryableIndex, TipProcessingDependencies},
+    crate::{
+        bam_dependencies::BamConnectionState,
+        banking_stage::consumer::{ExecutionFlags, RetryableIndex, TipProcessingDependencies},
+    },
     crossbeam_channel::{Receiver, SendError, Sender, TryRecvError},
     jito_protos::proto::bam_types::TransactionCommittedResult,
     solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
@@ -218,6 +221,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             tip_manager,
             last_tip_updated_bank,
             block_builder_fee_info,
+            bam_enabled,
             cluster_info,
             bundle_account_locker,
         }) = &self.tip_processing_dependencies
@@ -232,6 +236,10 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             .flat_map(|tx| tx.account_keys().iter())
             .any(|key| tip_accounts.contains(key))
         {
+            return true;
+        }
+
+        if bam_enabled.load(Ordering::Acquire) != BamConnectionState::Connected as u8 {
             return true;
         }
 
@@ -3237,7 +3245,10 @@ mod tests {
         solana_transaction_error::TransactionError,
         std::{
             collections::HashSet,
-            sync::{Mutex, RwLock, atomic::AtomicBool},
+            sync::{
+                Mutex, RwLock,
+                atomic::{AtomicBool, AtomicU8},
+            },
         },
     };
 
@@ -3332,6 +3343,7 @@ mod tests {
                     block_builder: mint_keypair.pubkey(),
                     block_builder_commission: 0,
                 })),
+                bam_enabled: Arc::new(AtomicU8::new(BamConnectionState::Connected as u8)),
                 cluster_info,
                 bundle_account_locker: BundleAccountLocker::default(),
             }),
@@ -3879,7 +3891,6 @@ mod tests {
         );
 
         let runtime_tx = RuntimeTransaction::from_transaction_for_tests(tx);
-
         consume_sender
             .send(ConsumeWork {
                 batch_id: TransactionBatchId::new(1),

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -36,7 +36,7 @@ use {
     solana_vote::vote_parser,
     std::{
         num::Saturating,
-        sync::{Arc, Mutex},
+        sync::{Arc, Mutex, atomic::AtomicU8},
     },
 };
 
@@ -118,6 +118,7 @@ pub struct TipProcessingDependencies {
     pub tip_manager: TipManager,
     pub last_tip_updated_bank: Arc<Mutex<Option<(Slot, BankId)>>>,
     pub block_builder_fee_info: Arc<ArcSwap<BlockBuilderFeeInfo>>,
+    pub bam_enabled: Arc<AtomicU8>,
     pub cluster_info: Arc<ClusterInfo>,
     pub bundle_account_locker: BundleAccountLocker,
 }

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -830,7 +830,7 @@ impl BundleStage {
     ) -> BundleExecutionResult<()> {
         let block_builder_fee_info = block_builder_fee_info.load();
         if block_builder_fee_info.block_builder == Pubkey::default() {
-            return Err(BundleExecutionError::TipError);
+            return Err(BundleExecutionError::ErrorRetryable);
         }
         let crank_tip_program_transactions = tip_manager
             .get_tip_programs_crank_bundle(bank, keypair, &block_builder_fee_info)
@@ -1101,6 +1101,28 @@ mod tests {
         );
 
         (init_executed_ok, config_account_exists, crank)
+    }
+
+    #[test]
+    fn test_missing_block_builder_fee_info_is_retryable() {
+        let bank = Arc::new(Bank::new_for_tests(&GenesisConfig::default()));
+        let (record_sender, _record_receiver) = solana_poh::record_channels::record_channels(false);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(None, replay_vote_sender, None);
+        let mut consumer =
+            BundleConsumer::new(committer, TransactionRecorder::new(record_sender), None);
+
+        let result = BundleStage::handle_crank_tip_programs(
+            &bank,
+            &BundleAccountLocker::default(),
+            &mut consumer,
+            &TipManager::new(TipManagerConfig::default()),
+            &Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo::default())),
+            &ConsumeWorkerMetrics::new(10_000),
+            &Keypair::new(),
+        );
+
+        assert_matches!(result, Err(BundleExecutionError::ErrorRetryable));
     }
 
     #[test]

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -829,6 +829,9 @@ impl BundleStage {
         keypair: &Keypair,
     ) -> BundleExecutionResult<()> {
         let block_builder_fee_info = block_builder_fee_info.load();
+        if block_builder_fee_info.block_builder == Pubkey::default() {
+            return Err(BundleExecutionError::TipError);
+        }
         let crank_tip_program_transactions = tip_manager
             .get_tip_programs_crank_bundle(bank, keypair, &block_builder_fee_info)
             .map_err(|e| {

--- a/core/src/proxy/block_engine_stage.rs
+++ b/core/src/proxy/block_engine_stage.rs
@@ -1075,21 +1075,51 @@ impl BlockEngineStage {
             )
         })?
         .into_inner();
-        let block_builder_pubkey =
-            Pubkey::from_str(&block_builder_info.pubkey).unwrap_or_else(|_| {
-                datapoint_warn!(
-                    "block_engine_stage-block_builder_pubkey_parse_error",
-                    ("url", block_engine_url, String),
-                    ("pubkey", &block_builder_info.pubkey, String),
-                    ("count", 1, i64),
-                );
-                block_builder_fee_info.load().block_builder
-            });
-        block_builder_fee_info.store(Arc::new(BlockBuilderFeeInfo {
-            block_builder: block_builder_pubkey,
+        if block_builder_info.commission > 100 {
+            return Err(ProxyError::BlockEngineEndpointError(
+                "block builder commission must be <= 100".to_string(),
+            ));
+        }
+        let Ok(block_builder) = Pubkey::from_str(&block_builder_info.pubkey) else {
+            datapoint_warn!(
+                "block_engine_stage-block_builder_pubkey_parse_error",
+                ("url", block_engine_url, String),
+                ("pubkey", &block_builder_info.pubkey, String),
+                ("count", 1, i64),
+            );
+            return Err(ProxyError::BlockEngineEndpointError(
+                "invalid block builder pubkey".to_string(),
+            ));
+        };
+        if block_builder == Pubkey::default() {
+            return Err(ProxyError::BlockEngineEndpointError(
+                "missing block builder config".to_string(),
+            ));
+        }
+        let current = block_builder_fee_info.load();
+        if bam_enabled.load(Ordering::Acquire) > BamConnectionState::Connecting as u8 {
+            return Err(ProxyError::BamEnabled);
+        }
+        let new_fee_info = Arc::new(BlockBuilderFeeInfo {
+            block_builder,
             block_builder_commission: block_builder_info.commission,
-        }));
+        });
+        if !Self::try_publish_block_builder_fee_info(block_builder_fee_info, &current, new_fee_info)
+        {
+            return Err(ProxyError::BamEnabled);
+        }
         Ok(())
+    }
+
+    fn try_publish_block_builder_fee_info(
+        block_builder_fee_info: &ArcSwap<BlockBuilderFeeInfo>,
+        current: &Arc<BlockBuilderFeeInfo>,
+        new: Arc<BlockBuilderFeeInfo>,
+    ) -> bool {
+        Arc::ptr_eq(
+            &block_builder_fee_info.compare_and_swap(current, new),
+            current,
+        )
     }
 }
 
@@ -1153,5 +1183,20 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn stale_block_engine_fee_info_does_not_overwrite_bam() {
+        let fee_info = ArcSwap::from_pointee(BlockBuilderFeeInfo::default());
+        let stale = fee_info.load();
+        let bam = Arc::new(BlockBuilderFeeInfo::default());
+        fee_info.store(bam.clone());
+
+        assert!(!BlockEngineStage::try_publish_block_builder_fee_info(
+            &fee_info,
+            &stale,
+            Arc::new(BlockBuilderFeeInfo::default()),
+        ));
+        assert!(Arc::ptr_eq(&fee_info.load(), &bam));
     }
 }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -60,7 +60,6 @@ use {
         transaction_execution::TransactionStatusSender,
         vote_sender_types::{ReplayVoteReceiver, ReplayVoteSender},
     },
-    solana_signer::Signer,
     solana_streamer::{
         evicting_sender::EvictingSender,
         quic::{
@@ -344,10 +343,9 @@ impl Tpu {
                 .expect("new rayon threadpool"),
         );
 
-        let block_builder_fee_info = Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
-            block_builder: cluster_info.keypair().pubkey(),
-            block_builder_commission: 0,
-        }));
+        // Shared config; the default pubkey disables cranking until Block Engine or BAM publishes.
+        let block_builder_fee_info =
+            Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo::default()));
 
         let (unverified_bundle_sender, unverified_bundle_receiver) = bounded(1024);
         let bam_enabled = Arc::new(AtomicU8::new(BamConnectionState::Disconnected as u8));
@@ -417,15 +415,13 @@ impl Tpu {
         };
         let (bam_batch_sender, bam_batch_receiver) = bounded(100_000);
         let (bam_outbound_sender, bam_outbound_receiver) = mpsc::channel(100_000);
-        let bam_block_builder_fee_info =
-            Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo::default()));
         let bam_dependencies = BamDependencies {
             bam_enabled: bam_enabled.clone(),
             batch_sender: bam_batch_sender,
             batch_receiver: bam_batch_receiver,
             outbound_sender: bam_outbound_sender,
             cluster_info: cluster_info.clone(),
-            block_builder_fee_info: bam_block_builder_fee_info.clone(),
+            block_builder_fee_info: block_builder_fee_info.clone(),
             bam_node_pubkey: Arc::new(ArcSwap::from_pointee(Pubkey::default())),
             bank_forks: bank_forks.clone(),
             bam_tpu_info,
@@ -456,7 +452,8 @@ impl Tpu {
             Some(TipProcessingDependencies {
                 tip_manager: tip_manager.clone(),
                 last_tip_updated_bank: Arc::new(Mutex::new(None)),
-                block_builder_fee_info: bam_block_builder_fee_info,
+                block_builder_fee_info: block_builder_fee_info.clone(),
+                bam_enabled: bam_enabled.clone(),
                 cluster_info: cluster_info.clone(),
                 bundle_account_locker: bundle_account_locker.clone(),
             }),

--- a/core/tests/bam_connection.rs
+++ b/core/tests/bam_connection.rs
@@ -61,7 +61,7 @@ struct MockConfig {
 impl Default for MockConfig {
     fn default() -> Self {
         Self {
-            builder_pubkey: "11111111111111111111111111111111".to_string(),
+            builder_pubkey: solana_pubkey::Pubkey::new_unique().to_string(),
             builder_commission: 10,
             prio_fee_recipient: "22222222222222222222222222222222".to_string(),
             commission_bps: 100,


### PR DESCRIPTION
#### Problem

BundleStage and BankingStage used separate block-builder fee snapshots with different update paths. After BAM connected, BundleStage could retain a stale Block Engine snapshot while BankingStage used BAM's current snapshot. Their independent per-slot guards allowed both stages to submit conflicting block-builder cranks in the same leader slot.

This was a reachable correctness issue that could temporarily publish a stale builder and commission, creating potential tip attribution and accounting impact. The investigation identified the code path that allowed the issue; it did not establish a confirmed production occurrence.

#### Summary of Changes

- Share one initially-empty `ArcSwapOption<BlockBuilderFeeInfo>`
- Validate the complete pubkey/commission pair before publishing.
- Add regressions for source ownership, replaced BAM snapshots, and stale fallback state.
