### PR TITLE
Share Jito validator CLI arguments

### DIFF
--- a/validator/src/commands/block_engine/mod.rs
+++ b/validator/src/commands/block_engine/mod.rs
@@ -1,42 +1,19 @@
 use {
-    crate::{admin_rpc_service, cli::DefaultArgs, commands::Result},
-    clap::{App, Arg, ArgMatches, SubCommand, value_t_or_exit},
+    crate::{
+        admin_rpc_service,
+        cli::DefaultArgs,
+        commands::{Result, jito_args},
+    },
+    clap::{App, ArgMatches, SubCommand, value_t_or_exit},
     std::path::Path,
 };
 
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
     SubCommand::with_name("set-block-engine-config")
         .about("Set configuration for connection to a block engine")
-        .arg(
-            Arg::with_name("block_engine_url")
-                .long("block-engine-url")
-                .help(
-                    "URL entrypoint to the Block Engine. Connected Block Engine will be \
-                     autoconfigured unless `--disable-block-engine-autoconfig` is used. Set to \
-                     empty string to disable block engine connection.",
-                )
-                .takes_value(true)
-                .required(true),
-        )
-        .arg(
-            Arg::with_name("disable_block_engine_autoconfig")
-                .long("disable-block-engine-autoconfig")
-                .takes_value(false)
-                .help(
-                    "Disables Block Engine auto-configuration. This stops the validator client \
-                     from using the most performant Block Engine region. Values provided to \
-                     `--block-engine-url` will be used as-is.",
-                ),
-        )
-        .arg(
-            Arg::with_name("trust_block_engine_packets")
-                .long("trust-block-engine-packets")
-                .takes_value(false)
-                .help(
-                    "Skip signature verification on block engine packets. Not recommended unless \
-                     the block engine is trusted.",
-                ),
-        )
+        .arg(jito_args::block_engine_url().required(true))
+        .arg(jito_args::disable_block_engine_autoconfig())
+        .arg(jito_args::trust_block_engine_packets())
 }
 
 pub fn execute(subcommand_matches: &ArgMatches, ledger_path: &Path) -> Result<()> {

--- a/validator/src/commands/jito_args.rs
+++ b/validator/src/commands/jito_args.rs
@@ -1,0 +1,93 @@
+use clap::Arg;
+
+pub fn block_engine_url<'a>() -> Arg<'a, 'a> {
+    Arg::with_name("block_engine_url")
+        .long("block-engine-url")
+        .help(
+            "URL entrypoint to the Block Engine. Connected Block Engine will be autoconfigured \
+             unless `--disable-block-engine-autoconfig` is used. Set to empty string to disable \
+             block engine connection.",
+        )
+        .takes_value(true)
+}
+
+pub fn disable_block_engine_autoconfig<'a>() -> Arg<'a, 'a> {
+    Arg::with_name("disable_block_engine_autoconfig")
+        .long("disable-block-engine-autoconfig")
+        .takes_value(false)
+        .help(
+            "Disables Block Engine auto-configuration. This stops the validator client from using \
+             the most performant Block Engine region. Values provided to `--block-engine-url` \
+             will be used as-is.",
+        )
+}
+
+pub fn trust_block_engine_packets<'a>() -> Arg<'a, 'a> {
+    Arg::with_name("trust_block_engine_packets")
+        .long("trust-block-engine-packets")
+        .takes_value(false)
+        .help(
+            "Skip signature verification on block engine packets. Not recommended unless the \
+             block engine is trusted.",
+        )
+}
+
+pub fn relayer_url<'a>() -> Arg<'a, 'a> {
+    Arg::with_name("relayer_url")
+        .long("relayer-url")
+        .help("Relayer url. Set to empty string to disable relayer connection.")
+        .takes_value(true)
+}
+
+pub fn relayer_expected_heartbeat_interval_ms<'a>(default_value: &'a str) -> Arg<'a, 'a> {
+    Arg::with_name("relayer_expected_heartbeat_interval_ms")
+        .long("relayer-expected-heartbeat-interval-ms")
+        .takes_value(true)
+        .help("Interval at which the Relayer is expected to send heartbeat messages.")
+        .default_value(default_value)
+}
+
+pub fn relayer_max_failed_heartbeats<'a>(default_value: &'a str) -> Arg<'a, 'a> {
+    Arg::with_name("relayer_max_failed_heartbeats")
+        .long("relayer-max-failed-heartbeats")
+        .takes_value(true)
+        .help(
+            "Maximum number of heartbeats the Relayer can miss before falling back to the normal \
+             TPU pipeline.",
+        )
+        .default_value(default_value)
+}
+
+pub fn shred_receiver_address<'a>() -> Arg<'a, 'a> {
+    Arg::with_name("shred_receiver_address")
+        .long("shred-receiver-address")
+        .value_name("SHRED_RECEIVER_ADDRESS")
+        .takes_value(true)
+        .multiple(true)
+        .number_of_values(1)
+        .help(
+            "Validator will mirror this validator's own broadcast shreds to these addresses in \
+             addition to normal turbine operation. This covers the direct leader path and \
+             replay-triggered rebroadcasts of this validator's slots. Pass this option multiple \
+             times or use comma-separated ip:port or host:port entries. Hostnames resolve to IPv4 \
+             addresses only. Up to 32 unique addresses are allowed. Set to empty string to \
+             configure an empty explicit receiver list.",
+        )
+}
+
+pub fn shred_retransmit_receiver_address<'a>() -> Arg<'a, 'a> {
+    Arg::with_name("shred_retransmit_receiver_address")
+        .long("shred-retransmit-receiver-address")
+        .value_name("SHRED_RETRANSMIT_RECEIVER_ADDRESS")
+        .takes_value(true)
+        .multiple(true)
+        .number_of_values(1)
+        .help(
+            "Validator will mirror TVU retransmit-stage shreds to these addresses in addition to \
+             normal turbine operation. This applies only to shreds that enter retransmit; it does \
+             not mirror this validator's own leader broadcast path. Pass this option multiple \
+             times or use comma-separated ip:port or host:port entries. Hostnames resolve to IPv4 \
+             addresses only. Up to 32 unique addresses are allowed. Set to empty string to \
+             disable.",
+        )
+}

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod block_engine;
 pub mod blockstore;
 pub mod contact_info;
 pub mod exit;
