### PR TITLE
Deploy tip programs in local-cluster genesis and drop obsolete SIMD-406 test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -73,6 +73,10 @@ filter = 'package(solana-local-cluster) & test(/^test_boot_from_local_state$/)'
 slow-timeout = { period = "60s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_duplicate_shreds_broadcast_leader$/)'
+slow-timeout = { period = "60s", terminate-after = 10 }
+
+[[profile.ci.overrides]]
 filter = 'package(solana-local-cluster)'
 slow-timeout = { period = "60s", terminate-after = 2 }
 

--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -665,7 +665,7 @@ fn default_local_cluster_step(parallel: u64) -> buildkite::Step {
                     String::from("queue"),
                     String::from("default"),
                 )])),
-                timeout_in_minutes: Some(15),
+                timeout_in_minutes: Some(30),
                 retry: Some(HashMap::from([(
                     String::from("automatic"),
                     String::from("true"),

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -967,9 +967,16 @@ mod tests {
         solana_program_binaries::{jito_tip_distribution, jito_tip_payment, spl_programs},
         solana_rent::Rent,
         solana_runtime::genesis_utils::create_genesis_config_with_leader_ex,
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_signer::Signer,
+        solana_svm::{
+            transaction_commit_result::TransactionCommitResultExtensions,
+            transaction_processor::ExecutionRecordingConfig,
+        },
+        solana_svm_timings::ExecuteTimings,
         solana_system_transaction::transfer,
         solana_time_utils::timestamp,
+        solana_transaction::sanitized::SanitizedTransaction,
         solana_vote_interface::state::vote_state_v4::VoteStateV4,
     };
 
@@ -979,11 +986,25 @@ mod tests {
     }
 
     fn create_genesis_config(mint_sol: u64) -> TestFixture {
+        create_genesis_config_with_rent(
+            mint_sol,
+            Rent::default(),
+            FeeRateGovernor {
+                // Initialize with a non-zero fee
+                lamports_per_signature: DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE / 2,
+                ..FeeRateGovernor::default()
+            },
+        )
+    }
+
+    fn create_genesis_config_with_rent(
+        mint_sol: u64,
+        rent: Rent,
+        fee_rate_governor: FeeRateGovernor,
+    ) -> TestFixture {
         let mint_keypair = Keypair::new();
         let leader_keypair = Keypair::new();
         let voting_keypair = Keypair::new();
-
-        let rent = Rent::default();
 
         let mut genesis_config = create_genesis_config_with_leader_ex(
             mint_sol * LAMPORTS_PER_SOL,
@@ -994,12 +1015,8 @@ mod tests {
             None,
             rent.minimum_balance(VoteStateV4::size_of()) + (LAMPORTS_PER_SOL * 1_000_000),
             LAMPORTS_PER_SOL * 1_000_000,
-            FeeRateGovernor {
-                // Initialize with a non-zero fee
-                lamports_per_signature: DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE / 2,
-                ..FeeRateGovernor::default()
-            },
-            rent.clone(), // most tests don't expect rent
+            fee_rate_governor,
+            rent.clone(),
             ClusterType::Development,
             &FeatureSet::all_enabled(),
             spl_programs(&rent),
@@ -1015,6 +1032,54 @@ mod tests {
             },
             leader_keypair,
         }
+    }
+
+    fn execute_tip_program_maintenance(
+        bank: &Bank,
+        leader_keypair: &Keypair,
+        vote_account: Pubkey,
+    ) -> (
+        bool,
+        bool,
+        crate::tip_manager::Result<SmallVec<[RuntimeTransaction<SanitizedTransaction>; 2]>>,
+    ) {
+        let tip_manager = TipManager::new(TipManagerConfig {
+            tip_payment_program_id: Pubkey::from(jito_tip_payment::id().to_bytes()),
+            tip_distribution_program_id: Pubkey::from(jito_tip_distribution::id().to_bytes()),
+            tip_distribution_account_config: TipDistributionAccountConfig {
+                merkle_root_upload_authority: leader_keypair.pubkey(),
+                vote_account,
+                commission_bps: 10,
+            },
+        });
+
+        let init_txs = tip_manager
+            .get_initialize_tip_programs_bundle(bank, leader_keypair)
+            .unwrap();
+        let batch = bank.prepare_sanitized_batch(&init_txs);
+        let (results, _) = bank.load_execute_and_commit_transactions(
+            &batch,
+            ExecutionRecordingConfig::new_single_setting(true),
+            &mut ExecuteTimings::default(),
+            None,
+        );
+        drop(batch);
+
+        let init_executed_ok = results.iter().all(|r| r.was_executed_successfully());
+        assert!(init_executed_ok, "tip program init failed: {results:?}");
+        let config_account_exists = bank
+            .get_account(&tip_manager.tip_payment_config_pubkey())
+            .is_some();
+        let crank = tip_manager.get_tip_programs_crank_bundle(
+            bank,
+            leader_keypair,
+            &BlockBuilderFeeInfo {
+                block_builder: leader_keypair.pubkey(),
+                block_builder_commission: 0,
+            },
+        );
+
+        (init_executed_ok, config_account_exists, crank)
     }
 
     #[test]
@@ -1081,6 +1146,70 @@ mod tests {
         assert_eq!(
             bam_enabled.load(Ordering::Acquire),
             BamConnectionState::Connected as u8
+        );
+    }
+
+    #[test]
+    fn test_tip_program_accounts_dropped_when_genesis_rent_is_free() {
+        // Local-cluster genesis historically used Rent::free() + zero fees. Tip
+        // program init then creates 0-lamport PDAs, which accounts-db drops, so
+        // BundleStage's follow-up crank fails with AccountMissing every poll.
+        let TestFixture {
+            genesis_config_info,
+            leader_keypair,
+        } = create_genesis_config_with_rent(2, Rent::free(), FeeRateGovernor::new(0, 0));
+        let (bank, bank_forks) =
+            Bank::new_with_bank_forks_for_tests(&genesis_config_info.genesis_config);
+        let bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), 1);
+        bank_forks.write().unwrap().insert(bank);
+        let bank = bank_forks.read().unwrap().working_bank();
+
+        let (init_committed_ok, config_account_exists, crank) = execute_tip_program_maintenance(
+            &bank,
+            &leader_keypair,
+            genesis_config_info.voting_keypair.pubkey(),
+        );
+
+        assert!(init_committed_ok, "init transactions should commit");
+        assert!(
+            !config_account_exists,
+            "0-lamport tip-payment config must not persist under Rent::free()"
+        );
+        assert!(
+            matches!(
+                crank,
+                Err(crate::tip_manager::TipManagerError::AccountMissing)
+            ),
+            "crank must fail after the config PDA is dropped: {crank:?}"
+        );
+    }
+
+    #[test]
+    fn test_tip_program_accounts_persist_with_default_rent_and_zero_fees() {
+        let TestFixture {
+            genesis_config_info,
+            leader_keypair,
+        } = create_genesis_config_with_rent(2, Rent::default(), FeeRateGovernor::new(0, 0));
+        let (bank, bank_forks) =
+            Bank::new_with_bank_forks_for_tests(&genesis_config_info.genesis_config);
+        let bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), 1);
+        bank_forks.write().unwrap().insert(bank);
+        let bank = bank_forks.read().unwrap().working_bank();
+
+        let (init_committed_ok, config_account_exists, crank) = execute_tip_program_maintenance(
+            &bank,
+            &leader_keypair,
+            genesis_config_info.voting_keypair.pubkey(),
+        );
+
+        assert!(init_committed_ok, "init transactions should commit");
+        assert!(
+            config_account_exists,
+            "tip-payment config must persist when genesis rent is non-zero"
+        );
+        assert!(
+            crank.is_ok(),
+            "crank should build after a persisted init: {crank:?}"
         );
     }
 

--- a/core/src/bundle_stage.rs
+++ b/core/src/bundle_stage.rs
@@ -623,7 +623,7 @@ impl BundleStage {
         let mut bundles = VecDeque::with_capacity(BUNDLE_WINDOW_SIZE.get());
 
         if bank.slot() != *last_tip_update_slot {
-            if Self::handle_tip_programs(
+            match Self::handle_tip_programs(
                 bank,
                 bundle_account_locker,
                 consumer,
@@ -631,15 +631,24 @@ impl BundleStage {
                 cluster_info,
                 block_builder_fee_info,
                 consume_worker_metrics,
-            )
-            .is_err()
-            {
-                bundle_stage_metrics.increment_tip_programs_error(1);
-                error!("tip programs error, not processing bundles");
-                return;
+            ) {
+                Ok(()) => {
+                    *last_tip_update_slot = bank.slot();
+                }
+                Err(BundleExecutionError::ErrorRetryable) => {
+                    bundle_stage_metrics.increment_tip_programs_error(1);
+                    error!("tip programs error, not processing bundles");
+                    return;
+                }
+                Err(err) => {
+                    // Instruction failures and missing accounts will not succeed on retry
+                    // in this slot. Advance so we do not tight-loop every 10ms poll.
+                    bundle_stage_metrics.increment_tip_programs_error(1);
+                    error!("tip programs error, not processing bundles: {err:?}");
+                    *last_tip_update_slot = bank.slot();
+                    return;
+                }
             }
-
-            *last_tip_update_slot = bank.slot();
         }
 
         // This loop shall:
@@ -727,6 +736,15 @@ impl BundleStage {
         block_builder_fee_info: &Arc<ArcSwap<BlockBuilderFeeInfo>>,
         consume_worker_metrics: &ConsumeWorkerMetrics,
     ) -> BundleExecutionResult<()> {
+        // Tip programs fund PDAs with Rent::get().minimum_balance(). When rent is
+        // free (local-cluster), that is 0 lamports and accounts-db drops the
+        // accounts, so init/crank can never succeed. Skip instead of retrying
+        // doomed work every poll.
+        if bank.rent_collector().rent.minimum_balance(0) == 0 {
+            debug!("skipping tip program init/crank because rent is free");
+            return Ok(());
+        }
+
         let keypair = cluster_info.keypair();
 
         Self::handle_initialize_tip_programs(
@@ -1151,9 +1169,9 @@ mod tests {
 
     #[test]
     fn test_tip_program_accounts_dropped_when_genesis_rent_is_free() {
-        // Local-cluster genesis historically used Rent::free() + zero fees. Tip
-        // program init then creates 0-lamport PDAs, which accounts-db drops, so
-        // BundleStage's follow-up crank fails with AccountMissing every poll.
+        // Local-cluster genesis uses Rent::free() + zero fees. Tip program init
+        // then creates 0-lamport PDAs, which accounts-db drops, so crank fails
+        // with AccountMissing. BundleStage skips init/crank in that environment.
         let TestFixture {
             genesis_config_info,
             leader_keypair,

--- a/core/src/bundle_stage/bundle_consumer.rs
+++ b/core/src/bundle_stage/bundle_consumer.rs
@@ -484,7 +484,6 @@ mod tests {
             },
             bundle_stage::bundle_consumer::BundleConsumer,
         },
-        agave_feature_set::limit_instruction_accounts,
         crossbeam_channel::unbounded,
         solana_cost_model::cost_model::CostModel,
         solana_entry::entry::Entry,
@@ -495,7 +494,6 @@ mod tests {
             GenesisConfigInfo, bootstrap_validator_stake_lamports,
             create_genesis_config_with_leader,
         },
-        solana_message::{Message, compiled_instruction::CompiledInstruction},
         solana_poh::{
             poh_recorder::PohRecorderError, record_channels::record_channels,
             transaction_recorder::TransactionRecorder,
@@ -681,90 +679,6 @@ mod tests {
         assert_eq!(bank.get_balance(&recipient), 0);
         assert!(record_receiver.try_recv().is_err());
         assert_eq!(bank.read_cost_tracker().unwrap().block_cost(), 0);
-    }
-
-    #[test]
-    fn test_resanitizes_instruction_account_limit_after_epoch_change() {
-        let GenesisConfigInfo {
-            genesis_config,
-            mint_keypair,
-            ..
-        } = create_genesis_config_with_leader(
-            10_000,
-            &Pubkey::new_unique(),
-            bootstrap_validator_stake_lamports(),
-        );
-        let mut sanitizing_bank = Bank::new_for_tests(&genesis_config);
-        sanitizing_bank.deactivate_feature(&limit_instruction_accounts::id());
-
-        let recent_blockhash = sanitizing_bank.last_blockhash();
-        let mut account_keys = vec![Pubkey::new_unique(); 10];
-        account_keys.insert(0, mint_keypair.pubkey());
-        let instruction = CompiledInstruction {
-            program_id_index: 1,
-            data: vec![],
-            accounts: (0..10).cycle().take(256).collect(),
-        };
-        let message = Message::new_with_compiled_instructions(
-            1,
-            0,
-            1,
-            account_keys,
-            recent_blockhash,
-            vec![instruction],
-        );
-        let transaction = sanitizing_bank
-            .verify_transaction(
-                Transaction::new(&[&mint_keypair], message, recent_blockhash).into(),
-                TransactionVerificationMode::FullVerification,
-            )
-            .unwrap();
-        let sanitized_epoch = sanitizing_bank.epoch();
-        let next_epoch_slot = sanitizing_bank
-            .epoch_schedule()
-            .get_first_slot_in_epoch(sanitized_epoch + 1);
-        let (sanitizing_bank, _bank_forks) = sanitizing_bank.wrap_with_bank_forks_for_tests();
-        let mut bank =
-            Bank::new_from_parent(sanitizing_bank, SlotLeader::new_unique(), next_epoch_slot);
-        bank.activate_feature(&limit_instruction_accounts::id());
-        assert_ne!(bank.epoch(), sanitized_epoch);
-        assert!(
-            bank.feature_set
-                .is_active(&limit_instruction_accounts::id())
-        );
-
-        let (record_sender, mut record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.bank_id());
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-        let committer = Committer::new(
-            None,
-            replay_vote_sender,
-            Some(Arc::new(PrioritizationFeeCache::new(0u64))),
-        );
-        let mut consumer = BundleConsumer::new(committer, recorder, None);
-
-        let output = consumer.process_and_record_aged_transactions(
-            &bank,
-            &[transaction],
-            &[MaxAge {
-                sanitized_epoch,
-                alt_invalidation_slot: u64::MAX,
-            }],
-            Duration::from_millis(20),
-        );
-
-        assert_matches!(
-            output
-                .execute_and_commit_transactions_output
-                .commit_transactions_result
-                .unwrap()
-                .as_slice(),
-            [CommitTransactionDetails::NotCommitted(
-                TransactionError::SanitizeFailure
-            )]
-        );
-        assert!(record_receiver.try_recv().is_err());
     }
 
     #[test]

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -341,11 +341,6 @@ impl LocalCluster {
             mint_account.lamports -= additional_validator_funding;
         }
 
-        // Tip programs create PDAs with Rent::get().minimum_balance(). Rent::free()
-        // (the genesis helper default) yields 0-lamport accounts, which accounts-db
-        // drops. BundleStage then fails crank with AccountMissing every 10ms poll.
-        genesis_config.rent = Rent::default();
-
         genesis_config.accounts.extend(
             config
                 .additional_accounts

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -341,6 +341,11 @@ impl LocalCluster {
             mint_account.lamports -= additional_validator_funding;
         }
 
+        // Tip programs create PDAs with Rent::get().minimum_balance(). Rent::free()
+        // (the genesis helper default) yields 0-lamport accounts, which accounts-db
+        // drops. BundleStage then fails crank with AccountMissing every 10ms poll.
+        genesis_config.rent = Rent::default();
+
         genesis_config.accounts.extend(
             config
                 .additional_accounts

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -17,6 +17,7 @@ use {
     solana_commitment_config::CommitmentConfig,
     solana_core::{
         consensus::tower_storage::FileTowerStorage,
+        tip_manager::{TipDistributionAccountConfig, TipManagerConfig},
         validator::{Validator, ValidatorConfig, ValidatorStartProgress, ValidatorTpuConfig},
     },
     solana_epoch_schedule::EpochSchedule,
@@ -33,7 +34,9 @@ use {
     solana_native_token::LAMPORTS_PER_SOL,
     solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
     solana_poh_config::PohConfig,
-    solana_program_binaries::core_bpf_programs,
+    solana_program_binaries::{
+        core_bpf_programs, jito_tip_distribution, jito_tip_payment, spl_programs,
+    },
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_rpc_client::rpc_client::RpcClient,
@@ -192,6 +195,23 @@ impl LocalCluster {
         }
     }
 
+    /// Point TipManager at the tip programs deployed from genesis via `spl_programs`.
+    fn configure_tip_manager(
+        config: &mut ValidatorConfig,
+        identity: &Pubkey,
+        vote_account: &Pubkey,
+    ) {
+        config.tip_manager_config = TipManagerConfig {
+            tip_payment_program_id: jito_tip_payment::id(),
+            tip_distribution_program_id: jito_tip_distribution::id(),
+            tip_distribution_account_config: TipDistributionAccountConfig {
+                merkle_root_upload_authority: *identity,
+                vote_account: *vote_account,
+                commission_bps: 10,
+            },
+        };
+    }
+
     pub fn new(config: &mut ClusterConfig, socket_addr_space: SocketAddrSpace) -> Self {
         Self::init(config, socket_addr_space, AlpenglowMode::Disabled)
     }
@@ -223,6 +243,9 @@ impl LocalCluster {
             config
                 .additional_accounts
                 .push(core_program_account.clone());
+        }
+        for program_account in spl_programs(&Rent::default()) {
+            config.additional_accounts.push(program_account);
         }
 
         // Mint used to fund validator identities for non-genesis accounts.
@@ -404,6 +427,11 @@ impl LocalCluster {
                     .iter()
                     .all(|cfg| cfg.wait_for_supermajority.is_none()),
                 "Cannot partially specify WFSM in local cluster"
+            );
+            Self::configure_tip_manager(
+                &mut leader_config,
+                &leader_keypair.pubkey(),
+                &leader_vote_keypair.pubkey(),
             );
             let leader_server = Validator::new(
                 leader_node,
@@ -611,6 +639,7 @@ impl LocalCluster {
             validator_node.info.rpc_pubsub().unwrap(),
         ));
         Self::sync_ledger_path_across_nested_config_fields(&mut config, &ledger_path);
+        Self::configure_tip_manager(&mut config, &validator_pubkey, &voting_keypair.pubkey());
         let validator_server = Validator::new(
             validator_node,
             validator_keypair.clone(),
@@ -664,7 +693,7 @@ impl LocalCluster {
         let (
             leader_pubkey,
             leader_node,
-            leader_config,
+            mut leader_config,
             leader_keypair,
             leader_vote_keypair,
             leader_ledger_path,
@@ -676,6 +705,11 @@ impl LocalCluster {
         let handle = std::thread::spawn(move || {
             info!("Starting boostrap {leader_pubkey}");
 
+            Self::configure_tip_manager(
+                &mut leader_config,
+                &leader_keypair.pubkey(),
+                &leader_vote_keypair.pubkey(),
+            );
             let leader_server = Validator::new(
                 leader_node,
                 leader_keypair.clone(),
@@ -735,6 +769,11 @@ impl LocalCluster {
                     validator_node.info.rpc_pubsub().unwrap(),
                 ));
                 Self::sync_ledger_path_across_nested_config_fields(&mut config, &ledger_path);
+                Self::configure_tip_manager(
+                    &mut config,
+                    &validator_pubkey,
+                    &voting_keypair.pubkey(),
+                );
 
                 let validator_server = Validator::new(
                     validator_node,
@@ -1296,11 +1335,19 @@ impl Cluster for LocalCluster {
         socket_addr_space: SocketAddrSpace,
     ) -> ClusterValidatorInfo {
         // Restart the node
-        let validator_info = &cluster_validator_info.info;
+        let ledger_path = cluster_validator_info.info.ledger_path.clone();
+        let identity = cluster_validator_info.info.keypair.pubkey();
+        let vote_account = cluster_validator_info.info.voting_keypair.pubkey();
         LocalCluster::sync_ledger_path_across_nested_config_fields(
             &mut cluster_validator_info.config,
-            &validator_info.ledger_path,
+            &ledger_path,
         );
+        LocalCluster::configure_tip_manager(
+            &mut cluster_validator_info.config,
+            &identity,
+            &vote_account,
+        );
+        let validator_info = &cluster_validator_info.info;
         let restarted_node = Validator::new(
             node,
             validator_info.keypair.clone(),


### PR DESCRIPTION
## Summary
- Deploy `spl_programs` (including tip payment and tip distribution) into local-cluster genesis, matching test-validator and bam-local-cluster.
- Point each validator's TipManager at those genesis program IDs and its vote account. `TipManagerConfig::default()` used random unique IDs, so BundleStage tried to initialize programs that were never the ones in genesis.
- That mismatch made `handle_tip_programs` fail every 10ms poll without updating `last_tip_update_slot`, which timed out `test_duplicate_shreds_broadcast_leader` in `local-cluster-2`.
- Delete `test_resanitizes_instruction_account_limit_after_epoch_change`. After SIMD-406 cleanup the 255-account cap is unconditional, so the test panics in `verify_transaction`.