### PR TITLE
ci: exempt v4.3 from mergify EoL auto-close

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -176,6 +176,7 @@ pull_request_rules:
       - base != v4.0
       - base != v4.1
       - base != v4.2
+      - base != v4.3
     actions:
       close:
         message: "`{{base}}` is end-of-life and no longer accepts changes."


### PR DESCRIPTION
Same as the v4.3-targeted fix — keeps master's `.mergify.yml` in sync so the exemption survives future branch cuts. Context: the EoL close rule only allowlists v4.0–v4.2 and was auto-closing v4.3 backports like #1591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)