### PR TITLE
v4.3: Skip tip maintenance when programs are unavailable

### DIFF
--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -23,6 +23,7 @@ use {
     arc_swap::ArcSwap,
     crossbeam_channel::{Receiver, RecvTimeoutError},
     smallvec::SmallVec,
+    solana_account::ReadableAccount,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
@@ -594,6 +595,11 @@ impl BundleStage {
         let mut bundles = VecDeque::with_capacity(BUNDLE_WINDOW_SIZE.get());
 
         if bank.slot() != *last_tip_update_slot {
+            if !Self::tip_programs_available(bank, tip_manager) {
+                bundle_stage_metrics.increment_tip_programs_error(1);
+                return;
+            }
+
             if Self::handle_tip_programs(
                 bank,
                 bundle_account_locker,
@@ -687,6 +693,18 @@ impl BundleStage {
                 .is_empty(),
             "bundle account write locks should be empty"
         );
+    }
+
+    fn tip_programs_available(bank: &Bank, tip_manager: &TipManager) -> bool {
+        [
+            tip_manager.tip_payment_program_id(),
+            tip_manager.tip_distribution_program_id(),
+        ]
+        .into_iter()
+        .all(|program_id| {
+            bank.get_account(&program_id)
+                .is_some_and(|account| account.executable())
+        })
     }
 
     fn handle_tip_programs(
@@ -1023,6 +1041,10 @@ mod tests {
             ContactInfo::new_localhost(&leader_keypair.pubkey(), timestamp()),
             Arc::new(leader_keypair.insecure_clone()),
             SocketAddrSpace::Unspecified,
+        ));
+        assert!(!BundleStage::tip_programs_available(
+            &bank,
+            &TipManager::new(TipManagerConfig::default())
         ));
 
         let (verified_bundle_sender, verified_bundle_receiver) = bounded(1024);


### PR DESCRIPTION
## Issue

The post-merge `v4.3` Buildkite run [#5283](https://buildkite.com/jito/jito-solana/builds/5283) failed in `local-cluster-2`. Its log contained 43,042 repetitions of:

```text
[2026-08-14T21:47:16.654381524Z ERROR solana_core::bundle_stage] tip programs error, not processing bundles
```

The shard eventually exhausted all retries for the duplicate-shred test:

```text
TRY 4 TMT [120.114s] (2/6) solana-local-cluster::local_cluster test_duplicate_shreds_broadcast_leader
Summary [661.163s] 2/6 tests run: 1 passed (1 slow, 1 flaky), 1 timed out, 52 skipped
```

Local-cluster validators use generated tip-program IDs without corresponding executable program accounts. While the validator is leader, BundleStage attempts tip-program initialization on every 10 ms polling interval. Each failure leaves `last_tip_update_slot` unchanged, so the same doomed maintenance work is immediately retried. Besides obscuring the actual failure, this repeatedly constructs and executes transactions, acquires locks, and writes error logs during timing-sensitive cluster tests.

## Change

- When per-slot maintenance is due, check that both configured tip-program accounts exist and are executable.
- When either program is unavailable, record the existing metric and return before constructing transactions.
- Keep bundle processing fail-closed while the prerequisite programs are unavailable.
- Preserve existing initialization, crank, and retry behavior when both programs are deployed.
- Extend the existing initialization test to cover an unavailable configuration.

After successful upkeep, the availability check is skipped for the rest of that slot. If a program is unavailable, it is checked on every BundleStage poll so a later deployment is detected without waiting for a slot change.

## Impact

Valid production configurations retain their existing behavior, with two account lookups only when per-slot maintenance is due. Local clusters without tip programs no longer execute permanently failing background transactions or emit the high-frequency BundleStage error.

## Verification

- `cargo fmt --package solana-core -- --check`
- `cargo test -p solana-core --lib bundle_stage::tests::test_tip_programs_initialized_with_no_bundles -- --nocapture` — passed
- CI-profile `test_duplicate_shreds_broadcast_leader` — passed without retries in 77.39s
- BundleStage tip-program error lines in the captured test output — 0
