### PR TITLE
ci: Build and publish release artifacts on tag push

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -126,3 +126,4 @@ jobs:
         with:
           name: jito-solana-release
           path: dist/
+          compression-level: 0  # contents are already bzip2

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -11,6 +11,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/release-artifacts.yml"
+      - "f"
+      - "dev/Dockerfile"
   workflow_dispatch:
     inputs:
       ref:
@@ -86,12 +88,16 @@ jobs:
 
       - name: Checksum and summarize
         run: |
+          ./docker-output/agave-validator --version
           cd dist
           for f in *.tar.bz2; do
             sha256sum "$f" > "$f.sha256"
           done
           {
             echo "## jito-solana release artifact"
+            echo '```'
+            ../docker-output/agave-validator --version
+            echo '```'
             echo '```'
             cat ./*.yml
             echo '```'

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -18,6 +18,9 @@ on:
         required: true
         description: git ref to build (tag, branch, or SHA)
 
+permissions:
+  contents: read
+
 concurrency:
   group: release-artifacts-${{ github.event.pull_request.number || inputs.ref || github.ref_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -73,7 +76,11 @@ jobs:
           fi
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             git fetch --depth=1 origin "$DISPATCH_REF"
-            args+=(--checkout "$(git rev-parse FETCH_HEAD)")
+            args+=(--checkout "$(git rev-parse 'FETCH_HEAD^{commit}')")
+            if [[ -z "$TAG" ]]; then
+              # keep the human-readable ref in the artifact name
+              args+=(--tag "${DISPATCH_REF//\//_}-$(git rev-parse --short 'FETCH_HEAD^{commit}')")
+            fi
           fi
           ./f "${args[@]}"
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,18 +1,13 @@
-# Build the versioned jito-solana validator artifact in CI and publish it so
-# deploys can download-and-swap instead of building from source (MEV-12300).
-#
-# Drives ./f (dev/Dockerfile), which produces a hermetic linux/amd64 release
-# tarball + version manifest. Tag pushes (and dispatch refs that name an
-# existing GitHub release) upload the tarball, manifest, and SHA-256 to that
-# release; any other dispatch ref is kept as a workflow artifact.
+# Build the release tarball with ./f and attach it (+ manifest, SHA-256) to
+# the tag's GitHub release, so deploys download instead of building from
+# source (MEV-12300).
 name: Release Artifacts
 
 on:
   push:
     tags:
       - "v*-jito"
-  # Self-test: PRs touching this workflow run the full build pre-merge.
-  # PR runs never touch a release (artifact-upload path only).
+  # Self-test: PR runs build but never touch a release.
   pull_request:
     paths:
       - ".github/workflows/release-artifacts.yml"
@@ -29,12 +24,11 @@ concurrency:
 
 jobs:
   build:
-    # Fork PRs get a read-only token (GHCR login would fail); skip them.
+    # Skip fork PRs: their token cannot push the GHCR cache.
     if: >-
       github.repository == 'jito-foundation/jito-solana' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
-    # Org larger runner: 16-core / 64GB / 600GB SSD (label big-runner-1).
     runs-on: big-runner-1
     timeout-minutes: 360
     permissions:
@@ -47,10 +41,8 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
 
-      # Tag pushes always name the artifact after the tag. A dispatch ref gets
-      # the release name only when a GitHub release for that exact ref already
-      # exists (backfills); anything else keeps ./f's derived
-      # v<version>_<shortsha> naming.
+      # Empty tag = not a release build; artifact keeps ./f's derived name
+      # and is uploaded as a workflow artifact instead.
       - name: Resolve release tag
         id: meta
         env:
@@ -68,11 +60,8 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
-      # Registry layer cache skips the toolchain stage (apt + rustup) on
-      # warm runs. It does NOT cache the cargo compile: that state lives in
-      # BuildKit cache mounts, which registry cache export doesn't cover.
-      # Registry cache export also requires a docker-container builder (the
-      # default docker driver can't export cache).
+      # Layer cache only (toolchain stage); cargo state lives in BuildKit
+      # cache mounts, which registry cache cannot export.
       - name: Set up registry build cache
         env:
           GH_TOKEN: ${{ github.token }}
@@ -91,8 +80,6 @@ jobs:
           fi
           ./f "${args[@]}"
 
-      # Publish the source revision, checksum, and contents alongside the
-      # artifact (see the job summary and the .sha256 asset).
       - name: Checksum and summarize
         run: |
           cd dist
@@ -121,8 +108,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.meta.outputs.tag }}
         run: |
-          # release.yml creates the release on tag push; recreate defensively
-          # in case it was deleted before this multi-hour build finished.
+          # release.yml normally creates the release on tag push
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
               --prerelease --title "Release $TAG" --notes "🚧"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -78,10 +78,19 @@ jobs:
           fi
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             git fetch --depth=1 origin "$DISPATCH_REF"
-            args+=(--checkout "$(git rev-parse 'FETCH_HEAD^{commit}')")
+            sha="$(git rev-parse 'FETCH_HEAD^{commit}')"
+            short="$(git rev-parse --short "$sha")"
+            args+=(--checkout "$sha")
             if [[ -z "$TAG" ]]; then
-              # keep the human-readable ref in the artifact name
-              args+=(--tag "${DISPATCH_REF//\//_}-$(git rev-parse --short 'FETCH_HEAD^{commit}')")
+              # Keep the human-readable ref in the artifact name. A SHA ref
+              # is already the commit, so use it alone.
+              name="${DISPATCH_REF//\//_}"
+              if [[ "$sha" == "$name"* ]]; then
+                name="$short"
+              else
+                name="${name}-${short}"
+              fi
+              args+=(--tag "$name")
             fi
           fi
           ./f "${args[@]}"
@@ -98,6 +107,7 @@ jobs:
             echo '```'
             ../docker-output/agave-validator --version
             echo '```'
+            echo "### Version manifest"
             echo '```'
             cat ./*.yml
             echo '```'

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -34,33 +34,13 @@ jobs:
       github.repository == 'jito-foundation/jito-solana' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-24.04
+    # Org larger runner: 16-core / 64GB / 600GB SSD (label big-runner-1).
+    runs-on: big-runner-1
     timeout-minutes: 360
     permissions:
       contents: write
       packages: write
     steps:
-      # The release build needs ~40GB of scratch; stock runners have ~14GB
-      # free on / and ~65GB on /mnt. Drop unused toolchains and move docker's
-      # data-root (where BuildKit keeps layers and cache mounts) to /mnt.
-      - name: Free runner disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
-            /usr/local/.ghcup /opt/hostedtoolcache
-          sudo systemctl stop docker
-          sudo rm -rf /var/lib/docker
-          sudo mkdir -p /etc/docker /mnt/docker
-          if [[ -s /etc/docker/daemon.json ]]; then
-            sudo jq '. + {"data-root": "/mnt/docker"}' /etc/docker/daemon.json \
-              | sudo tee /etc/docker/daemon.json.new >/dev/null
-            sudo mv /etc/docker/daemon.json.new /etc/docker/daemon.json
-          else
-            echo '{"data-root": "/mnt/docker"}' \
-              | sudo tee /etc/docker/daemon.json >/dev/null
-          fi
-          sudo systemctl start docker
-          df -h / /mnt
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -35,11 +35,13 @@ jobs:
       contents: write
       packages: write
     steps:
+      # Always check out the workflow's own ref; dispatch refs are built via
+      # ./f --checkout below so old tags get current build tooling.
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
+          persist-credentials: false
 
       # Empty tag = not a release build; artifact keeps ./f's derived name
       # and is uploaded as a workflow artifact instead.
@@ -71,12 +73,22 @@ jobs:
 
       - name: Build release tarball
         env:
+          EVENT: ${{ github.event_name }}
+          DISPATCH_REF: ${{ inputs.ref }}
           TAG: ${{ steps.meta.outputs.tag }}
           CACHE_REF: ghcr.io/${{ github.repository }}/build-cache
         run: |
           args=(--pull-cache "$CACHE_REF" --push-cache "$CACHE_REF")
           if [[ -n "$TAG" ]]; then
             args+=(--tag "$TAG")
+          fi
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            if git fetch --depth=1 origin "refs/tags/$DISPATCH_REF:refs/tags/$DISPATCH_REF" 2>/dev/null; then
+              args+=(--checkout "$DISPATCH_REF")
+            else
+              git fetch --depth=1 origin "$DISPATCH_REF"
+              args+=(--checkout "$(git rev-parse FETCH_HEAD)")
+            fi
           fi
           ./f "${args[@]}"
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,129 @@
+# Build the versioned jito-solana validator artifact in CI and publish it so
+# deploys can download-and-swap instead of building from source (MEV-12300).
+#
+# Drives ./f (dev/Dockerfile), which produces a hermetic linux/amd64 release
+# tarball + version manifest. Tag pushes (and dispatch refs that name an
+# existing GitHub release) upload the tarball, manifest, and SHA-256 to that
+# release; any other dispatch ref is kept as a workflow artifact.
+name: Release Artifacts
+
+on:
+  push:
+    tags:
+      - "v*-jito"
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        required: true
+        description: git ref to build (tag, branch, or SHA)
+
+jobs:
+  build:
+    if: github.repository == 'jito-foundation/jito-solana'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    permissions:
+      contents: write
+    steps:
+      # The release build needs ~40GB of scratch; stock runners have ~14GB
+      # free on / and ~65GB on /mnt. Drop unused toolchains and move docker's
+      # data-root (where BuildKit keeps layers and cache mounts) to /mnt.
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache
+          sudo systemctl stop docker
+          sudo rm -rf /var/lib/docker
+          sudo mkdir -p /etc/docker /mnt/docker
+          if [[ -s /etc/docker/daemon.json ]]; then
+            sudo jq '. + {"data-root": "/mnt/docker"}' /etc/docker/daemon.json \
+              | sudo tee /etc/docker/daemon.json.new >/dev/null
+            sudo mv /etc/docker/daemon.json.new /etc/docker/daemon.json
+          else
+            echo '{"data-root": "/mnt/docker"}' \
+              | sudo tee /etc/docker/daemon.json >/dev/null
+          fi
+          sudo systemctl start docker
+          df -h / /mnt
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: recursive
+
+      # Tag pushes always name the artifact after the tag. A dispatch ref gets
+      # the release name only when a GitHub release for that exact ref already
+      # exists (backfills); anything else keeps ./f's derived
+      # v<version>_<shortsha> naming.
+      - name: Resolve release tag
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          PUSH_TAG: ${{ github.ref_name }}
+          DISPATCH_REF: ${{ inputs.ref }}
+        run: |
+          tag=""
+          if [[ "$EVENT" == "push" ]]; then
+            tag="$PUSH_TAG"
+          elif gh release view "$DISPATCH_REF" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            tag="$DISPATCH_REF"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build release tarball
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          args=()
+          if [[ -n "$TAG" ]]; then
+            args+=(--tag "$TAG")
+          fi
+          ./f "${args[@]}"
+
+      # Publish the source revision, checksum, and contents alongside the
+      # artifact (see the job summary and the .sha256 asset).
+      - name: Checksum and summarize
+        run: |
+          cd dist
+          for f in *.tar.bz2; do
+            sha256sum "$f" > "$f.sha256"
+          done
+          {
+            echo "## jito-solana release artifact"
+            echo '```'
+            cat ./*.yml
+            echo '```'
+            echo "### SHA-256"
+            echo '```'
+            cat ./*.sha256
+            echo '```'
+            echo "### Contents"
+            echo '```'
+            tar -tjf ./*.tar.bz2
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          ls -lh
+
+      - name: Publish to GitHub release
+        if: steps.meta.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          # release.yml creates the release on tag push; recreate defensively
+          # in case it was deleted before this multi-hour build finished.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --prerelease --title "Release $TAG" --notes "🚧"
+          fi
+          gh release upload "$TAG" dist/* --clobber --repo "$GITHUB_REPOSITORY"
+
+      - name: Upload workflow artifact
+        if: steps.meta.outputs.tag == ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: jito-solana-release
+          path: dist/

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build:
-    # Skip fork PRs: their token cannot push the GHCR cache.
+    # Skip fork PRs: they cannot use org larger runners and would queue forever.
     if: >-
       github.repository == 'jito-foundation/jito-solana' &&
       (github.event_name != 'pull_request' ||
@@ -33,7 +33,6 @@ jobs:
     timeout-minutes: 360
     permissions:
       contents: write
-      packages: write
     steps:
       # Always check out the workflow's own ref; dispatch refs are built via
       # ./f --checkout below so old tags get current build tooling.
@@ -62,33 +61,19 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
-      # Layer cache only (toolchain stage); cargo state lives in BuildKit
-      # cache mounts, which registry cache cannot export.
-      - name: Set up registry build cache
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo "$GH_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
-          docker buildx create --use
-
       - name: Build release tarball
         env:
           EVENT: ${{ github.event_name }}
           DISPATCH_REF: ${{ inputs.ref }}
           TAG: ${{ steps.meta.outputs.tag }}
-          CACHE_REF: ghcr.io/${{ github.repository }}/build-cache
         run: |
-          args=(--pull-cache "$CACHE_REF" --push-cache "$CACHE_REF")
+          args=()
           if [[ -n "$TAG" ]]; then
             args+=(--tag "$TAG")
           fi
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
-            if git fetch --depth=1 origin "refs/tags/$DISPATCH_REF:refs/tags/$DISPATCH_REF" 2>/dev/null; then
-              args+=(--checkout "$DISPATCH_REF")
-            else
-              git fetch --depth=1 origin "$DISPATCH_REF"
-              args+=(--checkout "$(git rev-parse FETCH_HEAD)")
-            fi
+            git fetch --depth=1 origin "$DISPATCH_REF"
+            args+=(--checkout "$(git rev-parse FETCH_HEAD)")
           fi
           ./f "${args[@]}"
 
@@ -119,13 +104,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.meta.outputs.tag }}
-        run: |
-          # release.yml normally creates the release on tag push
-          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
-              --prerelease --title "Release $TAG" --notes "🚧"
-          fi
-          gh release upload "$TAG" dist/* --clobber --repo "$GITHUB_REPOSITORY"
+        # release.yml creates the release on tag push; fail if it is missing
+        run: gh release upload "$TAG" dist/* --clobber --repo "$GITHUB_REPOSITORY"
 
       - name: Upload workflow artifact
         if: steps.meta.outputs.tag == ''

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,6 +1,6 @@
 # Build the release tarball with ./f and attach it (+ manifest, SHA-256) to
 # the tag's GitHub release, so deploys download instead of building from
-# source (MEV-12300).
+# source.
 name: Release Artifacts
 
 on:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -11,6 +11,11 @@ on:
   push:
     tags:
       - "v*-jito"
+  # Self-test: PRs touching this workflow run the full build pre-merge.
+  # PR runs never touch a release (artifact-upload path only).
+  pull_request:
+    paths:
+      - ".github/workflows/release-artifacts.yml"
   workflow_dispatch:
     inputs:
       ref:
@@ -18,9 +23,17 @@ on:
         required: true
         description: git ref to build (tag, branch, or SHA)
 
+concurrency:
+  group: release-artifacts-${{ github.event.pull_request.number || inputs.ref || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
-    if: github.repository == 'jito-foundation/jito-solana'
+    # Fork PRs get a read-only token (GHCR login would fail); skip them.
+    if: >-
+      github.repository == 'jito-foundation/jito-solana' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     timeout-minutes: 360
     permissions:
@@ -69,7 +82,8 @@ jobs:
           tag=""
           if [[ "$EVENT" == "push" ]]; then
             tag="$PUSH_TAG"
-          elif gh release view "$DISPATCH_REF" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          elif [[ -n "$DISPATCH_REF" ]] \
+            && gh release view "$DISPATCH_REF" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             tag="$DISPATCH_REF"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -25,6 +25,7 @@ jobs:
     timeout-minutes: 360
     permissions:
       contents: write
+      packages: write
     steps:
       # The release build needs ~40GB of scratch; stock runners have ~14GB
       # free on / and ~65GB on /mnt. Drop unused toolchains and move docker's
@@ -73,11 +74,24 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
+      # Registry layer cache skips the toolchain stage (apt + rustup) on
+      # warm runs. It does NOT cache the cargo compile: that state lives in
+      # BuildKit cache mounts, which registry cache export doesn't cover.
+      # Registry cache export also requires a docker-container builder (the
+      # default docker driver can't export cache).
+      - name: Set up registry build cache
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "$GH_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+          docker buildx create --use
+
       - name: Build release tarball
         env:
           TAG: ${{ steps.meta.outputs.tag }}
+          CACHE_REF: ghcr.io/${{ github.repository }}/build-cache
         run: |
-          args=()
+          args=(--pull-cache "$CACHE_REF" --push-cache "$CACHE_REF")
           if [[ -n "$TAG" ]]; then
             args+=(--tag "$TAG")
           fi


### PR DESCRIPTION
Linear: MEV-12300
Buildkite agave-secondary stopped publishing tarballs around v3.0
(release.jito.wtf is stale since Dec 2024), so deploys rebuild from
source every time. Run ./f on tag pushes and manual dispatch, then
attach tarball, version manifest, and SHA-256 to the GitHub release
so Ansible can download-and-swap by exact version (MEV-12300).

- Dispatch refs naming an existing release backfill its assets
- Other refs are kept as workflow artifacts
- Stock runner disk is too small; drop unused toolchains and move
  the docker data-root to /mnt

🤖 Generated with [Claude Code](https://claude.com/claude-code)