+pub mod jito_args;
 pub mod manage_block_production;
 pub mod monitor;
 pub mod plugin;

--- a/validator/src/commands/relayer/mod.rs
+++ b/validator/src/commands/relayer/mod.rs
@@ -1,6 +1,10 @@
 use {
-    crate::{admin_rpc_service, cli::DefaultArgs, commands::Result},
-    clap::{App, Arg, ArgMatches, SubCommand, value_t_or_exit},
+    crate::{
+        admin_rpc_service,
+        cli::DefaultArgs,
+        commands::{Result, jito_args},
+    },
+    clap::{App, ArgMatches, SubCommand, value_t_or_exit},
     solana_clap_utils::input_parsers::value_of,
     std::path::Path,
 };
@@ -8,30 +12,13 @@ use {
 pub fn command(default_args: &DefaultArgs) -> App<'_, '_> {
     SubCommand::with_name("set-relayer-config")
         .about("Set configuration for connection to a relayer")
-        .arg(
-            Arg::with_name("relayer_url")
-                .long("relayer-url")
-                .help("Relayer url. Set to empty string to disable relayer connection.")
-                .takes_value(true)
-                .required(true),
-        )
-        .arg(
-            Arg::with_name("relayer_expected_heartbeat_interval_ms")
-                .long("relayer-expected-heartbeat-interval-ms")
-                .takes_value(true)
-                .help("Interval at which the Relayer is expected to send heartbeat messages.")
-                .default_value(&default_args.relayer_expected_heartbeat_interval_ms),
-        )
-        .arg(
-            Arg::with_name("relayer_max_failed_heartbeats")
-                .long("relayer-max-failed-heartbeats")
-                .takes_value(true)
-                .help(
-                    "Maximum number of heartbeats the Relayer can miss before falling back to the \
-                     normal TPU pipeline.",
-                )
-                .default_value(&default_args.relayer_max_failed_heartbeats),
-        )
+        .arg(jito_args::relayer_url().required(true))
+        .arg(jito_args::relayer_expected_heartbeat_interval_ms(
+            &default_args.relayer_expected_heartbeat_interval_ms,
+        ))
+        .arg(jito_args::relayer_max_failed_heartbeats(
+            &default_args.relayer_max_failed_heartbeats,
+        ))
 }
 
 pub fn execute(subcommand_matches: &ArgMatches, ledger_path: &Path) -> Result<()> {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         bootstrap::RpcBootstrapConfig,
         cli::{DefaultArgs, hash_validator, port_range_validator, port_validator},
-        commands::{FromClapArgMatches, Result, bam},
+        commands::{FromClapArgMatches, Result, bam, jito_args},
     },
     agave_snapshots::{SUPPORTED_ARCHIVE_COMPRESSION, SnapshotVersion},
     bytesize::ByteSize,
@@ -1209,48 +1209,15 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help(DefaultSchedulerPool::cli_message()),
     )
     .arg(bam::argument())
