### PR TITLE
Restore banking stage compatibility APIs

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -639,7 +639,7 @@ impl BankingStage {
         }
 
         // Both block production methods currently route to the greedy scheduler.
-        let scheduler = GreedyScheduler::new(
+        let scheduler = GreedyScheduler::new_with_bundle_locker(
             work_senders,
             finished_work_receiver,
             GreedySchedulerConfig::default(),

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -179,17 +179,19 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             .num_messages_processed
             .fetch_add(1, Ordering::Relaxed);
 
-        let output = self.consumer.process_and_record_aged_transactions(
-            bank,
-            &work.transactions,
-            &work.max_ages,
-            ExecutionFlags {
-                drop_on_failure: work.revert_on_error,
-                all_or_nothing: work.revert_on_error,
-            },
-            None, // bundle account locker checked in scheduler
-            work.revert_on_error,
-        );
+        let output = self
+            .consumer
+            .process_and_record_aged_transactions_with_policy(
+                bank,
+                &work.transactions,
+                &work.max_ages,
+                ExecutionFlags {
+                    drop_on_failure: work.revert_on_error,
+                    all_or_nothing: work.revert_on_error,
+                },
+                None, // bundle account locker checked in scheduler
+                work.revert_on_error,
+            );
         self.metrics.update_for_consume(&output);
         self.metrics.has_data.store(true, Ordering::Relaxed);
 
@@ -252,10 +254,10 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
         let initialize_tip_programs_bundle =
             tip_manager.get_initialize_tip_programs_bundle(bank, &keypair);
         if let Ok(init_bundle) = initialize_tip_programs_bundle {
-            let result = self.consumer.process_and_record_transactions(
+            let result = self.consumer.process_and_record_transactions_with_policy(
                 bank,
                 &init_bundle,
-                bundle_account_locker,
+                Some(bundle_account_locker),
                 true,
             );
             if result
@@ -277,10 +279,10 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
         }
         match tip_manager.get_tip_programs_crank_bundle(bank, &keypair, &block_builder_fee_info) {
             Ok(tip_crank_bundle) => {
-                let result = self.consumer.process_and_record_transactions(
+                let result = self.consumer.process_and_record_transactions_with_policy(
                     bank,
                     &tip_crank_bundle,
-                    bundle_account_locker,
+                    Some(bundle_account_locker),
                     true,
                 );
                 if result
@@ -681,14 +683,16 @@ pub(crate) mod external {
                     return Ok(false);
                 }
 
-                let output = self.consumer.process_and_record_aged_transactions(
-                    bank,
-                    &transactions,
-                    &max_ages,
-                    execution_flags,
-                    Some(&self.bundle_account_locker),
-                    false,
-                );
+                let output = self
+                    .consumer
+                    .process_and_record_aged_transactions_with_policy(
+                        bank,
+                        &transactions,
+                        &max_ages,
+                        execution_flags,
+                        Some(&self.bundle_account_locker),
+                        false,
+                    );
 
                 self.metrics.update_for_consume(&output);
                 self.metrics.has_data.store(true, Ordering::Relaxed);

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -146,7 +146,15 @@ impl Consumer {
         &self,
         bank: &Bank,
         txs: &[impl TransactionWithMeta],
-        bundle_account_locker: &BundleAccountLocker,
+    ) -> ProcessTransactionBatchOutput {
+        self.process_and_record_transactions_with_policy(bank, txs, None, false)
+    }
+
+    pub fn process_and_record_transactions_with_policy(
+        &self,
+        bank: &Bank,
+        txs: &[impl TransactionWithMeta],
+        bundle_account_locker: Option<&BundleAccountLocker>,
         revert_on_error: bool,
     ) -> ProcessTransactionBatchOutput {
         let mut error_counters = TransactionErrorMetrics::default();
@@ -181,7 +189,7 @@ impl Consumer {
                 drop_on_failure: revert_on_error,
                 all_or_nothing: revert_on_error,
             },
-            Some(bundle_account_locker),
+            bundle_account_locker,
             revert_on_error,
         );
 
@@ -195,6 +203,18 @@ impl Consumer {
     }
 
     pub fn process_and_record_aged_transactions(
+        &self,
+        bank: &Bank,
+        txs: &[impl TransactionWithMeta],
+        max_ages: &[MaxAge],
+        flags: ExecutionFlags,
+    ) -> ProcessTransactionBatchOutput {
+        self.process_and_record_aged_transactions_with_policy(
+            bank, txs, max_ages, flags, None, false,
+        )
+    }
+
+    pub fn process_and_record_aged_transactions_with_policy(
         &self,
         bank: &Bank,
         txs: &[impl TransactionWithMeta],
@@ -712,6 +732,18 @@ mod tests {
     fn execute_transactions_for_test(
         bank: Arc<Bank>,
         transactions: Vec<Transaction>,
+    ) -> ProcessTransactionBatchOutput {
+        execute_transactions_for_test_with_policy(
+            bank,
+            transactions,
+            BundleAccountLocker::default(),
+            false,
+        )
+    }
+
+    fn execute_transactions_for_test_with_policy(
+        bank: Arc<Bank>,
+        transactions: Vec<Transaction>,
         bundle_account_locker: BundleAccountLocker,
         revert_on_error: bool,
     ) -> ProcessTransactionBatchOutput {
@@ -724,10 +756,10 @@ mod tests {
         let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
         let committer = Committer::new(None, replay_vote_sender, None);
         let consumer = Consumer::new(committer, recorder, None);
-        consumer.process_and_record_transactions(
+        consumer.process_and_record_transactions_with_policy(
             &bank,
             &transactions,
-            &bundle_account_locker,
+            Some(&bundle_account_locker),
             revert_on_error,
         )
     }
@@ -795,12 +827,13 @@ mod tests {
             bank.confirmed_last_blockhash(),
         )]);
 
-        let process_transactions_batch_output = consumer.process_and_record_transactions(
-            &bank,
-            &transactions,
-            &BundleAccountLocker::default(),
-            revert_on_error,
-        );
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions_with_policy(
+                &bank,
+                &transactions,
+                None,
+                revert_on_error,
+            );
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
             commit_transactions_result,
@@ -834,12 +867,8 @@ mod tests {
             bank.confirmed_last_blockhash(),
         )]);
 
-        let process_transactions_batch_output = consumer.process_and_record_transactions(
-            &bank,
-            &transactions,
-            &BundleAccountLocker::default(),
-            false,
-        );
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -911,12 +940,8 @@ mod tests {
             bank.register_default_tick_for_test();
         }
 
-        let process_transactions_batch_output = consumer.process_and_record_transactions(
-            &bank,
-            &transactions,
-            &BundleAccountLocker::default(),
-            false,
-        );
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions);
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
             commit_transactions_result,
@@ -962,12 +987,8 @@ mod tests {
             sanitize_transactions(vec![tx])
         };
 
-        let process_transactions_batch_output = consumer.process_and_record_transactions(
-            &bank,
-            &transactions,
-            &BundleAccountLocker::default(),
-            false,
-        );
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1024,12 +1045,8 @@ mod tests {
             bank.last_blockhash(),
         )]);
 
-        let process_transactions_batch_output = consumer.process_and_record_transactions(
-            &bank,
-            &transactions,
-            &BundleAccountLocker::default(),
-            false,
-        );
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1066,12 +1083,8 @@ mod tests {
         )]);
         bank.try_lock_accounts(&conflicting_transaction);
 
-        let process_transactions_batch_output = consumer.process_and_record_transactions(
-            &bank,
-            &transactions,
-            &BundleAccountLocker::default(),
-            false,
-        );
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1157,12 +1170,8 @@ mod tests {
             bank.last_blockhash(),
         )]);
 
