### PR TITLE
Correct Jito live metrics

### DIFF
--- a/core/src/bam_connection.rs
+++ b/core/src/bam_connection.rs
@@ -51,7 +51,8 @@ const NETWORK_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const OUTBOUND_CHANNEL_CAPACITY: usize = 100_000;
 const MAX_OUTBOUND_RESULT_BATCH_SIZE: usize = 24;
 const VALIDATOR_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
-const METRICS_AND_HEALTH_CHECK_INTERVAL: Duration = Duration::from_millis(25);
+const HEALTH_CHECK_INTERVAL: Duration = Duration::from_millis(25);
+const METRICS_REPORT_INTERVAL: Duration = Duration::from_secs(1);
 const REFRESH_CONFIG_INTERVAL: Duration = Duration::from_secs(1);
 const WAIT_SLEEP_DURATION: Duration = Duration::from_millis(10);
 const CHILD_TASK_SHUTDOWN_GRACE: Duration = Duration::from_millis(100);
@@ -138,9 +139,10 @@ impl BamConnection {
         let mut last_heartbeat = None;
         let mut heartbeat_interval = interval(VALIDATOR_HEARTBEAT_INTERVAL);
         heartbeat_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        let mut metrics_and_health_check_interval = interval(METRICS_AND_HEALTH_CHECK_INTERVAL);
-        metrics_and_health_check_interval
-            .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut health_check_interval = interval(HEALTH_CHECK_INTERVAL);
+        health_check_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut metrics_report_interval = interval(METRICS_REPORT_INTERVAL);
+        metrics_report_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         // Create auth proof
         let Some(auth_proof) = Self::prepare_auth_proof(&mut validator_client, cluster_info).await
@@ -179,14 +181,14 @@ impl BamConnection {
                     }));
                     metrics.heartbeat_sent += 1;
                 }
