### PR TITLE
ci: exempt v4.3 from mergify EoL auto-close

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -176,6 +176,7 @@ pull_request_rules:
       - base != v4.0
       - base != v4.1
       - base != v4.2
+      - base != v4.3
     actions:
       close:
         message: "`{{base}}` is end-of-life and no longer accepts changes."


### PR DESCRIPTION
Mergify's "close PRs against EoL version branches" rule only allowlists v4.0–v4.2, so it auto-closes v4.3 backports like #1591. Mergify evaluates PRs with the config from the PR's base branch, so this fix on `v4.3` is the one that actually stops the closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)