### PR TITLE
Share proxy auth refresh state

### DIFF
--- a/core/src/proxy/auth.rs
+++ b/core/src/proxy/auth.rs
@@ -27,41 +27,70 @@ pub(crate) struct AuthRefreshState {
 }
 
 impl AuthRefreshState {
-    pub(crate) fn access_token(&self) -> Arc<ArcSwap<Token>> {
-        self.access_token.clone()
+    pub(crate) fn interceptor(&self) -> AuthInterceptor {
+        AuthInterceptor {
+            access_token: self.access_token.clone(),
+        }
     }
 
-    pub(crate) async fn maybe_refresh(
-        &mut self,
-        cluster_info: &Arc<ClusterInfo>,
-        connection_timeout: &Duration,
-        refresh_within_s: u64,
-    ) -> crate::proxy::Result<(bool, bool)> {
-        if cluster_info.id() != self.identity {
+    pub(crate) fn validate_identity(&self, identity: Pubkey) -> crate::proxy::Result<()> {
+        if identity != self.identity {
             return Err(ProxyError::AuthenticationConnectionError(
                 "validator identity changed".to_string(),
             ));
         }
+        Ok(())
+    }
 
-        let (new_access_token, new_refresh_token) = maybe_refresh_auth_tokens(
-            &mut self.auth_client,
-            &self.access_token,
-            &self.refresh_token,
-            cluster_info,
-            connection_timeout,
-            refresh_within_s,
-        )
-        .await?;
+    pub(crate) async fn maybe_refresh(
+        &mut self,
+        cluster_info: &ClusterInfo,
+        connection_timeout: &Duration,
+        refresh_within_s: u64,
+    ) -> crate::proxy::Result<(bool, bool)> {
+        let now = Utc::now().timestamp() as u64;
+        let expires_within = |token: &Token| {
+            token
+                .expires_at_utc
+                .as_ref()
+                .map(|ts| ts.seconds as u64)
+                .unwrap_or_default()
+                .saturating_sub(now)
+                <= refresh_within_s
+        };
 
-        let access_token_refreshed = new_access_token.is_some();
-        if let Some(new_access_token) = new_access_token {
+        if expires_within(&self.refresh_token) {
+            let keypair = cluster_info.keypair();
+            self.validate_identity(keypair.pubkey())?;
+            let (new_access_token, new_refresh_token) = timeout(
+                *connection_timeout,
+                generate_auth_tokens(&mut self.auth_client, keypair.as_ref()),
+            )
+            .await
+            .map_err(|_| ProxyError::MethodTimeout("generate_auth_tokens".to_string()))?
+            .map_err(|e| ProxyError::MethodError {
+                code: tonic::Code::Unknown,
+                message: sanitize_status_message_for_influx(&e.to_string()),
+            })?;
             self.access_token.store(Arc::new(new_access_token));
-        }
-        let refresh_token_refreshed = new_refresh_token.is_some();
-        if let Some(new_refresh_token) = new_refresh_token {
             self.refresh_token = new_refresh_token;
+            Ok((true, true))
+        } else if expires_within(&self.access_token.load()) {
+            let new_access_token = timeout(
+                *connection_timeout,
+                refresh_access_token(&mut self.auth_client, &self.refresh_token),
+            )
+            .await
+            .map_err(|_| ProxyError::MethodTimeout("refresh_access_token".to_string()))?
+            .map_err(|e| ProxyError::MethodError {
+                code: tonic::Code::Unknown,
+                message: sanitize_status_message_for_influx(&e.to_string()),
+            })?;
+            self.access_token.store(Arc::new(new_access_token));
+            Ok((true, false))
+        } else {
+            Ok((false, false))
         }
-        Ok((access_token_refreshed, refresh_token_refreshed))
     }
 }
 
@@ -69,12 +98,6 @@ impl AuthRefreshState {
 pub(crate) struct AuthInterceptor {
     /// The token added to each request header.
     access_token: Arc<ArcSwap<Token>>,
-}
-
-impl AuthInterceptor {
-    pub(crate) fn new(access_token: Arc<ArcSwap<Token>>) -> Self {
-        Self { access_token }
-    }
 }
 
 impl Interceptor for AuthInterceptor {
@@ -120,7 +143,7 @@ pub(crate) async fn auth_client_from_endpoint(
 }
 
 /// Generates an auth challenge then generates and returns validated auth tokens.
-pub async fn generate_auth_tokens(
+async fn generate_auth_tokens(
     auth_service_client: &mut AuthServiceClient<Channel>,
     // used to sign challenges
     keypair: &Keypair,
@@ -178,70 +201,7 @@ pub async fn generate_auth_tokens(
     Ok((access_token, refresh_token))
 }
 
-/// Tries to refresh the access token or run full-reauth if needed.
-pub async fn maybe_refresh_auth_tokens(
-    auth_service_client: &mut AuthServiceClient<Channel>,
-    access_token: &Arc<ArcSwap<Token>>,
-    refresh_token: &Token,
-    cluster_info: &Arc<ClusterInfo>,
-    connection_timeout: &Duration,
-    refresh_within_s: u64,
-) -> crate::proxy::Result<(
-    Option<Token>, // access token
-    Option<Token>, // refresh token
-)> {
-    let now = Utc::now().timestamp() as u64;
-
-    let should_refresh_access = access_token
-        .load()
-        .expires_at_utc
-        .as_ref()
-        .map(|ts| ts.seconds as u64)
-        .unwrap_or_default()
-        .saturating_sub(now)
-        <= refresh_within_s;
-    let should_generate_new_tokens = refresh_token
-        .expires_at_utc
-        .as_ref()
-        .map(|ts| ts.seconds as u64)
-        .unwrap_or_default()
-        .saturating_sub(now)
-        <= refresh_within_s;
-
-    if should_generate_new_tokens {
-        let kp = cluster_info.keypair().clone();
-
-        let (new_access_token, new_refresh_token) = timeout(
-            *connection_timeout,
-            generate_auth_tokens(auth_service_client, kp.as_ref()),
-        )
-        .await
-        .map_err(|_| ProxyError::MethodTimeout("generate_auth_tokens".to_string()))?
-        .map_err(|e| ProxyError::MethodError {
-            code: tonic::Code::Unknown,
-            message: sanitize_status_message_for_influx(&e.to_string()),
-        })?;
-
-        return Ok((Some(new_access_token), Some(new_refresh_token)));
-    } else if should_refresh_access {
-        let new_access_token = timeout(
-            *connection_timeout,
-            refresh_access_token(auth_service_client, refresh_token),
-        )
-        .await
-        .map_err(|_| ProxyError::MethodTimeout("refresh_access_token".to_string()))?
-        .map_err(|e| ProxyError::MethodError {
-            code: tonic::Code::Unknown,
-            message: sanitize_status_message_for_influx(&e.to_string()),
-        })?;
-
-        return Ok((Some(new_access_token), None));
-    }
-
-    Ok((None, None))
-}
-
-pub async fn refresh_access_token(
+async fn refresh_access_token(
     auth_service_client: &mut AuthServiceClient<Channel>,
     refresh_token: &Token,
 ) -> crate::proxy::Result<Token> {

--- a/core/src/proxy/auth.rs
+++ b/core/src/proxy/auth.rs
@@ -48,19 +48,13 @@ impl AuthRefreshState {
         connection_timeout: &Duration,
         refresh_within_s: u64,
     ) -> crate::proxy::Result<(bool, bool)> {
-        let now = Utc::now().timestamp() as u64;
-        let expires_within = |token: &Token| {
-            token
-                .expires_at_utc
-                .as_ref()
-                .map(|ts| ts.seconds as u64)
-                .unwrap_or_default()
-                .saturating_sub(now)
-                <= refresh_within_s
-        };
+        let refresh_deadline = Utc::now()
+            .timestamp()
+            .saturating_add_unsigned(refresh_within_s);
 
-        if expires_within(&self.refresh_token) {
+        if expires_by(&self.refresh_token, refresh_deadline) {
             let keypair = cluster_info.keypair();
+            // Close the identity-rotation race between the outer check and reauthentication.
             self.validate_identity(keypair.pubkey())?;
             let (new_access_token, new_refresh_token) = timeout(
                 *connection_timeout,
@@ -75,7 +69,7 @@ impl AuthRefreshState {
             self.access_token.store(Arc::new(new_access_token));
             self.refresh_token = new_refresh_token;
             Ok((true, true))
-        } else if expires_within(&self.access_token.load()) {
+        } else if expires_by(&self.access_token.load(), refresh_deadline) {
             let new_access_token = timeout(
                 *connection_timeout,
                 refresh_access_token(&mut self.auth_client, &self.refresh_token),
@@ -92,6 +86,14 @@ impl AuthRefreshState {
             Ok((false, false))
         }
     }
+}
+
+fn expires_by(token: &Token, deadline: i64) -> bool {
+    // Keep protobuf seconds signed so already-expired timestamps cannot wrap into the future.
+    token
+        .expires_at_utc
+        .as_ref()
+        .is_none_or(|ts| ts.seconds <= deadline)
 }
 
 /// Interceptor responsible for adding the access token to request headers.
@@ -217,17 +219,50 @@ async fn refresh_access_token(
     get_validated_token(response.into_inner().access_token)
 }
 
-/// An invalid token is one where any of its fields are None or the token itself is None.
-/// Performs the necessary validations on the auth tokens before returning,
-/// i.e. it is safe to call .unwrap() on the token fields from the call-site.
+/// Reject malformed auth responses before publishing a token to the interceptor.
 fn get_validated_token(maybe_token: Option<Token>) -> crate::proxy::Result<Token> {
     let token = maybe_token
         .ok_or_else(|| ProxyError::BadAuthenticationToken("received a null token".to_string()))?;
-    if token.expires_at_utc.is_none() {
+    if token.value.is_empty() {
+        Err(ProxyError::BadAuthenticationToken(
+            "token value is empty".to_string(),
+        ))
+    } else if token.expires_at_utc.is_none() {
         Err(ProxyError::BadAuthenticationToken(
             "expires_at_utc field is null".to_string(),
         ))
     } else {
         Ok(token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn token(value: &str, expires_at: i64) -> Token {
+        let mut token = Token {
+            value: value.to_string(),
+            ..Token::default()
+        };
+        token.expires_at_utc.get_or_insert_default().seconds = expires_at;
+        token
+    }
+
+    #[test]
+    fn expiry_is_signed_and_inclusive() {
+        for (expires_at, expected) in [(-1, true), (10, true), (11, false)] {
+            assert_eq!(expires_by(&token("token", expires_at), 10), expected);
+        }
+    }
+
+    #[test]
+    fn token_requires_value_and_expiry() {
+        assert!(get_validated_token(Some(token("token", 1))).is_ok());
+        let mut missing_expiry = token("token", 1);
+        missing_expiry.expires_at_utc = None;
+        for invalid in [None, Some(token("", 1)), Some(missing_expiry)] {
+            assert!(get_validated_token(invalid).is_err());
+        }
     }
 }

--- a/core/src/proxy/auth.rs
+++ b/core/src/proxy/auth.rs
@@ -8,6 +8,7 @@ use {
     },
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
+    solana_pubkey::Pubkey,
     solana_signer::Signer,
     std::{sync::Arc, time::Duration},
     tokio::time::timeout,
@@ -17,6 +18,52 @@ use {
         transport::{Channel, Endpoint},
     },
 };
+
+pub(crate) struct AuthRefreshState {
+    auth_client: AuthServiceClient<Channel>,
+    access_token: Arc<ArcSwap<Token>>,
+    refresh_token: Token,
+    identity: Pubkey,
+}
+
+impl AuthRefreshState {
+    pub(crate) fn access_token(&self) -> Arc<ArcSwap<Token>> {
+        self.access_token.clone()
+    }
+
+    pub(crate) async fn maybe_refresh(
+        &mut self,
+        cluster_info: &Arc<ClusterInfo>,
+        connection_timeout: &Duration,
+        refresh_within_s: u64,
+    ) -> crate::proxy::Result<(bool, bool)> {
+        if cluster_info.id() != self.identity {
+            return Err(ProxyError::AuthenticationConnectionError(
+                "validator identity changed".to_string(),
+            ));
+        }
+
+        let (new_access_token, new_refresh_token) = maybe_refresh_auth_tokens(
+            &mut self.auth_client,
+            &self.access_token,
+            &self.refresh_token,
+            cluster_info,
+            connection_timeout,
+            refresh_within_s,
+        )
+        .await?;
+
+        let access_token_refreshed = new_access_token.is_some();
+        if let Some(new_access_token) = new_access_token {
+            self.access_token.store(Arc::new(new_access_token));
+        }
+        let refresh_token_refreshed = new_refresh_token.is_some();
+        if let Some(new_refresh_token) = new_refresh_token {
+            self.refresh_token = new_refresh_token;
+        }
+        Ok((access_token_refreshed, refresh_token_refreshed))
+    }
+}
 
 /// Interceptor responsible for adding the access token to request headers.
 pub(crate) struct AuthInterceptor {
@@ -47,7 +94,7 @@ pub(crate) async fn auth_client_from_endpoint(
     endpoint: &Endpoint,
     connection_timeout: &Duration,
     keypair: &Keypair,
-) -> crate::proxy::Result<(AuthServiceClient<Channel>, Arc<ArcSwap<Token>>, Token)> {
+) -> crate::proxy::Result<AuthRefreshState> {
     let mut auth_client = AuthServiceClient::new(
         timeout(*connection_timeout, endpoint.connect())
             .await
@@ -64,11 +111,12 @@ pub(crate) async fn auth_client_from_endpoint(
     )
     .await
     .map_err(|_| ProxyError::AuthenticationTimeout)??;
-    Ok((
+    Ok(AuthRefreshState {
         auth_client,
-        Arc::new(ArcSwap::from_pointee(access_token)),
+        access_token: Arc::new(ArcSwap::from_pointee(access_token)),
         refresh_token,
-    ))
+        identity: keypair.pubkey(),
+    })
 }
 
 /// Generates an auth challenge then generates and returns validated auth tokens.

--- a/core/src/proxy/block_engine_stage.rs
+++ b/core/src/proxy/block_engine_stage.rs
@@ -12,7 +12,7 @@ use {
         proto_packet_to_packet,
         proxy::{
             ProxyError,
-            auth::{AuthInterceptor, auth_client_from_endpoint, maybe_refresh_auth_tokens},
+            auth::{AuthInterceptor, AuthRefreshState, auth_client_from_endpoint},
             endpoint_from_url, sanitize_status_message_for_influx,
         },
     },
@@ -20,18 +20,13 @@ use {
     arc_swap::ArcSwap,
     crossbeam_channel::Sender,
     itertools::Itertools,
-    jito_protos::proto::{
-        auth::{Token, auth_service_client::AuthServiceClient},
-        block_engine::{
-            self, BlockBuilderFeeInfoRequest, BlockEngineEndpoint, GetBlockEngineEndpointRequest,
-            block_engine_validator_client::BlockEngineValidatorClient,
-        },
+    jito_protos::proto::block_engine::{
+        self, BlockBuilderFeeInfoRequest, BlockEngineEndpoint, GetBlockEngineEndpointRequest,
+        block_engine_validator_client::BlockEngineValidatorClient,
     },
     solana_gossip::cluster_info::ClusterInfo,
-    solana_keypair::Keypair,
     solana_perf::packet::{BytesPacket, PacketBatch},
     solana_pubkey::Pubkey,
-    solana_signer::Signer,
     std::{
         collections::hash_map::Entry,
         net::{SocketAddr, ToSocketAddrs},
@@ -473,7 +468,7 @@ impl BlockEngineStage {
         let keypair = cluster_info.keypair().clone();
 
         debug!("connecting to auth: {}", backend_endpoint.uri());
-        let (auth_client, access_token, refresh_token) =
+        let auth_refresh_state =
             auth_client_from_endpoint(backend_endpoint, connection_timeout, keypair.as_ref())
                 .await
                 .map_err(|err| Self::map_bam_enabled(bam_enabled, err))?;
@@ -498,7 +493,7 @@ impl BlockEngineStage {
             })?;
         let block_engine_client = BlockEngineValidatorClient::with_interceptor(
             block_engine_channel,
-            AuthInterceptor::new(access_token.clone()),
+            AuthInterceptor::new(auth_refresh_state.access_token()),
         );
         datapoint_info!(
             "block_engine_stage-connected",
@@ -517,11 +512,8 @@ impl BlockEngineStage {
             block_builder_fee_info,
             shredstream_receiver_address,
             maybe_shredstream_socket,
-            auth_client,
-            access_token,
-            refresh_token,
+            auth_refresh_state,
             connection_timeout,
-            keypair,
             cluster_info,
             &backend_url,
             bam_enabled,
@@ -740,11 +732,8 @@ impl BlockEngineStage {
         block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         shredstream_receiver_address: &ArcSwap<Option<SocketAddr>>,
         maybe_shredstream_socket: Option<SocketAddr>,
-        auth_client: AuthServiceClient<Channel>,
-        access_token: Arc<ArcSwap<Token>>,
-        refresh_token: Token,
+        auth_refresh_state: AuthRefreshState,
         connection_timeout: &Duration,
-        keypair: Arc<Keypair>,
         cluster_info: &Arc<ClusterInfo>,
         block_engine_url: &str,
         bam_enabled: &Arc<AtomicU8>,
@@ -808,10 +797,7 @@ impl BlockEngineStage {
             banking_packet_sender,
             exit,
             block_builder_fee_info,
-            auth_client,
-            access_token,
-            refresh_token,
-            keypair,
+            auth_refresh_state,
             cluster_info,
             connection_timeout,
             block_engine_url,
@@ -834,10 +820,7 @@ impl BlockEngineStage {
         banking_packet_sender: &BankingPacketSender,
         exit: &Arc<AtomicBool>,
         block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
-        mut auth_client: AuthServiceClient<Channel>,
-        access_token: Arc<ArcSwap<Token>>,
-        mut refresh_token: Token,
-        keypair: Arc<Keypair>,
+        mut auth_refresh_state: AuthRefreshState,
         cluster_info: &Arc<ClusterInfo>,
         connection_timeout: &Duration,
         block_engine_url: &str,
@@ -880,24 +863,16 @@ impl BlockEngineStage {
                     block_engine_stats.report();
                     block_engine_stats = BlockEngineStageStats::default();
 
-                    if cluster_info.id() != keypair.pubkey() {
-                        return Err(ProxyError::AuthenticationConnectionError("validator identity changed".to_string()));
-                    }
-
                     if global_config.load().as_ref() != local_config {
                         return Err(ProxyError::BlockEngineConfigChanged);
                     }
 
-                    let (maybe_new_access, maybe_new_refresh) = maybe_refresh_auth_tokens(&mut auth_client,
-                        &access_token,
-                        &refresh_token,
-                        cluster_info,
-                        connection_timeout,
-                        refresh_within_s,
-                    ).await
-                    .map_err(|err| Self::map_bam_enabled(bam_enabled, err))?;
+                    let (access_token_refreshed, refresh_token_refreshed) = auth_refresh_state
+                        .maybe_refresh(cluster_info, connection_timeout, refresh_within_s)
+                        .await
+                        .map_err(|err| Self::map_bam_enabled(bam_enabled, err))?;
 
-                    if let Some(new_token) = maybe_new_access {
+                    if access_token_refreshed {
                         num_refresh_access_token += 1;
                         datapoint_info!(
                             "block_engine_stage-refresh_access_token",
@@ -905,16 +880,14 @@ impl BlockEngineStage {
                             ("count", num_refresh_access_token, i64),
                         );
 
-                        access_token.store(Arc::new(new_token));
                     }
-                    if let Some(new_token) = maybe_new_refresh {
+                    if refresh_token_refreshed {
                         num_full_refreshes += 1;
                         datapoint_info!(
                             "block_engine_stage-tokens_generated",
                             ("url", &block_engine_url, String),
                             ("count", num_full_refreshes, i64),
                         );
-                        refresh_token = new_token;
                     }
                 }
                 _ = maintenance_tick.tick() => {

--- a/core/src/proxy/block_engine_stage.rs
+++ b/core/src/proxy/block_engine_stage.rs
@@ -465,7 +465,7 @@ impl BlockEngineStage {
         bam_enabled: &Arc<AtomicU8>,
     ) -> crate::proxy::Result<()> {
         // Get a copy of configs here in case they have changed at runtime
-        let keypair = cluster_info.keypair().clone();
+        let keypair = cluster_info.keypair();
 
         debug!("connecting to auth: {}", backend_endpoint.uri());
         let auth_refresh_state =
@@ -493,7 +493,7 @@ impl BlockEngineStage {
             })?;
         let block_engine_client = BlockEngineValidatorClient::with_interceptor(
             block_engine_channel,
-            AuthInterceptor::new(auth_refresh_state.access_token()),
+            auth_refresh_state.interceptor(),
         );
         datapoint_info!(
             "block_engine_stage-connected",
@@ -863,6 +863,8 @@ impl BlockEngineStage {
                     block_engine_stats.report();
                     block_engine_stats = BlockEngineStageStats::default();
 
+                    auth_refresh_state.validate_identity(cluster_info.id())?;
+
                     if global_config.load().as_ref() != local_config {
                         return Err(ProxyError::BlockEngineConfigChanged);
                     }
@@ -879,7 +881,6 @@ impl BlockEngineStage {
                             ("url", &block_engine_url, String),
                             ("count", num_refresh_access_token, i64),
                         );
-
                     }
                     if refresh_token_refreshed {
                         num_full_refreshes += 1;

--- a/core/src/proxy/relayer_stage.rs
+++ b/core/src/proxy/relayer_stage.rs
@@ -13,20 +13,15 @@ use {
         proto_packet_to_packet,
         proxy::{
             HeartbeatEvent, ProxyError,
-            auth::{AuthInterceptor, auth_client_from_endpoint, maybe_refresh_auth_tokens},
+            auth::{AuthInterceptor, AuthRefreshState, auth_client_from_endpoint},
             endpoint_from_url,
         },
     },
     arc_swap::ArcSwap,
     crossbeam_channel::Sender,
-    jito_protos::proto::{
-        auth::{Token, auth_service_client::AuthServiceClient},
-        relayer::{self, relayer_client::RelayerClient},
-    },
+    jito_protos::proto::relayer::{self, relayer_client::RelayerClient},
     solana_gossip::cluster_info::ClusterInfo,
-    solana_keypair::Keypair,
     solana_perf::packet::{BytesPacket, PacketBatch},
-    solana_signer::Signer,
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
         ops::AddAssign,
@@ -188,7 +183,7 @@ impl RelayerStage {
         let backend_endpoint = Self::get_endpoint(&local_relayer_config.relayer_url)?;
 
         debug!("connecting to auth: {}", local_relayer_config.relayer_url);
-        let (auth_client, access_token, refresh_token) =
+        let auth_refresh_state =
             auth_client_from_endpoint(&backend_endpoint, connection_timeout, keypair.as_ref())
                 .await?;
 
@@ -197,7 +192,6 @@ impl RelayerStage {
             ("url", local_relayer_config.relayer_url, String),
             ("count", 1, i64),
         );
-
         debug!(
             "connecting to relayer: {}",
             local_relayer_config.relayer_url
@@ -212,7 +206,7 @@ impl RelayerStage {
             })?;
         let relayer_client = RelayerClient::with_interceptor(
             relayer_channel,
-            AuthInterceptor::new(access_token.clone()),
+            AuthInterceptor::new(auth_refresh_state.access_token()),
         );
 
         Self::start_consuming_relayer_packets(
@@ -222,10 +216,7 @@ impl RelayerStage {
             local_relayer_config,
             global_relayer_config,
             exit,
-            auth_client,
-            access_token,
-            refresh_token,
-            keypair,
+            auth_refresh_state,
             cluster_info,
             connection_timeout,
         )
@@ -240,10 +231,7 @@ impl RelayerStage {
         local_config: &RelayerConfig, // local copy of config with current connections
         global_config: &Arc<ArcSwap<RelayerConfig>>, // guarded reference for detecting run-time updates
         exit: &Arc<AtomicBool>,
-        auth_client: AuthServiceClient<Channel>,
-        access_token: Arc<ArcSwap<Token>>,
-        refresh_token: Token,
-        keypair: Arc<Keypair>,
+        auth_refresh_state: AuthRefreshState,
         cluster_info: &Arc<ClusterInfo>,
         connection_timeout: &Duration,
     ) -> crate::proxy::Result<()> {
@@ -295,10 +283,7 @@ impl RelayerStage {
             local_config,
             global_config,
             exit,
-            auth_client,
-            access_token,
-            refresh_token,
-            keypair,
+            auth_refresh_state,
             cluster_info,
             connection_timeout,
         )
@@ -314,10 +299,7 @@ impl RelayerStage {
         local_config: &RelayerConfig, // local copy of config with current connections
         global_config: &Arc<ArcSwap<RelayerConfig>>, // guarded reference for detecting run-time updates
         exit: &Arc<AtomicBool>,
-        mut auth_client: AuthServiceClient<Channel>,
-        access_token: Arc<ArcSwap<Token>>,
-        mut refresh_token: Token,
-        keypair: Arc<Keypair>,
+        mut auth_refresh_state: AuthRefreshState,
         cluster_info: &Arc<ClusterInfo>,
         connection_timeout: &Duration,
     ) -> crate::proxy::Result<()> {
@@ -352,23 +334,15 @@ impl RelayerStage {
                     relayer_stats.report();
                     relayer_stats = RelayerStageStats::default();
 
-                    if cluster_info.id() != keypair.pubkey() {
-                        return Err(ProxyError::AuthenticationConnectionError("validator identity changed".to_string()));
-                    }
-
                     if global_config.load().as_ref() != local_config {
                         return Err(ProxyError::AuthenticationConnectionError("relayer config changed".to_string()));
                     }
 
-                    let (maybe_new_access, maybe_new_refresh) = maybe_refresh_auth_tokens(&mut auth_client,
-                        &access_token,
-                        &refresh_token,
-                        cluster_info,
-                        connection_timeout,
-                        refresh_within_s,
-                    ).await?;
+                    let (access_token_refreshed, refresh_token_refreshed) = auth_refresh_state
+                        .maybe_refresh(cluster_info, connection_timeout, refresh_within_s)
+                        .await?;
 
-                    if let Some(new_token) = maybe_new_access {
+                    if access_token_refreshed {
                         num_refresh_access_token += 1;
                         datapoint_info!(
                             "relayer_stage-refresh_access_token",
@@ -376,16 +350,14 @@ impl RelayerStage {
                             ("count", num_refresh_access_token, i64),
                         );
 
-                        access_token.store(Arc::new(new_token));
                     }
-                    if let Some(new_token) = maybe_new_refresh {
+                    if refresh_token_refreshed {
                         num_full_refreshes += 1;
                         datapoint_info!(
                             "relayer_stage-tokens_generated",
                             ("url", &local_config.relayer_url, String),
                             ("count", num_full_refreshes, i64),
                         );
-                        refresh_token = new_token;
                     }
                 }
             }

--- a/core/src/proxy/relayer_stage.rs
+++ b/core/src/proxy/relayer_stage.rs
@@ -179,7 +179,7 @@ impl RelayerStage {
         connection_timeout: &Duration,
     ) -> crate::proxy::Result<()> {
         // Get a copy of configs here in case they have changed at runtime
-        let keypair = cluster_info.keypair().clone();
+        let keypair = cluster_info.keypair();
         let backend_endpoint = Self::get_endpoint(&local_relayer_config.relayer_url)?;
 
         debug!("connecting to auth: {}", local_relayer_config.relayer_url);
@@ -204,10 +204,8 @@ impl RelayerStage {
                     crate::proxy::sanitize_status_message_for_influx(&err.to_string()),
                 )
             })?;
-        let relayer_client = RelayerClient::with_interceptor(
-            relayer_channel,
-            AuthInterceptor::new(auth_refresh_state.access_token()),
-        );
+        let relayer_client =
+            RelayerClient::with_interceptor(relayer_channel, auth_refresh_state.interceptor());
 
         Self::start_consuming_relayer_packets(
             relayer_client,
@@ -334,6 +332,8 @@ impl RelayerStage {
                     relayer_stats.report();
                     relayer_stats = RelayerStageStats::default();
 
+                    auth_refresh_state.validate_identity(cluster_info.id())?;
+
                     if global_config.load().as_ref() != local_config {
                         return Err(ProxyError::AuthenticationConnectionError("relayer config changed".to_string()));
                     }
@@ -349,7 +349,6 @@ impl RelayerStage {
                             ("url", &local_config.relayer_url, String),
                             ("count", num_refresh_access_token, i64),
                         );
-
                     }
                     if refresh_token_refreshed {
                         num_full_refreshes += 1;


### PR DESCRIPTION
## What changed

- add `AuthRefreshState` to own the auth client, access token, refresh token, and authenticated validator identity
- centralize identity validation, token refresh, and token replacement
- pass one refresh state through Block Engine and relayer stream setup instead of four separate values
- keep service-specific config checks, counters, datapoint names, select loops, and reconnect behavior local

## Why

The two proxy stages duplicated the security-sensitive refresh core while having genuinely different stream and reconnect policies. Sharing only the auth state removes that duplication without introducing a generic stream driver.