-    .arg(
-        Arg::with_name("block_engine_url")
-            .long("block-engine-url")
-            .help(
-                "URL entrypoint to the Block Engine. Connected Block Engine will be \
-                 autoconfigured unless `--disable-block-engine-autoconfig` is used. Set to empty \
-                 string to disable block engine connection.",
-            )
-            .takes_value(true),
-    )
-    .arg(
-        Arg::with_name("relayer_url")
-            .long("relayer-url")
-            .help("Relayer url. Set to empty string to disable relayer connection.")
-            .takes_value(true),
-    )
-    .arg(
-        Arg::with_name("relayer_expected_heartbeat_interval_ms")
-            .long("relayer-expected-heartbeat-interval-ms")
-            .takes_value(true)
-            .help("Interval at which the Relayer is expected to send heartbeat messages.")
-            .default_value(&default_args.relayer_expected_heartbeat_interval_ms),
-    )
-    .arg(
-        Arg::with_name("relayer_max_failed_heartbeats")
-            .long("relayer-max-failed-heartbeats")
-            .takes_value(true)
-            .help(
-                "Maximum number of heartbeats the Relayer can miss before falling back to the \
-                 normal TPU pipeline.",
-            )
-            .default_value(&default_args.relayer_max_failed_heartbeats),
-    )
-    .arg(
-        Arg::with_name("trust_block_engine_packets")
-            .long("trust-block-engine-packets")
-            .takes_value(false)
-            .help(
-                "Skip signature verification on block engine packets. Not recommended unless the \
-                 block engine is trusted.",
-            ),
-    )
+    .arg(jito_args::block_engine_url())
+    .arg(jito_args::relayer_url())
+    .arg(jito_args::relayer_expected_heartbeat_interval_ms(
+        &default_args.relayer_expected_heartbeat_interval_ms,
+    ))
+    .arg(jito_args::relayer_max_failed_heartbeats(
+        &default_args.relayer_max_failed_heartbeats,
+    ))
+    .arg(jito_args::trust_block_engine_packets())
     .arg(
         Arg::with_name("tip_payment_program_pubkey")
             .long("tip-payment-program-pubkey")
@@ -1279,47 +1246,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .help("The commission validator takes from tips expressed in basis points."),
     )