-                _ = metrics_and_health_check_interval.tick() => {
-                    let is_healthy_now = last_heartbeat.is_some_and(|t: Instant| t.elapsed() < MAX_DURATION_BETWEEN_NODE_HEARTBEATS);
-                    is_healthy.store(is_healthy_now, Relaxed);
-                    if !is_healthy_now {
-                        metrics.unhealthy_connection_count += 1;
-                    }
-
-                    metrics.report();
+                _ = health_check_interval.tick() => {
+                    is_healthy.store(
+                        last_heartbeat.is_some_and(|t: Instant| t.elapsed() < MAX_DURATION_BETWEEN_NODE_HEARTBEATS),
+                        Relaxed,
+                    );
+                }
+                _ = metrics_report_interval.tick() => {
+                    metrics.report(is_healthy.load(Relaxed));
                 }
                 inbound = inbound_stream.message() => {
                     let inbound = match inbound {
@@ -494,8 +496,6 @@ struct BamConnectionMetrics {
     heartbeat_received: u64,
     builder_config_received: Arc<AtomicU64>,
 
-    unhealthy_connection_count: u64,
-
     leaderstate_sent: u64,
     bundleresult_sent: u64,
     heartbeat_sent: u64,
@@ -504,23 +504,7 @@ struct BamConnectionMetrics {
 }
 
 impl BamConnectionMetrics {
-    fn has_data(&self) -> bool {
-        self.bundle_received > 0
-            || self.bundle_forward_to_scheduler_fail > 0
-            || self.heartbeat_received > 0
-            || self.builder_config_received.load(Relaxed) > 0
-            || self.unhealthy_connection_count > 0
-            || self.leaderstate_sent > 0
-            || self.bundleresult_sent > 0
-            || self.heartbeat_sent > 0
-            || self.outbound_sent > 0
-            || self.outbound_fail > 0
-    }
-
-    fn report(&mut self) {
-        if !self.has_data() {
-            return;
-        }
+    fn report(&mut self, connection_healthy: bool) {
         datapoint_info!(
             "bam_connection-metrics",
             ("bundle_received", self.bundle_received, i64),
@@ -535,11 +519,7 @@ impl BamConnectionMetrics {
                 self.builder_config_received.swap(0, Relaxed),
                 i64
             ),
-            (
-                "unhealthy_connection_count",
-                self.unhealthy_connection_count,
-                i64
-            ),
+            ("connection_healthy", connection_healthy, bool),
             ("leaderstate_sent", self.leaderstate_sent, i64),
             ("bundleresult_sent", self.bundleresult_sent, i64),
             ("heartbeat_sent", self.heartbeat_sent, i64),
@@ -549,7 +529,6 @@ impl BamConnectionMetrics {
         self.bundle_received = 0;
         self.bundle_forward_to_scheduler_fail = 0;
         self.heartbeat_received = 0;
-        self.unhealthy_connection_count = 0;
         self.leaderstate_sent = 0;
         self.bundleresult_sent = 0;
         self.heartbeat_sent = 0;

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -219,6 +219,11 @@ impl BundleStageLoopMetrics {
                     i64
                 ),
                 (
+                    "cost_model_buffered_bundles_count",
+                    self.cost_model_buffered_bundles_count.0 as i64,
+                    i64
+                ),
+                (
                     "num_bundles_dropped",
                     self.num_bundles_dropped.0 as i64,
                     i64

--- a/core/src/proxy/fetch_stage_manager.rs
+++ b/core/src/proxy/fetch_stage_manager.rs
@@ -405,11 +405,12 @@ impl FetchStageTpuStateMachine {
             Ok(pkt) => {
                 // Only forward packets when fetch stage is "connected"
                 if self.should_forward_packets() {
+                    let packet_count = pkt.len() as u64;
                     if self.packet_tx.send(pkt).is_err() {
                         error!("{:?}", ProxyError::PacketForwardError);
                         return false;
                     }
-                    self.metrics.packets_forwarded += 1;
+                    self.metrics.packets_forwarded += packet_count;
                 }
                 true
             }
@@ -500,13 +501,15 @@ mod tests {
         packet_rx: &Receiver<PacketBatch>,
         should_send: bool,
     ) {
-        let pkt = PacketBatch::Single(BytesPacket::empty());
+        let packets_forwarded = brain.metrics.packets_forwarded;
+        let pkt = PacketBatch::from(vec![BytesPacket::empty(); 3]);
         assert!(brain.handle_packet_batch(Ok(pkt.clone())));
         if should_send {
-            let received_pkt = packet_rx.recv().unwrap();
-            assert_eq!(received_pkt, pkt);
+            assert_eq!(packet_rx.recv().unwrap(), pkt);
+            assert_eq!(brain.metrics.packets_forwarded, packets_forwarded + 3);
         } else {
             assert!(packet_rx.try_recv().is_err());
+            assert_eq!(brain.metrics.packets_forwarded, packets_forwarded);
         }
     }
 


### PR DESCRIPTION
## What changed

- emit `cost_model_buffered_bundles_count` in `bundle_stage-loop_stats`
- keep BAM's 25 ms health evaluation while reporting metrics once per second
- replace the misleading 25 ms unhealthy-tick counter with a `connection_healthy` boolean gauge that is emitted even when traffic counters are idle
- count packets inside forwarded `PacketBatch` values instead of counting channel messages
- exercise multi-packet accounting through the existing fetch-stage state-machine test paths instead of adding a separate setup-heavy test

## Why

The existing bundle gauge could trigger a report without appearing in it, BAM's "connection count" was actually a high-frequency timer count, and fetch-stage packet metrics undercounted multi-packet batches.

The health gauge is both simpler and more useful than a transition counter: a dashboard can see the current state every second, including during otherwise idle periods. Removed the transition state, reset plumbing, trivial helper, and tautological tests

## Production verification

A read-only InfluxDB query against the `mainnet-validator` database on 2026-08-18 inspected positive `unhealthy_connection_count` samples from the preceding 24 hours. Samples were grouped by `host_id` and one-second buckets:

```text
SELECT MAX("samples") AS "max_per_second",
       MEAN("samples") AS "mean_per_active_second"
FROM (
    SELECT COUNT("unhealthy_connection_count") AS "samples"
    FROM "bam_connection-metrics"
    WHERE time > now() - 24h
      AND "unhealthy_connection_count" > 0
    GROUP BY time(1s), "host_id"
)
GROUP BY "host_id"
```

Hosts that reached the code-implied 40 reports per second:

| Host ID | Maximum/sec | Mean/active sec | Positive samples |
|---|---:|---:|---:|
| `2X5yar…J1to1` | **40** | 16.22 | 746 |
| `A4hyMd…J1to2` | **40** | 26.67 | 80 |

Other observed hosts:

| Host ID | Maximum/sec | Mean/active sec | Positive samples |
|---|---:|---:|---:|
| `5Ei36L…RP59J` | 3 | 1.0003 | 74,245 |
| `8vQq8H…AXnKW` | 1 | 1.0000 | 42,010 |
| `DA3n68…LW78z` | 1 | 1.0000 | 44,494 |
| `Hg6Tvz…BPPRCq` | 3 | 1.0014 | 45,816 |
| `sJ1Dxw…BR3gJe` | 2 | 1.0002 | 18,217 |

As an exact spot check, host `2X5yar…J1to1` wrote **40** positive samples during `2026-08-17T23:45:23Z`. Raw timestamps were approximately 25 ms apart and every value was `1`, matching the original increment → report → reset control flow. This confirms that the 40-per-second behavior occurred in production; the database alone does not establish why the other hosts exhibit a different cadence.

## Impact

The BAM field changes from `unhealthy_connection_count` to `connection_healthy`. No conditional removal of existing heartbeat fields or bundle metric tags is included because no repository-owned dashboard definitions establish that those schemas are unused.

PR diff: **+28 / -41**. Relative to upstream base `41bbd0e258`, this reduces total Jito patch churn by **13 lines**.