-        let process_transactions_batch_output = consumer.process_and_record_transactions(
-            &bank,
-            &transactions,
-            &BundleAccountLocker::default(),
-            false,
-        );
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1229,12 +1238,8 @@ mod tests {
             bank.try_lock_accounts(&conflicting_transaction);
         }
 
-        let process_transactions_batch_output = consumer.process_and_record_transactions(
-            &bank,
-            &transactions,
-            &BundleAccountLocker::default(),
-            false,
-        );
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1290,12 +1295,7 @@ mod tests {
         let ProcessTransactionBatchOutput {
             execute_and_commit_transactions_output,
             ..
-        } = execute_transactions_for_test(
-            bank,
-            transactions,
-            BundleAccountLocker::default(),
-            false,
-        );
+        } = execute_transactions_for_test(bank, transactions);
 
         // All the transactions should have been replayed
         assert_eq!(
@@ -1362,12 +1362,7 @@ mod tests {
         let ProcessTransactionBatchOutput {
             execute_and_commit_transactions_output,
             ..
-        } = execute_transactions_for_test(
-            bank,
-            transactions,
-            BundleAccountLocker::default(),
-            false,
-        );
+        } = execute_transactions_for_test(bank, transactions);
 
         // if the transactions are distinct, all are executed.
         // otherwise, only one is executed. regardless, all are attempted.
@@ -1426,12 +1421,8 @@ mod tests {
         // Channel shutdown should result in error returned on record.
         record_receiver.shutdown();
 
-        let process_transactions_summary = consumer.process_and_record_transactions(
-            &bank,
-            &transactions,
-            &BundleAccountLocker::default(),
-            false,
-        );
+        let process_transactions_summary =
+            consumer.process_and_record_transactions(&bank, &transactions);
 
         let ProcessTransactionBatchOutput {
             mut execute_and_commit_transactions_output,
@@ -1518,12 +1509,7 @@ mod tests {
         bank.transfer(rent_exempt_amount, &mint_keypair, &keypair1.pubkey())
             .unwrap();
 
-        let _ = consumer.process_and_record_transactions(
-            &bank,
-            &transactions,
-            &BundleAccountLocker::default(),
-            false,
-        );
+        let _ = consumer.process_and_record_transactions(&bank, &transactions);
         drop(consumer); // drop/disconnect transaction_status_sender
 
         let status_messages = transaction_status_receiver.into_iter().collect::<Vec<_>>();
@@ -1614,12 +1600,8 @@ mod tests {
 
         bank.transfer(1, &mint_keypair, &keypair.pubkey()).unwrap();
 
-        let _ = consumer.process_and_record_transactions(
-            &bank,
-            std::slice::from_ref(&sanitized_tx),
-            &BundleAccountLocker::default(),
-            false,
-        );
+        let _ =
+            consumer.process_and_record_transactions(&bank, std::slice::from_ref(&sanitized_tx));
         drop(consumer); // drop/disconnect transaction_status_sender
 
         let status_messages = transaction_status_receiver.into_iter().collect::<Vec<_>>();
@@ -1678,10 +1660,10 @@ mod tests {
         );
         let consumer = Consumer::new(committer, recorder.clone(), None);
 
-        let process_transactions_summary = consumer.process_and_record_transactions(
+        let process_transactions_summary = consumer.process_and_record_transactions_with_policy(
             &bank,
             &transactions,
-            &bundle_account_locker,
+            Some(&bundle_account_locker),
             false,
         );
 
@@ -1745,7 +1727,12 @@ mod tests {
             cost_model_throttled_transactions_count: _cost_model_throttled_transactions_count,
             cost_model_us: _cost_model_us,
             execute_and_commit_transactions_output,
-        } = execute_transactions_for_test(bank, transactions, BundleAccountLocker::default(), true);
+        } = execute_transactions_for_test_with_policy(
+            bank,
+            transactions,
+            BundleAccountLocker::default(),
+            true,
+        );
 
         assert_eq!(
             execute_and_commit_transactions_output

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -61,7 +61,21 @@ pub struct GreedyScheduler<Tx: TransactionWithMeta> {
 }
 
 impl<Tx: TransactionWithMeta> GreedyScheduler<Tx> {
+    #[allow(dead_code)]
     pub(crate) fn new(
+        consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
+        finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+        config: GreedySchedulerConfig,
+    ) -> Self {
+        Self::new_with_bundle_locker(
+            consume_work_senders,
+            finished_consume_work_receiver,
+            config,
+            BundleAccountLocker::default(),
+        )
+    }
+
+    pub(crate) fn new_with_bundle_locker(
         consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
         finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
         config: GreedySchedulerConfig,
@@ -341,6 +355,18 @@ mod test {
     fn create_test_frame(
         num_threads: usize,
         config: GreedySchedulerConfig,
+    ) -> (
+        GreedyScheduler<RuntimeTransaction<SanitizedTransaction>>,
+        Vec<Receiver<ConsumeWork<RuntimeTransaction<SanitizedTransaction>>>>,
+        Sender<FinishedConsumeWork<RuntimeTransaction<SanitizedTransaction>>>,
+    ) {
+        create_test_frame_with_bundle_locker(num_threads, config, BundleAccountLocker::default())
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn create_test_frame_with_bundle_locker(
+        num_threads: usize,
+        config: GreedySchedulerConfig,
         bundle_account_locker: BundleAccountLocker,
     ) -> (
         GreedyScheduler<RuntimeTransaction<SanitizedTransaction>>,
@@ -350,7 +376,7 @@ mod test {
         let (consume_work_senders, consume_work_receivers) =
             (0..num_threads).map(|_| unbounded()).unzip();
         let (finished_consume_work_sender, finished_consume_work_receiver) = unbounded();
-        let scheduler = GreedyScheduler::new(
+        let scheduler = GreedyScheduler::new_with_bundle_locker(
             consume_work_senders,
             finished_consume_work_receiver,
             config,
@@ -434,11 +460,8 @@ mod test {
 
     #[test]
     fn test_schedule_disconnected_channel() {
-        let (mut scheduler, work_receivers, _finished_work_sender) = create_test_frame(
-            1,
-            GreedySchedulerConfig::default(),
-            BundleAccountLocker::default(),
-        );
+        let (mut scheduler, work_receivers, _finished_work_sender) =
+            create_test_frame(1, GreedySchedulerConfig::default());
         let mut container = create_container([(&Keypair::new(), &[Pubkey::new_unique()], 1, 1)]);
 
         drop(work_receivers); // explicitly drop receivers
@@ -453,11 +476,8 @@ mod test {
 
     #[test]
     fn test_schedule_single_threaded_no_conflicts() {
-        let (mut scheduler, work_receivers, _finished_work_sender) = create_test_frame(
-            1,
-            GreedySchedulerConfig::default(),
-            BundleAccountLocker::default(),
-        );
+        let (mut scheduler, work_receivers, _finished_work_sender) =
+            create_test_frame(1, GreedySchedulerConfig::default());
         let mut container = create_container([
             (&Keypair::new(), &[Pubkey::new_unique()], 1, 1),
             (&Keypair::new(), &[Pubkey::new_unique()], 2, 2),
@@ -476,11 +496,8 @@ mod test {
 
     #[test]
     fn test_schedule_budget() {
-        let (mut scheduler, _work_receivers, _finished_work_sender) = create_test_frame(
-            1,
-            GreedySchedulerConfig::default(),
-            BundleAccountLocker::default(),
-        );
+        let (mut scheduler, _work_receivers, _finished_work_sender) =
+            create_test_frame(1, GreedySchedulerConfig::default());
         let mut container = create_container([
             (&Keypair::new(), &[Pubkey::new_unique()], 1, 1),
             (&Keypair::new(), &[Pubkey::new_unique()], 2, 2),
@@ -504,7 +521,6 @@ mod test {
                 target_scheduled_cus: 1, // only allow 1 transaction scheduled
                 ..GreedySchedulerConfig::default()
             },
-            BundleAccountLocker::default(),
         );
         let mut container = create_container([
             (&Keypair::new(), &[Pubkey::new_unique()], 1, 1),
@@ -530,7 +546,6 @@ mod test {
                 max_scanned_transactions_per_scheduling_pass: 1, // only allow 1 transaction scheduled
                 ..GreedySchedulerConfig::default()
             },
-            BundleAccountLocker::default(),
         );
         let mut container = create_container([
             (&Keypair::new(), &[Pubkey::new_unique()], 1, 1),
@@ -556,7 +571,6 @@ mod test {
                 target_transactions_per_batch: 1, // only allow 1 transaction per batch
                 ..GreedySchedulerConfig::default()
             },
-            BundleAccountLocker::default(),
         );
         let mut container = create_container([
             (&Keypair::new(), &[Pubkey::new_unique()], 1, 1),
@@ -585,7 +599,6 @@ mod test {
                     + 1,
                 ..GreedySchedulerConfig::default()
             },
-            BundleAccountLocker::default(),
         );
         let mut container = create_container([
             (&Keypair::new(), &[Pubkey::new_unique()], 1, 1),
@@ -612,11 +625,8 @@ mod test {
 
     #[test]
     fn test_schedule_single_threaded_conflict() {
-        let (mut scheduler, work_receivers, _finished_work_sender) = create_test_frame(
-            1,
-            GreedySchedulerConfig::default(),
-            BundleAccountLocker::default(),
-        );
+        let (mut scheduler, work_receivers, _finished_work_sender) =
+            create_test_frame(1, GreedySchedulerConfig::default());
         let pubkey = Pubkey::new_unique();
         let mut container = create_container([
             (&Keypair::new(), &[pubkey], 1, 1),
@@ -636,11 +646,8 @@ mod test {
 
     #[test]
     fn test_schedule_simple_thread_selection() {
-        let (mut scheduler, work_receivers, _finished_work_sender) = create_test_frame(
-            2,
-            GreedySchedulerConfig::default(),
-            BundleAccountLocker::default(),
-        );
+        let (mut scheduler, work_receivers, _finished_work_sender) =
+            create_test_frame(2, GreedySchedulerConfig::default());
         let mut container =
             create_container((0..4).map(|i| (Keypair::new(), [Pubkey::new_unique()], 1, i)));
 
@@ -658,11 +665,8 @@ mod test {
 
     #[test]
     fn test_schedule_scan_past_highest_priority() {
-        let (mut scheduler, work_receivers, _finished_work_sender) = create_test_frame(
-            2,
-            GreedySchedulerConfig::default(),
-            BundleAccountLocker::default(),
-        );
+        let (mut scheduler, work_receivers, _finished_work_sender) =
+            create_test_frame(2, GreedySchedulerConfig::default());
         let pubkey1 = Pubkey::new_unique();
         let pubkey2 = Pubkey::new_unique();
         let pubkey3 = Pubkey::new_unique();
@@ -706,7 +710,6 @@ mod test {
                 target_scheduled_cus: 4 * 5_000, // 2 txs per thread
                 ..GreedySchedulerConfig::default()
             },
-            BundleAccountLocker::default(),
         );
 
         // Low priority transaction that does not conflict with other work.
@@ -757,14 +760,15 @@ mod test {
         container.insert_new_transaction(runtime_tx_1_a, MaxAge::MAX, 1, 5000);
         container.insert_new_transaction(runtime_tx_2_a, MaxAge::MAX, 1, 5000);
 
-        let (mut scheduler, work_receivers, _finished_work_sender) = create_test_frame(
-            1,
-            GreedySchedulerConfig {
-                target_scheduled_cus: 4 * 5_000, // 2 txs per thread
-                ..GreedySchedulerConfig::default()
-            },
-            bundle_account_locker.clone(),
-        );
+        let (mut scheduler, work_receivers, _finished_work_sender) =
+            create_test_frame_with_bundle_locker(
+                1,
+                GreedySchedulerConfig {
+                    target_scheduled_cus: 4 * 5_000, // 2 txs per thread
+                    ..GreedySchedulerConfig::default()
+                },
+                bundle_account_locker.clone(),
+            );
 
         bundle_account_locker
             .lock_bundle(&runtime_tx_1_b, &bank)

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -600,7 +600,6 @@ mod tests {
     fn setup_transaction_view_receive_and_buffer(
         receiver: Receiver<BankingPacketBatch>,
         bank_forks: Arc<RwLock<BankForks>>,
-        _blacklisted_accounts: HashSet<Pubkey>,
     ) -> (
         TransactionViewReceiveAndBuffer,
         TransactionViewStateContainer,
@@ -679,7 +678,7 @@ mod tests {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, _mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
-            setup_transaction_view_receive_and_buffer(receiver, bank_forks, HashSet::default());
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks);
 
         drop(sender); // disconnect channel
         let r = receive_and_buffer
@@ -691,11 +690,8 @@ mod tests {
     fn test_receive_and_buffer_no_hold() {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
-        let (mut receive_and_buffer, mut container) = setup_transaction_view_receive_and_buffer(
-            receiver,
-            bank_forks.clone(),
-            HashSet::default(),
-        );
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
 
         let transaction = transfer(
             &mint_keypair,
@@ -744,11 +740,8 @@ mod tests {
     fn test_receive_and_buffer_discard() {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
-        let (mut receive_and_buffer, mut container) = setup_transaction_view_receive_and_buffer(
-            receiver,
-            bank_forks.clone(),
-            HashSet::default(),
-        );
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
 
         let transaction = transfer(
             &mint_keypair,
@@ -801,7 +794,7 @@ mod tests {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, _mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
-            setup_transaction_view_receive_and_buffer(receiver, bank_forks, HashSet::default());
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks);
 
         let packet_batches = Arc::new(vec![PacketBatch::from(RecycledPacketBatch::new(vec![
             Packet::new([1u8; PACKET_DATA_SIZE], Meta::default()),
@@ -845,7 +838,7 @@ mod tests {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
-            setup_transaction_view_receive_and_buffer(receiver, bank_forks, HashSet::default());
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks);
 
         let transaction = transfer(&mint_keypair, &Pubkey::new_unique(), 1, Hash::new_unique());
         let packet_batches = Arc::new(to_packet_batches(&[transaction], 1));
@@ -887,11 +880,8 @@ mod tests {
     fn test_receive_and_buffer_simple_transfer_unfunded_fee_payer() {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, _mint_keypair) = test_bank_forks();
-        let (mut receive_and_buffer, mut container) = setup_transaction_view_receive_and_buffer(
-            receiver,
-            bank_forks.clone(),
-            HashSet::default(),
-        );
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
 
         let transaction = transfer(
             &Keypair::new(),
@@ -938,11 +928,8 @@ mod tests {
     fn test_receive_and_buffer_failed_alt_resolve() {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
-        let (mut receive_and_buffer, mut container) = setup_transaction_view_receive_and_buffer(
-            receiver,
-            bank_forks.clone(),
-            HashSet::default(),
-        );
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
 
         let to_pubkey = Pubkey::new_unique();
         let transaction = VersionedTransaction::try_new(
@@ -1004,11 +991,8 @@ mod tests {
     fn test_receive_and_buffer_simple_transfer() {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
-        let (mut receive_and_buffer, mut container) = setup_transaction_view_receive_and_buffer(
-            receiver,
-            bank_forks.clone(),
-            HashSet::default(),
-        );
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
 
         let transaction = transfer(
             &mint_keypair,
@@ -1055,11 +1039,8 @@ mod tests {
     fn test_receive_and_buffer_buffers_already_processed() {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
-        let (mut receive_and_buffer, mut container) = setup_transaction_view_receive_and_buffer(
-            receiver,
-            bank_forks.clone(),
-            HashSet::default(),
-        );
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
 
         let bank = bank_forks.read().unwrap().root_bank();
         let transaction = transfer(
@@ -1180,11 +1161,8 @@ mod tests {
     fn test_receive_and_buffer_overfull() {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
-        let (mut receive_and_buffer, mut container) = setup_transaction_view_receive_and_buffer(
-            receiver,
-            bank_forks.clone(),
-            HashSet::default(),
-        );
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
 
         let num_transactions = 3 * TEST_CONTAINER_CAPACITY;
         let transactions = Vec::from_iter((0..num_transactions).map(|_| {
@@ -1262,11 +1240,8 @@ mod tests {
 
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
-        let (mut receive_and_buffer, mut container) = setup_transaction_view_receive_and_buffer(
-            receiver,
-            bank_forks.clone(),
-            HashSet::default(),
-        );
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
 
         let transaction_account_lock_limit = bank_forks
             .read()

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -639,15 +639,12 @@ impl CostPacer {
 mod tests {
     use {
         super::*,
-        crate::{
-            banking_stage::{
-                TransactionViewReceiveAndBuffer,
-                consumer::{RetryableIndex, TARGET_NUM_TRANSACTIONS_PER_BATCH},
-                scheduler_messages::{ConsumeWork, FinishedConsumeWork, TransactionBatchId},
-                tests::create_slow_genesis_config,
-                transaction_scheduler::greedy_scheduler::{GreedyScheduler, GreedySchedulerConfig},
-            },
-            bundle_stage::bundle_account_locker::BundleAccountLocker,
+        crate::banking_stage::{
+            TransactionViewReceiveAndBuffer,
+            consumer::{RetryableIndex, TARGET_NUM_TRANSACTIONS_PER_BATCH},
+            scheduler_messages::{ConsumeWork, FinishedConsumeWork, TransactionBatchId},
+            tests::create_slow_genesis_config,
+            transaction_scheduler::greedy_scheduler::{GreedyScheduler, GreedySchedulerConfig},
         },
         agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
         ahash::HashSet,
@@ -707,7 +704,6 @@ mod tests {
             Arc<RwLock<BankForks>>,
             HashSet<Pubkey>,
         ) -> R,
-        bundle_account_locker: BundleAccountLocker,
     ) -> (
         TestFrame<R::Transaction>,
         SchedulerController<R, GreedyScheduler<R::Transaction>>,
@@ -748,7 +744,6 @@ mod tests {
             consume_work_senders,
             finished_consume_work_receiver,
             GreedySchedulerConfig::default(),
-            bundle_account_locker,
         );
         let exit = Arc::new(AtomicBool::new(false));
         let scheduler_controller = SchedulerController::new(
@@ -848,11 +843,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "batch id 0 is not being tracked")]
     fn test_unexpected_batch_id() {
-        let (test_frame, mut scheduler_controller) = create_test_frame(
-            1,
-            test_create_transaction_view_receive_and_buffer,
-            BundleAccountLocker::default(),
-        );
+        let (test_frame, mut scheduler_controller) =
+            create_test_frame(1, test_create_transaction_view_receive_and_buffer);
         let TestFrame {
             finished_consume_work_sender,
             ..
@@ -879,11 +871,8 @@ mod tests {
 
     #[test]
     fn test_schedule_consume_single_threaded_no_conflicts() {
-        let (mut test_frame, mut scheduler_controller) = create_test_frame(
-            1,
-            test_create_transaction_view_receive_and_buffer,
-            BundleAccountLocker::default(),
-        );
+        let (mut test_frame, mut scheduler_controller) =
+            create_test_frame(1, test_create_transaction_view_receive_and_buffer);
         let TestFrame {
             bank,
             mint_keypair,
@@ -941,11 +930,8 @@ mod tests {
 
     #[test]
     fn test_schedule_consume_single_threaded_conflict() {
-        let (mut test_frame, mut scheduler_controller) = create_test_frame(
-            1,
-            test_create_transaction_view_receive_and_buffer,
-            BundleAccountLocker::default(),
-        );
+        let (mut test_frame, mut scheduler_controller) =
+            create_test_frame(1, test_create_transaction_view_receive_and_buffer);
         let TestFrame {
             bank,
             mint_keypair,
@@ -1006,11 +992,8 @@ mod tests {
 
     #[test]
     fn test_schedule_consume_single_threaded_multi_batch() {
-        let (mut test_frame, mut scheduler_controller) = create_test_frame(
-            1,
-            test_create_transaction_view_receive_and_buffer,
-            BundleAccountLocker::default(),
-        );
+        let (mut test_frame, mut scheduler_controller) =
+            create_test_frame(1, test_create_transaction_view_receive_and_buffer);
         let TestFrame {
             bank,
             mint_keypair,
@@ -1078,11 +1061,8 @@ mod tests {
 
     #[test]
     fn test_schedule_consume_simple_thread_selection() {
-        let (mut test_frame, mut scheduler_controller) = create_test_frame(
-            2,
-            test_create_transaction_view_receive_and_buffer,
-            BundleAccountLocker::default(),
-        );
+        let (mut test_frame, mut scheduler_controller) =
+            create_test_frame(2, test_create_transaction_view_receive_and_buffer);
         let TestFrame {
             bank,
             mint_keypair,
@@ -1151,11 +1131,8 @@ mod tests {
 
     #[test]
     fn test_schedule_consume_retryable() {
-        let (mut test_frame, mut scheduler_controller) = create_test_frame(
-            1,
-            test_create_transaction_view_receive_and_buffer,
-            BundleAccountLocker::default(),
-        );
+        let (mut test_frame, mut scheduler_controller) =
+            create_test_frame(1, test_create_transaction_view_receive_and_buffer);
         let TestFrame {
             bank,
             mint_keypair,

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -362,12 +362,13 @@ impl VoteWorker {
         transactions: &[impl TransactionWithMeta],
         bundle_account_locker: &BundleAccountLocker,
     ) -> ProcessTransactionsSummary {
-        let process_transaction_batch_output = consumer.process_and_record_transactions(
-            bank,
-            transactions,
-            bundle_account_locker,
-            false,
-        );
+        let process_transaction_batch_output = consumer
+            .process_and_record_transactions_with_policy(
+                bank,
+                transactions,
+                Some(bundle_account_locker),
+                false,
+            );
 
         let ProcessTransactionBatchOutput {
             cost_model_throttled_transactions_count,


### PR DESCRIPTION
## What changed

- restore upstream-compatible `Consumer::process_and_record_transactions` and `process_and_record_aged_transactions` entry points
- move bundle-lock and revert behavior to explicit `*_with_policy` variants
- restore `GreedyScheduler::new` with a default locker and add `new_with_bundle_locker`
- remove the ignored blacklist parameter from the transaction-view test fixture
- return default-only test call sites to the compatibility APIs

## Why

Jito-specific bundle locking and revert policy had been threaded through common upstream signatures, forcing default arguments through unrelated call sites and increasing rebase conflicts.

## Correctness

`revert_on_error` remains an independent policy. BAM work keeps its requested revert behavior, tip upkeep keeps bundle locking plus revert semantics, and the external scheduler still passes its independent execution flags with `revert_on_error = false`.

## Validation

- `cargo test -p solana-core banking_stage::consumer::tests --lib` (15 passed)
- `cargo test -p solana-core greedy_scheduler::test --lib` (13 passed)
- `cargo test -p solana-core banking_stage::transaction_scheduler::receive_and_buffer::tests --lib` (15 passed)
- `cargo test -p solana-core banking_stage::vote_worker::tests --lib` (4 passed)