-    .arg(
-        Arg::with_name("disable_block_engine_autoconfig")
-            .long("disable-block-engine-autoconfig")
-            .value_name("DISABLE_BLOCK_ENGINE_AUTOCONFIG")
-            .takes_value(false)
-            .help(
-                "Disables Block Engine auto-configuration. This stops the validator client from \
-                 using the most performant Block Engine region. Values provided to \
-                 `--block-engine-url` will be used as-is.",
-            ),
-    )
-    .arg(
-        Arg::with_name("shred_receiver_address")
-            .long("shred-receiver-address")
-            .value_name("SHRED_RECEIVER_ADDRESS")
-            .takes_value(true)
-            .multiple(true)
-            .help(
-                "Validator will mirror this validator's own broadcast shreds to these addresses \
-                 in addition to normal turbine operation. Used for the direct leader path and \
-                 replay-triggered rebroadcasts of this validator's slots. Pass this flag multiple \
-                 times or use comma-separated entries; each entry may be ip:port or host:port. \
-                 Hostnames resolve to IPv4 addresses only. Up to 32 unique addresses are allowed. \
-                 Pass empty string as the only value to configure an empty explicit receiver list.",
-            ),
-    )
-    .arg(
-        Arg::with_name("shred_retransmit_receiver_address")
-            .long("shred-retransmit-receiver-address")
-            .value_name("SHRED_RETRANSMIT_RECEIVER_ADDRESS")
-            .takes_value(true)
-            .multiple(true)
-            .help(
-                "Validator will mirror TVU retransmit-stage shreds to these addresses in addition \
-                 to normal turbine operation. This applies only to shreds that enter retransmit; \
-                 it does not mirror this validator's own leader broadcast path. Pass this flag \
-                 multiple times or use comma-separated entries; each entry may be ip:port or \
-                 host:port. Hostnames resolve to IPv4 addresses only. Up to 32 unique addresses \
-                 are allowed. Pass empty string as the only value to disable.",
-            ),
-    )
+    .arg(jito_args::disable_block_engine_autoconfig())
+    .arg(jito_args::shred_receiver_address())
+    .arg(jito_args::shred_retransmit_receiver_address())
     .arg(
         Arg::with_name("disable_multicast_shred_check")
             .long("disable-multicast-shred-check")

--- a/validator/src/commands/shred/mod.rs
+++ b/validator/src/commands/shred/mod.rs
@@ -1,54 +1,30 @@
 use {
-    crate::{admin_rpc_service, cli::DefaultArgs, commands::Result},
-    clap::{App, Arg, ArgMatches, SubCommand, value_t_or_exit},
+    crate::{
+        admin_rpc_service,
+        cli::DefaultArgs,
+        commands::{Result, jito_args},
+    },
+    clap::{App, ArgMatches, SubCommand, values_t_or_exit},
     std::path::Path,
 };
 
 pub fn shred_receiver_command(_default_args: &DefaultArgs) -> App<'_, '_> {
     SubCommand::with_name("set-shred-receiver-address")
         .about("Set leader-broadcast shred receiver address(es)")
-        .arg(
-            Arg::with_name("shred_receiver_address")
-                .long("shred-receiver-address")
-                .value_name("SHRED_RECEIVER_ADDRESS")
-                .takes_value(true)
-                .help(
-                    "Validator will mirror this validator's own broadcast shreds to these \
-                     addresses in addition to normal turbine operation. Used for the direct \
-                     leader path and replay-triggered rebroadcasts of this validator's slots. \
-                     Accepts comma-separated ip:port or host:port entries. Hostnames resolve to \
-                     IPv4 addresses only. Up to 32 unique addresses are allowed. Set to empty \
-                     string to configure an empty explicit receiver list.",
-                )
-                .required(true),
-        )
+        .arg(jito_args::shred_receiver_address().required(true))
 }
 
 pub fn shred_retransmit_receiver_command(_default_args: &DefaultArgs) -> App<'_, '_> {
     SubCommand::with_name("set-shred-retransmit-receiver-address")
         .about("Set TVU retransmit-stage shred receiver address(es)")
-        .arg(
-            Arg::with_name("shred_retransmit_receiver_address")
-                .long("shred-retransmit-receiver-address")
-                .value_name("SHRED_RETRANSMIT_RECEIVER_ADDRESS")
-                .takes_value(true)
-                .help(
-                    "Validator will mirror TVU retransmit-stage shreds to these addresses in \
-                     addition to normal turbine operation. This applies only to shreds that enter \
-                     retransmit; it does not mirror this validator's own leader broadcast path. \
-                     Accepts comma-separated ip:port or host:port entries. Hostnames resolve to \
-                     IPv4 addresses only. Up to 32 unique addresses are allowed. Set to empty \
-                     string to disable.",
-                )
-                .required(true),
-        )
+        .arg(jito_args::shred_retransmit_receiver_address().required(true))
 }
 
 pub fn set_shred_receiver_execute(
     subcommand_matches: &ArgMatches,
     ledger_path: &Path,
 ) -> Result<()> {
-    let addr = value_t_or_exit!(subcommand_matches, "shred_receiver_address", String);
+    let addr = values_t_or_exit!(subcommand_matches, "shred_receiver_address", String).join(",");
     let admin_client = admin_rpc_service::connect(ledger_path);
     admin_rpc_service::runtime()
         .block_on(async move { admin_client.await?.set_shred_receiver_address(addr).await })?;
@@ -59,11 +35,12 @@ pub fn set_shred_retransmit_receiver_execute(
     subcommand_matches: &ArgMatches,
     ledger_path: &Path,
 ) -> Result<()> {
-    let addr = value_t_or_exit!(
+    let addr = values_t_or_exit!(
         subcommand_matches,
         "shred_retransmit_receiver_address",
         String
-    );
+    )
+    .join(",");
     let admin_client = admin_rpc_service::connect(ledger_path);
     admin_rpc_service::runtime().block_on(async move {
         admin_client


### PR DESCRIPTION
## What changed

- keep only the eight Jito argument builders shared by startup and runtime admin commands in `commands::jito_args`
- leave startup-only tip, commission, Merkle-authority, and multicast arguments directly at their sole caller
- use one complete help description for each shred argument
- allow both startup and admin shred options to be repeated or supplied as comma-separated entries
- collect every admin occurrence into the existing comma-based RPC payload
- leave BAM in its already-shared feature module, deprecated compatibility handling in `cli.rs`, and generic networking arguments outside the Jito module
- keep `--disable-block-engine-autoconfig` value-less by omitting the incompatible `.value_name(...)`

## Why

The Jito CLI definitions were repeated across validator startup and runtime admin commands. The original cleanup also missed the duplicated retransmit shred receiver argument. Sharing only definitions with multiple callers removes real duplication without introducing one-use wrapper functions.

The admin shred commands previously extracted a single value even when the option appeared more than once. The shared builders now allow repeated one-value occurrences, preserve comma-containing values, and prevent greedy consumption of following arguments.
