### PR TITLE
Preserve BAM work across same-slot sad handover

### DIFF
--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -65,6 +65,8 @@ impl DecisionMaker {
             } else {
                 BufferedPacketsDecision::Consume(working_bank.clone())
             }
+        } else if state.bank_slot().is_some() {
+            BufferedPacketsDecision::Hold
         } else if let Some(leader_first_tick_height) = state.leader_first_tick_height() {
             let current_tick_height = state.tick_height();
             let ticks_until_leader = leader_first_tick_height.saturating_sub(current_tick_height);
@@ -154,6 +156,12 @@ mod tests {
             decision_maker.make_atomic_consume_or_forward_decision(),
             BufferedPacketsDecision::Hold
         );
+
+        shared_leader_state.set_bank_replacement();
+        assert!(matches!(
+            decision_maker.make_consume_or_forward_decision(),
+            BufferedPacketsDecision::Hold
+        ));
         shared_leader_state.store(Arc::new(LeaderState::new(None, 0, None, None)));
 
         // Will be leader shortly - Hold

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -85,6 +85,7 @@ pub struct BamReceiveAndBuffer {
     /// Owned by this struct (unlike the shared `exit` flag) so `drop` can
     /// stop the parsing thread without shutting anything else down.
     shutdown: Arc<AtomicBool>,
+    shared_leader_state: Option<SharedLeaderState>,
     next_fifo_priority: u64,
 }
 
@@ -115,6 +116,7 @@ impl BamReceiveAndBuffer {
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = shutdown.clone();
         let response_sender_clone = response_sender.clone();
+        let parsing_leader_state = shared_leader_state.clone();
         let parsing_thread = std::thread::spawn(move || {
             Self::run_parsing(
                 exit,
@@ -124,7 +126,7 @@ impl BamReceiveAndBuffer {
                 recv_stats_sender,
                 response_sender_clone,
                 bank_forks,
-                shared_leader_state,
+                parsing_leader_state,
                 blacklisted_accounts,
             )
         });
@@ -136,6 +138,7 @@ impl BamReceiveAndBuffer {
             recv_stats_receiver,
             parsing_thread: Some(parsing_thread),
             shutdown,
+            shared_leader_state,
             next_fifo_priority: u64::MAX,
         }
     }
@@ -346,6 +349,50 @@ impl BamReceiveAndBuffer {
                     )),
                 },
             ));
+    }
+
+    fn should_buffer_batches(&self) -> bool {
+        self.shared_leader_state
+            .as_ref()
+            .is_some_and(|shared_leader_state| shared_leader_state.load().bank_slot().is_some())
+    }
+
+    fn buffer_batch(
+        &mut self,
+        container: &mut TransactionStateContainer<
+            RuntimeTransaction<ResolvedTransactionView<Bytes>>,
+        >,
+        batch: ParsedBatch,
+        bam_state: BamConnectionState,
+        stats: &mut ReceivingStats,
+    ) {
+        if bam_state != BamConnectionState::Connected {
+            stats.num_dropped_without_parsing += batch.txns_max_age.len();
+            return;
+        }
+
+        let ParsedBatch {
+            txns_max_age,
+            revert_on_error,
+            max_schedule_slot,
+            seq_id,
+        } = batch;
+
+        if container
+            .insert_new_batch(
+                txns_max_age,
+                self.next_fifo_priority,
+                revert_on_error,
+                max_schedule_slot,
+                seq_id,
+            )
+            .is_none()
+        {
+            stats.num_dropped_on_capacity += 1;
+            self.send_container_full_txn_batch_result(seq_id);
+            return;
+        }
+        self.next_fifo_priority = self.next_fifo_priority.saturating_sub(1);
     }
 
     fn parse_batch(
@@ -817,16 +864,18 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
             stats.accumulate(batch_stats);
         }
 
-        match decision {
+        let should_buffer_batches = matches!(
+            decision,
+            BufferedPacketsDecision::Consume(_) | BufferedPacketsDecision::Hold
+        ) || self.should_buffer_batches();
+        match (should_buffer_batches, bam_state) {
             // Preserve batches during the short Block Engine handoff. Connecting may be
             // long-lived, so retain the existing drain behavior for that state.
-            BufferedPacketsDecision::Consume(_) | BufferedPacketsDecision::Hold
-                if matches!(
-                    bam_state,
-                    BamConnectionState::DrainingBlockEngine
-                        | BamConnectionState::BlockEngineDrained
-                ) => {}
-            BufferedPacketsDecision::Consume(_) | BufferedPacketsDecision::Hold => loop {
+            (
+                true,
+                BamConnectionState::DrainingBlockEngine | BamConnectionState::BlockEngineDrained,
+            ) => {}
+            (true, _) => loop {
                 let batch = match self.parsed_batch_receiver.try_recv() {
                     Ok(batch) => batch,
                     Err(TryRecvError::Disconnected) => return Err(DisconnectedError::Receiver),
@@ -836,36 +885,9 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
                     }
                 };
 
-                // If BAM is not enabled, drain the channel
-                if bam_state != BamConnectionState::Connected {
-                    stats.num_dropped_without_parsing += batch.txns_max_age.len();
-                    continue;
-                }
-
-                let ParsedBatch {
-                    txns_max_age,
-                    revert_on_error,
-                    max_schedule_slot,
-                    seq_id,
-                } = batch;
-
-                if container
-                    .insert_new_batch(
-                        txns_max_age,
-                        self.next_fifo_priority,
-                        revert_on_error,
-                        max_schedule_slot,
-                        seq_id,
-                    )
-                    .is_none()
-                {
-                    stats.num_dropped_on_capacity += 1;
-                    self.send_container_full_txn_batch_result(seq_id);
-                    continue;
-                }
-                self.next_fifo_priority = self.next_fifo_priority.saturating_sub(1);
+                self.buffer_batch(container, batch, bam_state, &mut stats);
             },
-            BufferedPacketsDecision::ForwardAndHold | BufferedPacketsDecision::Forward => {
+            (false, _) => {
                 // Ensure nothing is left in the container
                 while let Some(next_batch_id) = container.pop() {
                     if let Some((_, _, _, seq_id)) = container.get_batch(next_batch_id.id) {
@@ -874,7 +896,7 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
                     container.remove_by_id(next_batch_id.id);
                 }
 
-                // Send back any batches that were received while in Forward/Hold state
+                // Allow the parser to catch up, but refresh leader state before rejecting work.
                 let deadline = Instant::now() + Duration::from_millis(100);
                 loop {
                     let (batch, receive_time_us) =
@@ -890,8 +912,13 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
                             break;
                         }
                     };
-                    self.send_no_leader_slot_txn_batch_result(batch.seq_id);
-                    stats.num_dropped_without_parsing += 1;
+                    if self.should_buffer_batches() {
+                        self.buffer_batch(container, batch, bam_state, &mut stats);
+                        break;
+                    } else {
+                        self.send_no_leader_slot_txn_batch_result(batch.seq_id);
+                        stats.num_dropped_without_parsing += 1;
+                    }
                 }
             }
         }
@@ -1529,12 +1556,6 @@ mod tests {
         assert_ne!(old_bank.bank_id(), replacement_bank.bank_id());
 
         let mut shared_leader_state = SharedLeaderState::new(0, None, None);
-        shared_leader_state.store(Arc::new(LeaderState::new(
-            Some(old_bank.clone()),
-            0,
-            None,
-            None,
-        )));
         let (exit, mut receive_and_buffer, mut container, mut response_receiver) =
             setup_bam_receive_and_buffer(
                 receiver,
@@ -1594,6 +1615,7 @@ mod tests {
         ));
 
         // Hide the retiring Bank so parsing retains work until its replacement is ready.
+        shared_leader_state.store(Arc::new(LeaderState::new(Some(old_bank), 0, None, None)));
         shared_leader_state.set_bank_replacement();
         assert!(shared_leader_state.load().working_bank().is_none());
 

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -47,7 +47,7 @@ use {
     solana_perf::sigverify::verify_transaction_view,
     solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::Pubkey,
-    solana_runtime::bank_forks::BankForks,
+    solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_meta::TransactionMeta,
     },
@@ -193,27 +193,25 @@ impl BamReceiveAndBuffer {
                 }
             }
 
-            let (current_slot, enable_tx_v1) = shared_leader_state
-                .as_ref()
-                .and_then(|leader_state| {
-                    let leader_state = leader_state.load();
-                    leader_state
-                        .working_bank()
-                        .map(|bank| (bank.slot(), bank.feature_set.snapshot().enable_tx_v1))
-                })
-                .unwrap_or_else(|| {
-                    let working_bank = bank_forks.read().unwrap().working_bank();
-                    (
-                        working_bank.slot(),
-                        working_bank.feature_set.snapshot().enable_tx_v1,
-                    )
-                });
+            let working_bank = loop {
+                if exit.load(Ordering::Relaxed) || shutdown.load(Ordering::Relaxed) {
+                    return;
+                }
+                if let Some(working_bank) =
+                    Self::select_parsing_bank(&bank_forks, shared_leader_state.as_ref())
+                {
+                    break working_bank;
+                }
+                // Keep the received burst intact until the replacement resolves.
+                std::thread::sleep(TIMEOUT);
+            };
+            let root_bank = bank_forks.read().unwrap().root_bank();
 
             let (deserialize_stats, duration_us) = measure_us!(Self::batch_verify(
                 &sigverify_thread_pool,
                 &mut recv_buffer,
-                current_slot,
-                enable_tx_v1,
+                working_bank.slot(),
+                working_bank.feature_set.snapshot().enable_tx_v1,
                 &mut metrics,
                 &mut prevalidated,
                 &mut packet_data,
@@ -262,7 +260,7 @@ impl BamReceiveAndBuffer {
                                 seq_id,
                                 revert_on_error,
                                 max_schedule_slot,
-                                &bank_forks,
+                                (&root_bank, &working_bank),
                                 &blacklisted_accounts,
                                 &mut metrics,
                             ));
@@ -297,6 +295,23 @@ impl BamReceiveAndBuffer {
             debug_assert_eq!(verification_result_offset, verification_results.len());
             verification_results.clear();
         }
+    }
+
+    /// Returns `None` only while a retained working bank is being replaced.
+    fn select_parsing_bank(
+        bank_forks: &RwLock<BankForks>,
+        shared_leader_state: Option<&SharedLeaderState>,
+    ) -> Option<Arc<Bank>> {
+        if let Some(shared_leader_state) = shared_leader_state {
+            let leader_state = shared_leader_state.load();
+            if let Some(working_bank) = leader_state.working_bank() {
+                return Some(working_bank.clone());
+            }
+            if leader_state.bank_slot().is_some() {
+                return None;
+            }
+        }
+        Some(bank_forks.read().unwrap().working_bank())
     }
 
     fn send_no_leader_slot_txn_batch_result(&self, seq_id: u32) {
@@ -338,18 +353,11 @@ impl BamReceiveAndBuffer {
         seq_id: u32,
         revert_on_error: bool,
         max_schedule_slot: u64,
-        bank_forks: &Arc<RwLock<BankForks>>,
+        (root_bank, working_bank): (&Bank, &Bank),
         blacklisted_accounts: &HashSet<Pubkey>,
         metrics: &mut BamReceiveAndBufferMetrics,
     ) -> (Result<ParsedBatch, Reason>, ReceivingStats) {
         let mut stats = ReceivingStats::default();
-
-        let (root_bank, working_bank) = {
-            let bank_forks = bank_forks.read().unwrap();
-            let root_bank = bank_forks.root_bank();
-            let working_bank = bank_forks.working_bank();
-            (root_bank, working_bank)
-        };
         let alt_resolved_slot = root_bank.slot();
         let sanitized_epoch = root_bank.epoch();
         let transaction_account_lock_limit = working_bank.get_transaction_account_lock_limit();
@@ -522,7 +530,7 @@ impl BamReceiveAndBuffer {
             // Downstream fee payers may be funded by earlier transactions in the same bundle.
             if index == 0 {
                 let (result, duration_us) = measure_us!(Consumer::check_fee_payer_unlocked(
-                    &working_bank,
+                    working_bank,
                     &view,
                     &mut TransactionErrorMetrics::default(),
                 ));
@@ -1117,8 +1125,10 @@ mod tests {
         solana_hash::Hash,
         solana_instruction::Instruction,
         solana_keypair::Keypair,
+        solana_leader_schedule::SlotLeader,
         solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_message::{Message, VersionedMessage, v1},
+        solana_poh::poh_recorder::LeaderState,
         solana_pubkey::Pubkey,
         solana_runtime::bank::Bank,
         solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -1150,6 +1160,14 @@ mod tests {
         bank.activate_feature(&agave_feature_set::enable_tx_v1::id());
         let (_bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         (bank_forks, mint_keypair)
+    }
+
+    fn child_bank(parent: &Arc<Bank>, slot: Slot) -> Arc<Bank> {
+        Arc::new(Bank::new_from_parent(
+            parent.clone(),
+            SlotLeader::new_unique(),
+            slot,
+        ))
     }
 
     fn v1_transaction_with_wire_size(
@@ -1210,6 +1228,7 @@ mod tests {
     fn setup_bam_receive_and_buffer(
         receiver: crossbeam_channel::Receiver<MultipleAtomicTxnBatch>,
         bank_forks: Arc<RwLock<BankForks>>,
+        shared_leader_state: Option<SharedLeaderState>,
         blacklisted_accounts: HashSet<Pubkey>,
     ) -> (
         Arc<AtomicBool>,
@@ -1226,11 +1245,41 @@ mod tests {
             receiver,
             response_sender,
             bank_forks,
-            None,
+            shared_leader_state,
             blacklisted_accounts,
         );
         let container = TransactionStateContainer::with_capacity(100);
         (exit, receive_and_buffer, container, response_receiver)
+    }
+
+    #[test]
+    fn test_select_parsing_bank_during_replacement() {
+        let (bank_forks, _mint_keypair) = test_bank_forks();
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let old_bank = child_bank(&root_bank, 1);
+        let new_bank = child_bank(&root_bank, 1);
+
+        let mut shared_leader_state = SharedLeaderState::new(0, None, None);
+        let select = |state: &SharedLeaderState| {
+            BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(state))
+        };
+        let leader_state = LeaderState::new(Some(old_bank.clone()), 0, None, None);
+        shared_leader_state.store(Arc::new(leader_state));
+        let selected = select(&shared_leader_state).unwrap();
+        assert!(Arc::ptr_eq(&selected, &old_bank));
+
+        shared_leader_state.set_bank_replacement();
+        assert!(select(&shared_leader_state).is_none());
+
+        let leader_state = LeaderState::new(Some(new_bank.clone()), 0, None, None);
+        shared_leader_state.store(Arc::new(leader_state));
+        let selected = select(&shared_leader_state).unwrap();
+        assert!(Arc::ptr_eq(&selected, &new_bank));
+
+        shared_leader_state.store(Arc::new(LeaderState::new(None, 0, None, None)));
+        let working_bank = bank_forks.read().unwrap().working_bank();
+        let selected = select(&shared_leader_state).unwrap();
+        assert!(Arc::ptr_eq(&selected, &working_bank));
     }
 
     fn verify_container<Tx: TransactionWithMeta>(
@@ -1408,7 +1457,7 @@ mod tests {
         let (sender, receiver) = unbounded();
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (exit, mut receive_and_buffer, mut container, _response_receiver) =
-            setup_bam_receive_and_buffer(receiver, bank_forks.clone(), HashSet::new());
+            setup_bam_receive_and_buffer(receiver, bank_forks.clone(), None, HashSet::new());
         let bam_enabled = receive_and_buffer.bam_enabled.clone();
         bam_enabled.store(
             BamConnectionState::DrainingBlockEngine as u8,
@@ -1469,11 +1518,78 @@ mod tests {
     }
 
     #[test]
+    fn test_receive_and_buffer_waits_for_replacement_bank() {
+        let (sender, receiver) = unbounded();
+        let (bank_forks, mint_keypair) = test_bank_forks();
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let old_bank = child_bank(&root_bank, 1);
+        let replacement_bank = child_bank(&root_bank, 1);
+        replacement_bank.register_unique_recent_blockhash_for_test();
+
+        let mut shared_leader_state = SharedLeaderState::new(0, None, None);
+        shared_leader_state.store(Arc::new(LeaderState::new(Some(old_bank), 0, None, None)));
+        shared_leader_state.set_bank_replacement();
+        let (_, mut receive_and_buffer, mut container, mut response_receiver) =
+            setup_bam_receive_and_buffer(
+                receiver,
+                bank_forks,
+                Some(shared_leader_state.clone()),
+                HashSet::new(),
+            );
+
+        let transaction = transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            replacement_bank.last_blockhash(),
+        );
+        let batch = batch_with_packet_data(wincode::serialize(&transaction).unwrap().into());
+        sender
+            .send(MultipleAtomicTxnBatch {
+                batches: vec![batch],
+            })
+            .unwrap();
+
+        let receive_deadline = Instant::now() + Duration::from_secs(5);
+        while !sender.is_empty() {
+            assert!(
+                Instant::now() < receive_deadline,
+                "parser did not receive the pending batch"
+            );
+            std::thread::yield_now();
+        }
+        receive_and_buffer
+            .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
+            .unwrap();
+        assert!(container.is_empty());
+
+        let leader_state = LeaderState::new(Some(replacement_bank), 0, None, None);
+        shared_leader_state.store(Arc::new(leader_state));
+        let parse_deadline = Instant::now() + Duration::from_secs(5);
+        while container.is_empty() {
+            receive_and_buffer
+                .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
+                .unwrap();
+            assert!(
+                response_receiver.try_recv().is_err(),
+                "batch was rejected before replacement validation"
+            );
+            assert!(
+                Instant::now() < parse_deadline,
+                "timed out waiting for the replacement-valid batch"
+            );
+            std::thread::yield_now();
+        }
+
+        verify_container(&mut container, 1);
+    }
+
+    #[test]
     fn test_receive_and_buffer_invalid_packet() {
         let (bank_forks, _mint_keypair) = test_bank_forks();
         let (sender, receiver) = unbounded();
         let (exit, mut receive_and_buffer, mut container, mut response_receiver) =
-            setup_bam_receive_and_buffer(receiver, bank_forks.clone(), HashSet::new());
+            setup_bam_receive_and_buffer(receiver, bank_forks.clone(), None, HashSet::new());
 
         let bundle = AtomicTxnBatch {
             seq_id: 1,
@@ -1540,7 +1656,7 @@ mod tests {
         let (bank_forks, mint_keypair) = test_bank_forks_with_tx_v1();
         let (sender, receiver) = unbounded();
         let (exit, mut receive_and_buffer, mut container, mut response_receiver) =
-            setup_bam_receive_and_buffer(receiver, bank_forks.clone(), HashSet::new());
+            setup_bam_receive_and_buffer(receiver, bank_forks.clone(), None, HashSet::new());
         let transaction = large_v1_transfer_transaction(
             &mint_keypair,
             bank_forks.read().unwrap().root_bank().last_blockhash(),
@@ -1648,12 +1764,13 @@ mod tests {
         if let Ok((mut verified_packets, revert_on_error, seq_id, max_schedule_slot)) =
             results.into_iter().next().unwrap()
         {
+            let bank_forks = bank_forks.read().unwrap();
             let (result, stats) = BamReceiveAndBuffer::parse_batch(
                 &mut verified_packets,
                 seq_id,
                 revert_on_error,
                 max_schedule_slot,
-                &bank_forks,
+                (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &HashSet::new(),
                 &mut stats,
             );
@@ -1706,12 +1823,13 @@ mod tests {
         if let Ok((mut verified_packets, revert_on_error, seq_id, max_schedule_slot)) =
             results.into_iter().next().unwrap()
         {
+            let bank_forks = bank_forks.read().unwrap();
             let (result, stats) = BamReceiveAndBuffer::parse_batch(
                 &mut verified_packets,
                 seq_id,
                 revert_on_error,
                 max_schedule_slot,
-                &bank_forks,
+                (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &HashSet::new(),
                 &mut stats,
             );
@@ -1803,12 +1921,13 @@ mod tests {
         if let Ok((mut verified_packets, revert_on_error, seq_id, max_schedule_slot)) =
             results.into_iter().next().unwrap()
         {
+            let bank_forks = bank_forks.read().unwrap();
             let (result, stats) = BamReceiveAndBuffer::parse_batch(
                 &mut verified_packets,
                 seq_id,
                 revert_on_error,
                 max_schedule_slot,
-                &bank_forks,
+                (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &blacklisted_accounts,
                 &mut stats,
             );
@@ -1861,12 +1980,13 @@ mod tests {
         if let Ok((mut verified_packets, revert_on_error, seq_id, max_schedule_slot)) =
             results.into_iter().next().unwrap()
         {
+            let bank_forks = bank_forks.read().unwrap();
             let (result, stats) = BamReceiveAndBuffer::parse_batch(
                 &mut verified_packets,
                 seq_id,
                 revert_on_error,
                 max_schedule_slot,
-                &bank_forks,
+                (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &HashSet::new(),
                 &mut stats,
             );

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -1518,18 +1518,24 @@ mod tests {
     }
 
     #[test]
-    fn test_receive_and_buffer_waits_for_replacement_bank() {
+    fn test_receive_and_buffer_preserves_replacement_batches_during_stale_forward_drain() {
         let (sender, receiver) = unbounded();
         let (bank_forks, mint_keypair) = test_bank_forks();
         let root_bank = bank_forks.read().unwrap().root_bank();
         let old_bank = child_bank(&root_bank, 1);
         let replacement_bank = child_bank(&root_bank, 1);
         replacement_bank.register_unique_recent_blockhash_for_test();
+        assert_eq!(old_bank.slot(), replacement_bank.slot());
+        assert_ne!(old_bank.bank_id(), replacement_bank.bank_id());
 
         let mut shared_leader_state = SharedLeaderState::new(0, None, None);
-        shared_leader_state.store(Arc::new(LeaderState::new(Some(old_bank), 0, None, None)));
-        shared_leader_state.set_bank_replacement();
-        let (_, mut receive_and_buffer, mut container, mut response_receiver) =
+        shared_leader_state.store(Arc::new(LeaderState::new(
+            Some(old_bank.clone()),
+            0,
+            None,
+            None,
+        )));
+        let (exit, mut receive_and_buffer, mut container, mut response_receiver) =
             setup_bam_receive_and_buffer(
                 receiver,
                 bank_forks,
@@ -1537,51 +1543,185 @@ mod tests {
                 HashSet::new(),
             );
 
-        let transaction = transfer(
+        // Reject a probe first so replacement begins while the same Forward call
+        // is blocked on its fixed receive deadline.
+        const DRAIN_PROBE_SEQ_ID: u32 = 70_000;
+        let drain_probe = transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            old_bank.last_blockhash(),
+        );
+        let mut drain_probe_batch =
+            batch_with_packet_data(wincode::serialize(&drain_probe).unwrap().into());
+        drain_probe_batch.seq_id = DRAIN_PROBE_SEQ_ID;
+        sender
+            .send(MultipleAtomicTxnBatch {
+                batches: vec![drain_probe_batch],
+            })
+            .unwrap();
+
+        let stale_drain = std::thread::spawn(move || {
+            receive_and_buffer
+                .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Forward)
+                .unwrap();
+            (receive_and_buffer, container)
+        });
+
+        let probe_deadline = Instant::now() + Duration::from_secs(5);
+        let response = loop {
+            if let Ok(response) = response_receiver.try_recv() {
+                break response;
+            }
+            assert!(
+                Instant::now() < probe_deadline,
+                "timed out waiting for the drain probe result"
+            );
+            std::thread::yield_now();
+        };
+        let BamOutboundMessage::AtomicTxnBatchResult(result) = response else {
+            panic!("expected drain probe result");
+        };
+        assert_eq!(result.seq_id, DRAIN_PROBE_SEQ_ID);
+        assert!(matches!(
+            &result.result,
+            Some(atomic_txn_batch_result::Result::NotCommitted(not_committed))
+                if matches!(
+                    &not_committed.reason,
+                    Some(Reason::SchedulingError(reason))
+                        if *reason == SchedulingError::OutsideLeaderSlot as i32
+                )
+        ));
+
+        // Hide the retiring Bank so parsing retains work until its replacement is ready.
+        shared_leader_state.set_bank_replacement();
+        assert!(shared_leader_state.load().working_bank().is_none());
+
+        const DURING_REPLACEMENT_SEQ_ID: u32 = 70_001;
+        let during_replacement_transaction = transfer(
             &mint_keypair,
             &Pubkey::new_unique(),
             1,
             replacement_bank.last_blockhash(),
         );
-        let batch = batch_with_packet_data(wincode::serialize(&transaction).unwrap().into());
+        let mut during_replacement_batch = batch_with_packet_data(
+            wincode::serialize(&during_replacement_transaction)
+                .unwrap()
+                .into(),
+        );
+        during_replacement_batch.seq_id = DURING_REPLACEMENT_SEQ_ID;
         sender
             .send(MultipleAtomicTxnBatch {
-                batches: vec![batch],
+                batches: vec![during_replacement_batch],
             })
             .unwrap();
-
         let receive_deadline = Instant::now() + Duration::from_secs(5);
         while !sender.is_empty() {
             assert!(
                 Instant::now() < receive_deadline,
-                "parser did not receive the pending batch"
+                "parser did not receive the replacement-pending batch"
             );
             std::thread::yield_now();
         }
-        receive_and_buffer
-            .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
-            .unwrap();
-        assert!(container.is_empty());
+        assert!(
+            response_receiver.try_recv().is_err(),
+            "replacement-pending batch escaped before the new Bank was published"
+        );
 
-        let leader_state = LeaderState::new(Some(replacement_bank), 0, None, None);
-        shared_leader_state.store(Arc::new(leader_state));
-        let parse_deadline = Instant::now() + Duration::from_secs(5);
-        while container.is_empty() {
+        // Publishing the replacement releases pending parsing while the stale
+        // Forward call is still active.
+        shared_leader_state.store(Arc::new(LeaderState::new(
+            Some(replacement_bank.clone()),
+            0,
+            None,
+            None,
+        )));
+
+        // Work sent after publication must use the replacement state rather than
+        // the cached Forward decision.
+        const POST_REPLACEMENT_SEQ_ID: u32 = 70_002;
+        let post_replacement_transaction = transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            replacement_bank.last_blockhash(),
+        );
+        let mut post_replacement_batch = batch_with_packet_data(
+            wincode::serialize(&post_replacement_transaction)
+                .unwrap()
+                .into(),
+        );
+        post_replacement_batch.seq_id = POST_REPLACEMENT_SEQ_ID;
+        sender
+            .send(MultipleAtomicTxnBatch {
+                batches: vec![post_replacement_batch],
+            })
+            .unwrap();
+
+        let (mut receive_and_buffer, mut container) = stale_drain.join().unwrap();
+        let current_leader_state = shared_leader_state.load();
+        let current_bank = current_leader_state
+            .working_bank()
+            .expect("replacement Bank must be active when the stale drain exits");
+        assert!(Arc::ptr_eq(current_bank, &replacement_bank));
+
+        let mut unexpected_responses = Vec::new();
+        while let Ok(BamOutboundMessage::AtomicTxnBatchResult(result)) =
+            response_receiver.try_recv()
+        {
+            let outside_leader_slot = matches!(
+                &result.result,
+                Some(atomic_txn_batch_result::Result::NotCommitted(not_committed))
+                    if matches!(
+                        &not_committed.reason,
+                        Some(Reason::SchedulingError(reason))
+                            if *reason == SchedulingError::OutsideLeaderSlot as i32
+                    )
+            );
+            unexpected_responses.push((result.seq_id, outside_leader_slot));
+        }
+        assert!(
+            unexpected_responses.is_empty(),
+            "replacement batches received responses from the stale Forward drain (seq_id, \
+             outside_leader_slot): {unexpected_responses:?}"
+        );
+
+        // A fresh Consume decision must recover retained work and accept new work.
+        const CONTROL_SEQ_ID: u32 = 70_003;
+        let control_transaction = transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            replacement_bank.last_blockhash(),
+        );
+        let mut control_batch =
+            batch_with_packet_data(wincode::serialize(&control_transaction).unwrap().into());
+        control_batch.seq_id = CONTROL_SEQ_ID;
+        sender
+            .send(MultipleAtomicTxnBatch {
+                batches: vec![control_batch],
+            })
+            .unwrap();
+
+        let consume = BufferedPacketsDecision::Consume(replacement_bank);
+        let buffer_deadline = Instant::now() + Duration::from_secs(5);
+        while container.queue_size() < 3 {
             receive_and_buffer
-                .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
+                .receive_and_buffer_packets(&mut container, &consume)
                 .unwrap();
             assert!(
                 response_receiver.try_recv().is_err(),
-                "batch was rejected before replacement validation"
+                "replacement or control batch was unexpectedly rejected"
             );
             assert!(
-                Instant::now() < parse_deadline,
-                "timed out waiting for the replacement-valid batch"
+                Instant::now() < buffer_deadline,
+                "timed out waiting for replacement and control batches"
             );
             std::thread::yield_now();
         }
 
-        verify_container(&mut container, 1);
+        verify_container(&mut container, 3);
+        exit.store(true, Ordering::Relaxed);
     }
 
     #[test]

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -87,6 +87,10 @@ pub struct BamReceiveAndBuffer {
     shutdown: Arc<AtomicBool>,
     shared_leader_state: Option<SharedLeaderState>,
     next_fifo_priority: u64,
+    #[cfg(test)]
+    before_nonleader_receive: Option<Box<dyn FnOnce() + Send>>,
+    #[cfg(test)]
+    replacement_wait_receiver: crossbeam_channel::Receiver<()>,
 }
 
 struct ParsedBatch {
@@ -112,6 +116,8 @@ impl BamReceiveAndBuffer {
             crossbeam_channel::unbounded::<ParsedBatch>();
         let (recv_stats_sender, recv_stats_receiver) =
             crossbeam_channel::unbounded::<ReceivingStats>();
+        #[cfg(test)]
+        let (replacement_wait_sender, replacement_wait_receiver) = crossbeam_channel::bounded(1);
 
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = shutdown.clone();
@@ -128,6 +134,8 @@ impl BamReceiveAndBuffer {
                 bank_forks,
                 parsing_leader_state,
                 blacklisted_accounts,
+                #[cfg(test)]
+                replacement_wait_sender,
             )
         });
 
@@ -140,9 +148,14 @@ impl BamReceiveAndBuffer {
             shutdown,
             shared_leader_state,
             next_fifo_priority: u64::MAX,
+            #[cfg(test)]
+            before_nonleader_receive: None,
+            #[cfg(test)]
+            replacement_wait_receiver,
         }
     }
 
+    #[cfg_attr(test, allow(clippy::too_many_arguments))]
     fn run_parsing(
         exit: Arc<AtomicBool>,
         shutdown: Arc<AtomicBool>,
@@ -153,6 +166,7 @@ impl BamReceiveAndBuffer {
         bank_forks: Arc<RwLock<BankForks>>,
         shared_leader_state: Option<SharedLeaderState>,
         blacklisted_accounts: HashSet<Pubkey>,
+        #[cfg(test)] replacement_wait_sender: crossbeam_channel::Sender<()>,
     ) {
         let sigverify_thread_pool = rayon::ThreadPoolBuilder::new()
             .num_threads(2)
@@ -206,6 +220,8 @@ impl BamReceiveAndBuffer {
                     break working_bank;
                 }
                 // Keep the received burst intact until the replacement resolves.
+                #[cfg(test)]
+                let _ = replacement_wait_sender.try_send(());
                 std::thread::sleep(TIMEOUT);
             };
             let root_bank = bank_forks.read().unwrap().root_bank();
@@ -355,44 +371,6 @@ impl BamReceiveAndBuffer {
         self.shared_leader_state
             .as_ref()
             .is_some_and(|shared_leader_state| shared_leader_state.load().bank_slot().is_some())
-    }
-
-    fn buffer_batch(
-        &mut self,
-        container: &mut TransactionStateContainer<
-            RuntimeTransaction<ResolvedTransactionView<Bytes>>,
-        >,
-        batch: ParsedBatch,
-        bam_state: BamConnectionState,
-        stats: &mut ReceivingStats,
-    ) {
-        if bam_state != BamConnectionState::Connected {
-            stats.num_dropped_without_parsing += batch.txns_max_age.len();
-            return;
-        }
-
-        let ParsedBatch {
-            txns_max_age,
-            revert_on_error,
-            max_schedule_slot,
-            seq_id,
-        } = batch;
-
-        if container
-            .insert_new_batch(
-                txns_max_age,
-                self.next_fifo_priority,
-                revert_on_error,
-                max_schedule_slot,
-                seq_id,
-            )
-            .is_none()
-        {
-            stats.num_dropped_on_capacity += 1;
-            self.send_container_full_txn_batch_result(seq_id);
-            return;
-        }
-        self.next_fifo_priority = self.next_fifo_priority.saturating_sub(1);
     }
 
     fn parse_batch(
@@ -856,70 +834,77 @@ impl ReceiveAndBuffer for BamReceiveAndBuffer {
         container: &mut Self::Container,
         decision: &BufferedPacketsDecision,
     ) -> Result<ReceivingStats, DisconnectedError> {
-        let bam_state = BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Acquire));
-
-        // Receive all stats
         let mut stats = ReceivingStats::default();
         while let Ok(batch_stats) = self.recv_stats_receiver.try_recv() {
             stats.accumulate(batch_stats);
         }
 
-        let should_buffer_batches = matches!(
+        let buffering = matches!(
             decision,
             BufferedPacketsDecision::Consume(_) | BufferedPacketsDecision::Hold
         ) || self.should_buffer_batches();
-        match (should_buffer_batches, bam_state) {
-            // Preserve batches during the short Block Engine handoff. Connecting may be
-            // long-lived, so retain the existing drain behavior for that state.
-            (
-                true,
-                BamConnectionState::DrainingBlockEngine | BamConnectionState::BlockEngineDrained,
-            ) => {}
-            (true, _) => loop {
-                let batch = match self.parsed_batch_receiver.try_recv() {
+        if !buffering {
+            while let Some(next_batch_id) = container.pop() {
+                if let Some((_, _, _, seq_id)) = container.get_batch(next_batch_id.id) {
+                    self.send_no_leader_slot_txn_batch_result(seq_id);
+                }
+                container.remove_by_id(next_batch_id.id);
+            }
+            #[cfg(test)]
+            if let Some(before_receive) = self.before_nonleader_receive.take() {
+                before_receive();
+            }
+        }
+
+        let deadline = (!buffering).then(|| Instant::now() + Duration::from_millis(100));
+        loop {
+            let batch = if let Some(deadline) = deadline {
+                let (result, receive_time_us) =
+                    measure_us!(self.parsed_batch_receiver.recv_deadline(deadline));
+                stats.receive_time_us += receive_time_us;
+                match result {
+                    Ok(batch) => batch,
+                    Err(RecvTimeoutError::Disconnected) => return Err(DisconnectedError::Receiver),
+                    Err(RecvTimeoutError::Timeout) => break,
+                }
+            } else {
+                match self.parsed_batch_receiver.try_recv() {
                     Ok(batch) => batch,
                     Err(TryRecvError::Disconnected) => return Err(DisconnectedError::Receiver),
-                    Err(TryRecvError::Empty) => {
-                        // If the channel is empty, work here is done.
-                        break;
-                    }
-                };
-
-                self.buffer_batch(container, batch, bam_state, &mut stats);
-            },
-            (false, _) => {
-                // Ensure nothing is left in the container
-                while let Some(next_batch_id) = container.pop() {
-                    if let Some((_, _, _, seq_id)) = container.get_batch(next_batch_id.id) {
-                        self.send_no_leader_slot_txn_batch_result(seq_id);
-                    }
-                    container.remove_by_id(next_batch_id.id);
+                    Err(TryRecvError::Empty) => break,
                 }
+            };
 
-                // Allow the parser to catch up, but refresh leader state before rejecting work.
-                let deadline = Instant::now() + Duration::from_millis(100);
-                loop {
-                    let (batch, receive_time_us) =
-                        measure_us!(self.parsed_batch_receiver.recv_deadline(deadline));
-                    stats.receive_time_us += receive_time_us;
-
-                    let batch = match batch {
-                        Ok(batch) => batch,
-                        Err(RecvTimeoutError::Disconnected) => {
-                            return Err(DisconnectedError::Receiver);
-                        }
-                        Err(RecvTimeoutError::Timeout) => {
-                            break;
-                        }
-                    };
-                    if self.should_buffer_batches() {
-                        self.buffer_batch(container, batch, bam_state, &mut stats);
-                        break;
-                    } else {
-                        self.send_no_leader_slot_txn_batch_result(batch.seq_id);
-                        stats.num_dropped_without_parsing += 1;
-                    }
-                }
+            // Both leadership and the BAM connection can change while receive is blocked.
+            if !buffering && !self.should_buffer_batches() {
+                self.send_no_leader_slot_txn_batch_result(batch.seq_id);
+                stats.num_dropped_without_parsing += 1;
+                continue;
+            }
+            let bam_state = BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Acquire));
+            if matches!(
+                bam_state,
+                BamConnectionState::Disconnected | BamConnectionState::Connecting
+            ) {
+                stats.num_dropped_without_parsing += batch.txns_max_age.len();
+            } else if container
+                .insert_new_batch(
+                    batch.txns_max_age,
+                    self.next_fifo_priority,
+                    batch.revert_on_error,
+                    batch.max_schedule_slot,
+                    batch.seq_id,
+                )
+                .is_none()
+            {
+                stats.num_dropped_on_capacity += 1;
+                self.send_container_full_txn_batch_result(batch.seq_id);
+            } else {
+                self.next_fifo_priority = self.next_fifo_priority.saturating_sub(1);
+            }
+            if !buffering {
+                // Resume scheduling with a fresh decision after recovering replacement work.
+                break;
             }
         }
 
@@ -1136,7 +1121,7 @@ impl SigverifyMetrics {
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
     use {
         super::*,
         crate::{
@@ -1251,6 +1236,31 @@ mod tests {
         )
     }
 
+    pub(crate) fn transfer_batch(payer: &Keypair, bank: &Bank, seq_id: u32) -> AtomicTxnBatch {
+        let transaction = transfer(payer, &Pubkey::new_unique(), 1, bank.last_blockhash());
+        AtomicTxnBatch {
+            seq_id,
+            ..batch_with_packet_data(wincode::serialize(&transaction).unwrap().into())
+        }
+    }
+
+    pub(crate) fn set_leader_bank(state: &mut SharedLeaderState, bank: Option<Arc<Bank>>) {
+        state.store(Arc::new(LeaderState::new(bank, 0, None, None)));
+    }
+
+    impl BamReceiveAndBuffer {
+        pub(crate) fn wait_for_parsed_batches(&self, count: usize) {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while self.parsed_batch_receiver.len() < count {
+                assert!(
+                    Instant::now() < deadline,
+                    "parser did not produce {count} batches"
+                );
+                std::thread::sleep(TIMEOUT);
+            }
+        }
+    }
+
     #[allow(clippy::type_complexity)]
     fn setup_bam_receive_and_buffer(
         receiver: crossbeam_channel::Receiver<MultipleAtomicTxnBatch>,
@@ -1279,58 +1289,21 @@ mod tests {
         (exit, receive_and_buffer, container, response_receiver)
     }
 
-    #[test]
-    fn test_select_parsing_bank_during_replacement() {
-        let (bank_forks, _mint_keypair) = test_bank_forks();
-        let root_bank = bank_forks.read().unwrap().root_bank();
-        let old_bank = child_bank(&root_bank, 1);
-        let new_bank = child_bank(&root_bank, 1);
-
-        let mut shared_leader_state = SharedLeaderState::new(0, None, None);
-        let select = |state: &SharedLeaderState| {
-            BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(state))
-        };
-        let leader_state = LeaderState::new(Some(old_bank.clone()), 0, None, None);
-        shared_leader_state.store(Arc::new(leader_state));
-        let selected = select(&shared_leader_state).unwrap();
-        assert!(Arc::ptr_eq(&selected, &old_bank));
-
-        shared_leader_state.set_bank_replacement();
-        assert!(select(&shared_leader_state).is_none());
-
-        let leader_state = LeaderState::new(Some(new_bank.clone()), 0, None, None);
-        shared_leader_state.store(Arc::new(leader_state));
-        let selected = select(&shared_leader_state).unwrap();
-        assert!(Arc::ptr_eq(&selected, &new_bank));
-
-        shared_leader_state.store(Arc::new(LeaderState::new(None, 0, None, None)));
-        let working_bank = bank_forks.read().unwrap().working_bank();
-        let selected = select(&shared_leader_state).unwrap();
-        assert!(Arc::ptr_eq(&selected, &working_bank));
-    }
-
     fn verify_container<Tx: TransactionWithMeta>(
         container: &mut impl StateContainer<Tx>,
         expected_length: usize,
     ) {
-        let mut actual_length: usize = 0;
-        while let Some(id) = container.pop() {
-            let Some((ids, _, _, _)) = container.get_batch(id.id) else {
-                panic!(
-                    "transaction in queue position {} with id {} must exist.",
-                    actual_length, id.id
-                );
-            };
+        for _ in 0..expected_length {
+            let id = container.pop().expect("expected queued batch");
+            let (ids, _, _, _) = container.get_batch(id.id).expect("batch must exist");
             for id in ids {
                 assert!(
                     container.get_transaction(*id).is_some(),
-                    "Transaction ID {id} not found in container",
+                    "transaction must exist"
                 );
             }
-            actual_length += 1;
         }
-
-        assert_eq!(actual_length, expected_length);
+        assert!(container.pop().is_none(), "unexpected extra batch");
     }
 
     type TestVerifyResult = Result<(Vec<PacketVerificationResult>, bool, u32, u64), (Reason, u32)>;
@@ -1480,270 +1453,189 @@ mod tests {
     }
 
     #[test]
-    fn test_receive_and_buffer_simple_transfer_across_bam_handoff() {
-        let (sender, receiver) = unbounded();
-        let (bank_forks, mint_keypair) = test_bank_forks();
-        let (exit, mut receive_and_buffer, mut container, _response_receiver) =
-            setup_bam_receive_and_buffer(receiver, bank_forks.clone(), None, HashSet::new());
-        let bam_enabled = receive_and_buffer.bam_enabled.clone();
-        bam_enabled.store(
-            BamConnectionState::DrainingBlockEngine as u8,
-            Ordering::Release,
-        );
-        let transaction = transfer(
-            &mint_keypair,
-            &Pubkey::new_unique(),
-            1,
-            bank_forks.read().unwrap().root_bank().last_blockhash(),
-        );
-        sender
-            .send(MultipleAtomicTxnBatch {
-                batches: vec![AtomicTxnBatch {
-                    seq_id: 1,
-                    packets: vec![Packet {
-                        data: wincode::serialize(&transaction).unwrap().into(),
-                        meta: None,
-                    }],
-                    max_schedule_slot: Slot::MAX,
-                }],
-            })
-            .unwrap();
+    fn test_receive_and_buffer_replacement_and_connection_transitions() {
+        use BamConnectionState::*;
+        for decision in [
+            BufferedPacketsDecision::Forward,
+            BufferedPacketsDecision::ForwardAndHold,
+        ] {
+            for (initial, state, published) in [
+                (Connecting, Disconnected, false),
+                (Connecting, Connecting, false),
+                (Connecting, DrainingBlockEngine, false),
+                (Connecting, BlockEngineDrained, true),
+                (Connecting, Connected, false),
+                (Connected, Connected, true),
+            ] {
+                let (sender, receiver) = unbounded();
+                let (bank_forks, mint) = test_bank_forks();
+                let replacement = bank_forks.read().unwrap().working_bank();
+                let mut shared = SharedLeaderState::new(0, None, None);
+                set_leader_bank(&mut shared, Some(replacement.clone()));
+                let (_exit, mut receiver, mut container, mut responses) =
+                    setup_bam_receive_and_buffer(
+                        receiver,
+                        bank_forks,
+                        Some(shared.clone()),
+                        HashSet::new(),
+                    );
+                let batches = (70_001..=70_002)
+                    .map(|seq_id| transfer_batch(&mint, &replacement, seq_id))
+                    .collect();
+                sender.send(MultipleAtomicTxnBatch { batches }).unwrap();
+                // Prepare real parsed work first; delivery below is independent of parser timing.
+                let batches = (0..2)
+                    .map(|_| {
+                        receiver
+                            .parsed_batch_receiver
+                            .recv_timeout(Duration::from_secs(5))
+                            .unwrap()
+                    })
+                    .collect::<Vec<_>>();
+                let (parsed_sender, parsed_receiver) = unbounded();
+                receiver.parsed_batch_receiver = parsed_receiver;
+                set_leader_bank(&mut shared, None);
+                let bam_enabled = receiver.bam_enabled.clone();
+                bam_enabled.store(initial as u8, Ordering::Release);
+                let publish_bank = replacement.clone();
+                let delivery = parsed_sender.clone();
+                let connection = bam_enabled.clone();
+                receiver.before_nonleader_receive = Some(Box::new(move || {
+                    set_leader_bank(&mut shared, Some(publish_bank.clone()));
+                    shared.set_bank_replacement();
+                    assert!(shared.load().working_bank().is_none());
+                    if published {
+                        set_leader_bank(&mut shared, Some(publish_bank));
+                    }
+                    connection.store(state as u8, Ordering::Release);
+                    for batch in batches {
+                        delivery.send(batch).unwrap();
+                    }
+                }));
 
-        let start = Instant::now();
-        loop {
-            if receive_and_buffer
-                .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
-                .unwrap()
-                .num_received
-                > 0
-            {
-                break;
+                let stats = receiver
+                    .receive_and_buffer_packets(&mut container, &decision)
+                    .unwrap();
+                let retained = !matches!(state, Disconnected | Connecting);
+                assert!(receiver.before_nonleader_receive.is_none());
+                assert_eq!(
+                    container.queue_size(),
+                    usize::from(retained),
+                    "{decision:?}, {state:?}"
+                );
+                assert_eq!(stats.num_dropped_without_parsing, usize::from(!retained));
+                assert!(responses.try_recv().is_err());
+                // The stale invocation must retain the first batch itself; a fresh decision
+                // only drains the second batch and must preserve their FIFO ordering.
+                bam_enabled.store(Connected as u8, Ordering::Release);
+                receiver
+                    .receive_and_buffer_packets(
+                        &mut container,
+                        &BufferedPacketsDecision::Consume(replacement),
+                    )
+                    .unwrap();
+                let mut seq_ids = Vec::new();
+                while let Some(id) = container.pop() {
+                    seq_ids.push(container.get_batch(id.id).unwrap().3);
+                }
+                assert_eq!(
+                    seq_ids,
+                    if retained {
+                        vec![70_001, 70_002]
+                    } else {
+                        vec![70_002]
+                    }
+                );
+                assert!(responses.try_recv().is_err());
             }
-            assert!(start.elapsed() < Duration::from_secs(30));
         }
-        assert!(container.is_empty());
-
-        bam_enabled.store(
-            BamConnectionState::BlockEngineDrained as u8,
-            Ordering::Release,
-        );
-        receive_and_buffer
-            .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
-            .unwrap();
-        assert!(container.is_empty());
-
-        bam_enabled.store(BamConnectionState::Connected as u8, Ordering::Release);
-        let start = Instant::now();
-        while container.is_empty() && start.elapsed() < Duration::from_secs(30) {
-            receive_and_buffer
-                .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
-                .unwrap();
-        }
-
-        verify_container(&mut container, 1);
-        exit.store(true, Ordering::Relaxed);
     }
 
     #[test]
-    fn test_receive_and_buffer_preserves_replacement_batches_during_stale_forward_drain() {
+    fn test_parser_replacement_handoff_and_rejection() {
         let (sender, receiver) = unbounded();
-        let (bank_forks, mint_keypair) = test_bank_forks();
-        let root_bank = bank_forks.read().unwrap().root_bank();
-        let old_bank = child_bank(&root_bank, 1);
-        let replacement_bank = child_bank(&root_bank, 1);
-        replacement_bank.register_unique_recent_blockhash_for_test();
-        assert_eq!(old_bank.slot(), replacement_bank.slot());
-        assert_ne!(old_bank.bank_id(), replacement_bank.bank_id());
-
-        let mut shared_leader_state = SharedLeaderState::new(0, None, None);
-        let (exit, mut receive_and_buffer, mut container, mut response_receiver) =
-            setup_bam_receive_and_buffer(
-                receiver,
-                bank_forks,
-                Some(shared_leader_state.clone()),
-                HashSet::new(),
-            );
-
-        // Reject a probe first so replacement begins while the same Forward call
-        // is blocked on its fixed receive deadline.
-        const DRAIN_PROBE_SEQ_ID: u32 = 70_000;
-        let drain_probe = transfer(
-            &mint_keypair,
-            &Pubkey::new_unique(),
-            1,
-            old_bank.last_blockhash(),
+        let (bank_forks, mint) = test_bank_forks();
+        let root = bank_forks.read().unwrap().root_bank();
+        let old_bank = child_bank(&root, 1);
+        let bank = child_bank(&root, 1);
+        bank.register_unique_recent_blockhash_for_test();
+        assert_eq!(old_bank.slot(), bank.slot());
+        assert_ne!(old_bank.bank_id(), bank.bank_id());
+        let mut shared = SharedLeaderState::new(0, None, None);
+        let parsing_state = shared.clone();
+        let select = || BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(&parsing_state));
+        let (_exit, mut receiver, mut container, mut responses) = setup_bam_receive_and_buffer(
+            receiver,
+            bank_forks.clone(),
+            Some(shared.clone()),
+            HashSet::new(),
         );
-        let mut drain_probe_batch =
-            batch_with_packet_data(wincode::serialize(&drain_probe).unwrap().into());
-        drain_probe_batch.seq_id = DRAIN_PROBE_SEQ_ID;
-        sender
-            .send(MultipleAtomicTxnBatch {
-                batches: vec![drain_probe_batch],
-            })
-            .unwrap();
-
-        let stale_drain = std::thread::spawn(move || {
-            receive_and_buffer
-                .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Forward)
+        for state in [
+            BamConnectionState::DrainingBlockEngine,
+            BamConnectionState::BlockEngineDrained,
+        ] {
+            receiver.bam_enabled.store(state as u8, Ordering::Release);
+            set_leader_bank(&mut shared, Some(old_bank.clone()));
+            assert!(Arc::ptr_eq(&select().unwrap(), &old_bank));
+            shared.set_bank_replacement();
+            assert!(select().is_none());
+            while receiver.replacement_wait_receiver.try_recv().is_ok() {}
+            sender
+                .send(MultipleAtomicTxnBatch {
+                    batches: vec![transfer_batch(&mint, &bank, 1)],
+                })
                 .unwrap();
-            (receive_and_buffer, container)
-        });
-
-        let probe_deadline = Instant::now() + Duration::from_secs(5);
-        let response = loop {
-            if let Ok(response) = response_receiver.try_recv() {
-                break response;
-            }
-            assert!(
-                Instant::now() < probe_deadline,
-                "timed out waiting for the drain probe result"
-            );
-            std::thread::yield_now();
-        };
-        let BamOutboundMessage::AtomicTxnBatchResult(result) = response else {
-            panic!("expected drain probe result");
-        };
-        assert_eq!(result.seq_id, DRAIN_PROBE_SEQ_ID);
-        assert!(matches!(
-            &result.result,
-            Some(atomic_txn_batch_result::Result::NotCommitted(not_committed))
-                if matches!(
-                    &not_committed.reason,
-                    Some(Reason::SchedulingError(reason))
-                        if *reason == SchedulingError::OutsideLeaderSlot as i32
-                )
-        ));
-
-        // Hide the retiring Bank so parsing retains work until its replacement is ready.
-        shared_leader_state.store(Arc::new(LeaderState::new(Some(old_bank), 0, None, None)));
-        shared_leader_state.set_bank_replacement();
-        assert!(shared_leader_state.load().working_bank().is_none());
-
-        const DURING_REPLACEMENT_SEQ_ID: u32 = 70_001;
-        let during_replacement_transaction = transfer(
-            &mint_keypair,
-            &Pubkey::new_unique(),
-            1,
-            replacement_bank.last_blockhash(),
-        );
-        let mut during_replacement_batch = batch_with_packet_data(
-            wincode::serialize(&during_replacement_transaction)
-                .unwrap()
-                .into(),
-        );
-        during_replacement_batch.seq_id = DURING_REPLACEMENT_SEQ_ID;
-        sender
-            .send(MultipleAtomicTxnBatch {
-                batches: vec![during_replacement_batch],
-            })
-            .unwrap();
-        let receive_deadline = Instant::now() + Duration::from_secs(5);
-        while !sender.is_empty() {
-            assert!(
-                Instant::now() < receive_deadline,
-                "parser did not receive the replacement-pending batch"
-            );
-            std::thread::yield_now();
-        }
-        assert!(
-            response_receiver.try_recv().is_err(),
-            "replacement-pending batch escaped before the new Bank was published"
-        );
-
-        // Publishing the replacement releases pending parsing while the stale
-        // Forward call is still active.
-        shared_leader_state.store(Arc::new(LeaderState::new(
-            Some(replacement_bank.clone()),
-            0,
-            None,
-            None,
-        )));
-
-        // Work sent after publication must use the replacement state rather than
-        // the cached Forward decision.
-        const POST_REPLACEMENT_SEQ_ID: u32 = 70_002;
-        let post_replacement_transaction = transfer(
-            &mint_keypair,
-            &Pubkey::new_unique(),
-            1,
-            replacement_bank.last_blockhash(),
-        );
-        let mut post_replacement_batch = batch_with_packet_data(
-            wincode::serialize(&post_replacement_transaction)
-                .unwrap()
-                .into(),
-        );
-        post_replacement_batch.seq_id = POST_REPLACEMENT_SEQ_ID;
-        sender
-            .send(MultipleAtomicTxnBatch {
-                batches: vec![post_replacement_batch],
-            })
-            .unwrap();
-
-        let (mut receive_and_buffer, mut container) = stale_drain.join().unwrap();
-        let current_leader_state = shared_leader_state.load();
-        let current_bank = current_leader_state
-            .working_bank()
-            .expect("replacement Bank must be active when the stale drain exits");
-        assert!(Arc::ptr_eq(current_bank, &replacement_bank));
-
-        let mut unexpected_responses = Vec::new();
-        while let Ok(BamOutboundMessage::AtomicTxnBatchResult(result)) =
-            response_receiver.try_recv()
-        {
-            let outside_leader_slot = matches!(
-                &result.result,
-                Some(atomic_txn_batch_result::Result::NotCommitted(not_committed))
-                    if matches!(
-                        &not_committed.reason,
-                        Some(Reason::SchedulingError(reason))
-                            if *reason == SchedulingError::OutsideLeaderSlot as i32
-                    )
-            );
-            unexpected_responses.push((result.seq_id, outside_leader_slot));
-        }
-        assert!(
-            unexpected_responses.is_empty(),
-            "replacement batches received responses from the stale Forward drain (seq_id, \
-             outside_leader_slot): {unexpected_responses:?}"
-        );
-
-        // A fresh Consume decision must recover retained work and accept new work.
-        const CONTROL_SEQ_ID: u32 = 70_003;
-        let control_transaction = transfer(
-            &mint_keypair,
-            &Pubkey::new_unique(),
-            1,
-            replacement_bank.last_blockhash(),
-        );
-        let mut control_batch =
-            batch_with_packet_data(wincode::serialize(&control_transaction).unwrap().into());
-        control_batch.seq_id = CONTROL_SEQ_ID;
-        sender
-            .send(MultipleAtomicTxnBatch {
-                batches: vec![control_batch],
-            })
-            .unwrap();
-
-        let consume = BufferedPacketsDecision::Consume(replacement_bank);
-        let buffer_deadline = Instant::now() + Duration::from_secs(5);
-        while container.queue_size() < 3 {
-            receive_and_buffer
-                .receive_and_buffer_packets(&mut container, &consume)
+            // Observe the actual parser holding raw ingress before publishing the new bank.
+            receiver
+                .replacement_wait_receiver
+                .recv_timeout(Duration::from_secs(5))
                 .unwrap();
-            assert!(
-                response_receiver.try_recv().is_err(),
-                "replacement or control batch was unexpectedly rejected"
-            );
-            assert!(
-                Instant::now() < buffer_deadline,
-                "timed out waiting for replacement and control batches"
-            );
-            std::thread::yield_now();
+            assert!(receiver.parsed_batch_receiver.is_empty());
+            assert!(responses.try_recv().is_err());
+            set_leader_bank(&mut shared, Some(bank.clone()));
+            assert!(Arc::ptr_eq(&select().unwrap(), &bank));
+            receiver.wait_for_parsed_batches(1);
+            receiver
+                .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
+                .unwrap();
+            assert!(!container.is_empty());
+            assert!(responses.try_recv().is_err());
         }
-
-        verify_container(&mut container, 3);
-        exit.store(true, Ordering::Relaxed);
+        set_leader_bank(&mut shared, None);
+        assert!(Arc::ptr_eq(&select().unwrap(), &root));
+        // A genuine boundary still rejects work buffered during handoff.
+        receiver
+            .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Forward)
+            .unwrap();
+        assert!(container.is_empty());
+        for _ in 0..2 {
+            let BamOutboundMessage::AtomicTxnBatchResult(result) = responses.try_recv().unwrap()
+            else {
+                panic!("expected batch result")
+            };
+            assert!(
+                matches!(result.result, Some(atomic_txn_batch_result::Result::NotCommitted(not_committed))
+                if not_committed.reason == Some(Reason::SchedulingError(SchedulingError::OutsideLeaderSlot as i32)))
+            );
+        }
+        container = TransactionStateContainer::with_capacity(0);
+        sender
+            .send(MultipleAtomicTxnBatch {
+                batches: vec![transfer_batch(&mint, &root, 1)],
+            })
+            .unwrap();
+        receiver.wait_for_parsed_batches(1);
+        let stats = receiver
+            .receive_and_buffer_packets(&mut container, &BufferedPacketsDecision::Hold)
+            .unwrap();
+        assert_eq!(stats.num_dropped_on_capacity, 1);
+        let BamOutboundMessage::AtomicTxnBatchResult(result) = responses.try_recv().unwrap() else {
+            panic!("expected batch result")
+        };
+        assert!(
+            matches!(result.result, Some(atomic_txn_batch_result::Result::NotCommitted(not_committed))
+            if not_committed.reason == Some(Reason::SchedulingError(SchedulingError::ContainerFull as i32)))
+        );
     }
 
     #[test]

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -534,7 +534,11 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         container: &mut impl StateContainer<Tx>,
     ) {
         // Check if no bank or slot has changed
-        let bank_slot = decision.bank().map(|bank| bank.slot());
+        let bank_slot = decision.bank().map(|bank| bank.slot()).or_else(|| {
+            matches!(decision, BufferedPacketsDecision::Hold)
+                .then(|| self.shared_leader_state.load().bank_slot())
+                .flatten()
+        });
         if bank_slot == self.slot {
             return;
         }
@@ -852,7 +856,7 @@ mod tests {
         solana_keypair::Keypair,
         solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_message::Message,
-        solana_poh::poh_recorder::SharedLeaderState,
+        solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
         solana_pubkey::Pubkey,
         solana_runtime::{bank::Bank, bank_forks::BankForks},
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
@@ -1252,7 +1256,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "node must exist")]
     fn test_prio_graph_clears_on_slot_boundary() {
         let (bank_forks, _) = test_bank_forks();
         let TestScheduler {
@@ -1295,27 +1298,13 @@ mod tests {
             "Prio graph should have transactions"
         );
 
-        // Store transaction IDs that are currently in the prio_graph
-        let mut stored_txn_ids = Vec::new();
-        while let Some(txn_id) = scheduler.prio_graph.pop() {
-            stored_txn_ids.push(txn_id);
-            // Unblock to allow the next transaction to be popped
-            scheduler.prio_graph.unblock(&txn_id);
-        }
-
-        // Re-insert the transactions back into prio_graph for testing
-        for txn_id in &stored_txn_ids {
-            // Get transaction from container to re-insert
-            if let Some((batch_ids, _, _, _)) = container.get_batch(txn_id.id) {
-                let txns = batch_ids
-                    .iter()
-                    .filter_map(|id| container.get_transaction(*id));
-                scheduler.prio_graph.insert_transaction(
-                    *txn_id,
-                    BamScheduler::<RuntimeTransaction<SanitizedTransaction>>::get_transactions_account_access(txns.into_iter()),
-                );
-            }
-        }
+        let leader_state = LeaderState::new(Some(bank), 0, None, None);
+        scheduler.shared_leader_state.store(Arc::new(leader_state));
+        scheduler.shared_leader_state.set_bank_replacement();
+        scheduler
+            .receive_completed(&mut container, &BufferedPacketsDecision::Hold)
+            .unwrap();
+        assert!(!scheduler.prio_graph.is_empty());
 
         // Simulate slot boundary change by changing to no bank (None)
         let decision_no_bank = BufferedPacketsDecision::Forward;
@@ -1324,12 +1313,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(scheduler.slot, None);
-
-        // This should panic because the prio_graph has been cleared
-        // and the transaction ID no longer exists in the graph
-        if let Some(first_id) = stored_txn_ids.first() {
-            scheduler.prio_graph.unblock(first_id);
-        }
+        assert!(scheduler.prio_graph.is_empty());
+        assert!(container.is_empty());
     }
 
     /// Regression test for the `solBamSched` "blocking node must exist" panic.

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -425,7 +425,12 @@ where
                     // is never called so `pull_into_prio_graph` never drains the
                     // priority queue. Drain leftover batch entries here to avoid
                     // stale batches accumulating until the next slot change.
-                    if self.bam_controller {
+                    if self.bam_controller
+                        && matches!(
+                            BamConnectionState::from_u8(self.bam_enabled.load(Ordering::Acquire)),
+                            BamConnectionState::Disconnected | BamConnectionState::Connecting
+                        )
+                    {
                         while let Some(id) = self.container.pop() {
                             self.container.remove_by_id(id.id);
                         }
@@ -1456,13 +1461,19 @@ mod tests {
     }
 
     #[test]
-    fn test_bam_controller_process_transactions_no_panic() {
+    fn test_bam_controller_handoff() {
         use crate::banking_stage::transaction_scheduler::{
-            bam_receive_and_buffer::BamReceiveAndBuffer, bam_scheduler::BamScheduler,
+            bam_receive_and_buffer::{
+                BamReceiveAndBuffer,
+                tests::{set_leader_bank, transfer_batch},
+            },
+            bam_scheduler::BamScheduler,
         };
 
         let GenesisConfigInfo {
-            mut genesis_config, ..
+            mut genesis_config,
+            mint_keypair,
+            ..
         } = create_slow_genesis_config(u64::MAX);
         genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
         let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
@@ -1473,8 +1484,8 @@ mod tests {
         let bam_enabled = Arc::new(AtomicU8::new(BamConnectionState::Connected as u8));
         let exit = Arc::new(AtomicBool::new(false));
 
-        let (_bundle_sender, bundle_receiver) = unbounded();
-        let (response_sender, _response_receiver) = tokio::sync::mpsc::channel(100);
+        let (bundle_sender, bundle_receiver) = unbounded();
+        let (response_sender, mut response_receiver) = tokio::sync::mpsc::channel(100);
 
         let receive_and_buffer = BamReceiveAndBuffer::new(
             exit.clone(),
@@ -1486,7 +1497,7 @@ mod tests {
             HashSet::default(),
         );
 
-        let (consume_work_sender, _consume_work_receiver) = unbounded();
+        let (consume_work_sender, consume_work_receiver) = unbounded();
         let (_finished_work_sender, finished_work_receiver) = unbounded();
 
         let scheduler = BamScheduler::new(
@@ -1497,7 +1508,7 @@ mod tests {
             shared_leader_state.clone(),
         );
 
-        let mut scheduler_controller = SchedulerController::new(
+        let mut controller = SchedulerController::new(
             exit.clone(),
             SchedulerConfig::default(),
             decision_maker,
@@ -1507,28 +1518,63 @@ mod tests {
             vec![],
             Arc::new(SchedulerPriorityFloor::default()),
             true, // bam_controller
-            bam_enabled,
+            bam_enabled.clone(),
         );
 
         // Set leader state so DecisionMaker returns Consume
-        shared_leader_state.store(Arc::new(LeaderState::new(
-            Some(bank.clone()),
-            bank.tick_height(),
-            None,
-            None,
-        )));
+        set_leader_bank(&mut shared_leader_state, Some(bank.clone()));
 
-        let decision = scheduler_controller
-            .decision_maker
-            .make_consume_or_forward_decision();
+        let decision = controller.decision_maker.make_consume_or_forward_decision();
         assert!(matches!(decision, BufferedPacketsDecision::Consume(_)));
 
-        // This would have panicked before the fix: cost_pacer is None for
-        // bam_controller, but process_transactions now uses u64::MAX budget.
+        // BAM scheduling must also work without a cost pacer.
+        controller.receive_completed(&decision).unwrap();
         let now = Instant::now();
-        let result = scheduler_controller.process_transactions(&decision, None, &now);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
+
+        for (seq_id, state) in [
+            BamConnectionState::DrainingBlockEngine,
+            BamConnectionState::BlockEngineDrained,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            bam_enabled.store(state as u8, Ordering::Release);
+            bundle_sender
+                .send(jito_protos::proto::bam_types::MultipleAtomicTxnBatch {
+                    batches: vec![transfer_batch(&mint_keypair, &bank, seq_id as u32)],
+                })
+                .unwrap();
+            controller.receive_and_buffer.wait_for_parsed_batches(1);
+            controller.receive_and_buffer_packets(&decision).unwrap();
+            assert_eq!(
+                controller
+                    .process_transactions(&decision, None, &now)
+                    .unwrap(),
+                0
+            );
+            assert_eq!(controller.container.queue_size(), seq_id + 1);
+            assert!(consume_work_receiver.is_empty());
+            assert!(response_receiver.try_recv().is_err());
+        }
+        let ids = (0..2)
+            .map(|seq_id| {
+                let id = controller.container.pop().unwrap();
+                assert_eq!(controller.container.get_batch(id.id).unwrap().3, seq_id);
+                id
+            })
+            .collect::<Vec<_>>();
+        controller.container.push_ids_into_queue(ids.into_iter());
+        bam_enabled.store(BamConnectionState::Connected as u8, Ordering::Release);
+        assert_eq!(
+            controller
+                .process_transactions(&decision, None, &now)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            consume_work_receiver.try_recv().unwrap().transactions.len(),
+            1
+        );
 
         exit.store(true, Ordering::Relaxed);
     }

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1018,12 +1018,13 @@ fn handle_parent_ready(
             new_parent_slot,
         ))?;
     let cleared_bank_id = bank.bank_id();
+    ctx.poh_recorder.write().unwrap().set_bank_replacement();
     bank.quiesce_transaction_execution();
     let entry_bytes_consumed = bank.entry_bytes_budget().consumed();
     ctx.bank_forks_controller
         .clear_bank(slot)
         .map_err(|_| PohRecorderError::ResetBankError(old_parent_slot, new_parent_slot))?;
-    ctx.poh_recorder.write().unwrap().clear_bank(true);
+    ctx.poh_recorder.write().unwrap().clear_bank(false);
 
     if let Some(sender) = &ctx.entry_notification_sender
         && let Err(err) = sender.send(EntryNotification::UpdateParent(EntryUpdateParentInfo {
@@ -1047,7 +1048,10 @@ fn handle_parent_ready(
         *block_timer,
         entry_bytes_consumed,
     )
-    .map_err(|_| PohRecorderError::ResetBankError(old_parent_slot, new_parent_slot))?;
+    .map_err(|_| {
+        reset_poh_recorder(&ctx.bank_forks.read().unwrap().working_bank(), ctx);
+        PohRecorderError::ResetBankError(old_parent_slot, new_parent_slot)
+    })?;
     update_leader_window_clock(ctx, slot, *block_timer);
 
     // Re-inject accumulated transactions back to banking stage for rescheduling
@@ -1498,7 +1502,7 @@ mod tests {
         solana_leader_schedule::{FixedSchedule, LeaderSchedule, SlotLeader},
         solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path_auto_delete},
         solana_poh::{
-            poh_recorder::{PohRecorder, Record, WorkingBankEntryOrMarker},
+            poh_recorder::{PohRecorder, Record, SharedLeaderState, WorkingBankEntryOrMarker},
             record_channels::record_channels,
             transaction_recorder::TransactionRecorder,
         },
@@ -1549,6 +1553,7 @@ mod tests {
 
     struct TestBankForksController {
         bank_forks: Arc<RwLock<BankForks>>,
+        shared_leader_state: Option<SharedLeaderState>,
     }
 
     impl BankForksController for TestBankForksController {
@@ -1566,6 +1571,11 @@ mod tests {
         }
 
         fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {
+            if let Some(shared_leader_state) = &self.shared_leader_state {
+                let leader_state = shared_leader_state.load();
+                assert!(leader_state.working_bank().is_none());
+                assert!(leader_state.bank_slot().is_some());
+            }
             let bank_to_clear = self.bank_forks.read().unwrap().get_with_scheduler(slot);
             if let Some(bank) = bank_to_clear {
                 let _ = bank.wait_for_completed_scheduler();
@@ -1578,7 +1588,10 @@ mod tests {
     fn test_bank_forks_controller(
         bank_forks: Arc<RwLock<BankForks>>,
     ) -> Arc<dyn BankForksController> {
-        Arc::new(TestBankForksController { bank_forks })
+        Arc::new(TestBankForksController {
+            bank_forks,
+            shared_leader_state: None,
+        })
     }
 
     fn leader_window_info(start_slot: Slot, parent_slot: Slot) -> LeaderWindowInfo {
@@ -2007,11 +2020,15 @@ mod tests {
         );
         poh_recorder.enable_alpenglow();
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let shared_leader_state = poh_recorder.read().unwrap().shared_leader_state();
 
         let (record_sender, record_receiver) = record_channels(false);
         let (leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
         let (banking_stage_sender, banking_stage_receiver) = BankingTracer::channel_for_test();
-        let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
+        let bank_forks_controller = Arc::new(TestBankForksController {
+            bank_forks: bank_forks.clone(),
+            shared_leader_state: Some(shared_leader_state.clone()),
+        });
         let (reward_certs_requestor, _receiver) = CertsRequestor::new();
         let (entry_notification_sender, entry_notification_receiver) = bounded(1);
 
@@ -2060,7 +2077,6 @@ mod tests {
             ctx.poh_recorder.read().unwrap().start_bank_id(),
             optimistic_parent_bank_id
         );
-        let shared_leader_state = ctx.poh_recorder.read().unwrap().shared_leader_state();
         let optimistic_leader_state = shared_leader_state.load();
 
         // Both atomic transactions are valid on the optimistic fork: they reference its

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -336,7 +336,7 @@ fn start_loop(config: BlockCreationLoopConfig, reward_certs_requestor: CertsRequ
         let mut w_poh_recorder = ctx.poh_recorder.write().unwrap();
         w_poh_recorder.enable_alpenglow();
     }
-    reset_poh_recorder(&ctx.bank_forks.read().unwrap().working_bank(), &ctx);
+    reset_poh_recorder(&ctx.bank_forks.read().unwrap().working_bank(), &ctx, false);
 
     while !ctx.exit.load(Ordering::Relaxed) {
         // Check if set-identity was called at each leader window start
@@ -436,7 +436,7 @@ fn start_loop(config: BlockCreationLoopConfig, reward_certs_requestor: CertsRequ
 }
 
 /// Resets poh recorder
-fn reset_poh_recorder(bank: &Arc<Bank>, ctx: &LeaderContext) {
+fn reset_poh_recorder(bank: &Arc<Bank>, ctx: &LeaderContext, preserve_replacement_slot: bool) {
     trace!("{}: resetting poh to {}", ctx.my_pubkey, bank.slot());
     assert!(ctx.record_receiver.is_shutdown() && ctx.record_receiver.is_safe_to_restart());
     let next_leader_slot = ctx.leader_schedule_cache.next_leader_slot(
@@ -447,10 +447,12 @@ fn reset_poh_recorder(bank: &Arc<Bank>, ctx: &LeaderContext) {
         GRACE_TICKS_FACTOR * MAX_GRACE_SLOTS,
     );
 
-    ctx.poh_recorder
-        .write()
-        .unwrap()
-        .reset(bank.clone(), next_leader_slot);
+    let mut poh_recorder = ctx.poh_recorder.write().unwrap();
+    if preserve_replacement_slot {
+        poh_recorder.reset_for_bank_replacement(bank.clone(), next_leader_slot);
+    } else {
+        poh_recorder.reset(bank.clone(), next_leader_slot);
+    }
 }
 
 /// Returns the elapsed leader-window time at which `slot` must be completed.
@@ -929,7 +931,7 @@ fn abort_working_bank(ctx: &mut LeaderContext, slot: Slot) -> Result<(), BankFor
         .unwrap_or_else(|| ctx.bank_forks.read().unwrap().root_bank());
     bank.quiesce_transaction_execution();
     ctx.bank_forks_controller.clear_bank(slot)?;
-    reset_poh_recorder(&reset_bank, ctx);
+    reset_poh_recorder(&reset_bank, ctx, false);
     Ok(())
 }
 
@@ -1049,7 +1051,7 @@ fn handle_parent_ready(
         entry_bytes_consumed,
     )
     .map_err(|_| {
-        reset_poh_recorder(&ctx.bank_forks.read().unwrap().working_bank(), ctx);
+        reset_poh_recorder(&ctx.bank_forks.read().unwrap().working_bank(), ctx, false);
         PohRecorderError::ResetBankError(old_parent_slot, new_parent_slot)
     })?;
     update_leader_window_clock(ctx, slot, *block_timer);
@@ -1359,7 +1361,7 @@ fn create_and_insert_leader_bank(
     if ctx.poh_recorder.read().unwrap().start_bank_id() != parent_bank.bank_id() {
         // PoH must be based on the exact parent bank. Comparing slots is insufficient because
         // fast leader handover can switch between parent banks in the same slot.
-        reset_poh_recorder(&parent_bank, ctx);
+        reset_poh_recorder(&parent_bank, ctx, true);
     }
 
     // After potentially resetting, there should be no working bank.
@@ -1495,7 +1497,7 @@ mod tests {
         },
         agave_banking_stage_ingress_types::BankingPacketReceiver,
         crossbeam_channel::{bounded, unbounded},
-        jito_protos::proto::bam_types::atomic_txn_batch_result::Result::NotCommitted,
+        jito_protos::proto::bam_types::atomic_txn_batch_result::Result::{Committed, NotCommitted},
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_entry::{block_component::VersionedUpdateParent, entry_or_marker::EntryOrMarker},
         solana_keypair::Keypair,
@@ -1503,7 +1505,7 @@ mod tests {
         solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path_auto_delete},
         solana_poh::{
             poh_recorder::{PohRecorder, Record, SharedLeaderState, WorkingBankEntryOrMarker},
-            record_channels::record_channels,
+            record_channels::{RecordSender, record_channels},
             transaction_recorder::TransactionRecorder,
         },
         solana_poh_config::PohConfig,
@@ -1558,6 +1560,12 @@ mod tests {
 
     impl BankForksController for TestBankForksController {
         fn insert_bank(&self, bank: Bank) -> Result<BankWithScheduler, BankForksControllerError> {
+            if let Some(shared_leader_state) = &self.shared_leader_state {
+                let leader_state = shared_leader_state.load();
+                assert!(leader_state.working_bank().is_none());
+                assert_eq!(leader_state.bank_slot(), Some(bank.slot()));
+                assert!(!leader_state.atomic_batches_enabled());
+            }
             Ok(self.bank_forks.write().unwrap().insert(bank))
         }
 
@@ -1574,7 +1582,8 @@ mod tests {
             if let Some(shared_leader_state) = &self.shared_leader_state {
                 let leader_state = shared_leader_state.load();
                 assert!(leader_state.working_bank().is_none());
-                assert!(leader_state.bank_slot().is_some());
+                assert_eq!(leader_state.bank_slot(), Some(slot));
+                assert!(!leader_state.atomic_batches_enabled());
             }
             let bank_to_clear = self.bank_forks.read().unwrap().get_with_scheduler(slot);
             if let Some(bank) = bank_to_clear {
@@ -1592,6 +1601,75 @@ mod tests {
             bank_forks,
             shared_leader_state: None,
         })
+    }
+
+    struct TestContext {
+        ctx: LeaderContext,
+        record_sender: RecordSender,
+        entry_receiver: Receiver<WorkingBankEntryOrMarker>,
+        banking_stage_receiver: BankingPacketReceiver,
+        leader_window_info_sender: Sender<LeaderWindowInfo>,
+        _reward_requests: Receiver<rewards::msg_types::RewardRequest>,
+    }
+
+    fn test_context(
+        my_pubkey: Pubkey,
+        bank_forks: Arc<RwLock<BankForks>>,
+        blockstore: Arc<Blockstore>,
+        leader_slots: (Slot, Slot),
+    ) -> TestContext {
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
+        let exit = Arc::new(AtomicBool::new(false));
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+            root_bank.tick_height(),
+            root_bank.last_blockhash(),
+            root_bank.clone(),
+            Some(leader_slots),
+            root_bank.ticks_per_slot(),
+            blockstore.clone(),
+            &leader_schedule_cache,
+            &PohConfig::default(),
+            exit.clone(),
+        );
+        poh_recorder.enable_alpenglow();
+        let (record_sender, record_receiver) = record_channels(false);
+        let (leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
+        let (banking_stage_sender, banking_stage_receiver) = BankingTracer::channel_for_test();
+        let (reward_certs_requestor, reward_requests) = CertsRequestor::new();
+        let ctx = LeaderContext {
+            exit,
+            my_pubkey,
+            leader_window_info_receiver,
+            pending_parent_ready: None,
+            highest_parent_ready: Arc::new(RwLock::new((0, Block::new_unique(0)))),
+            highest_finalized: Arc::new(RwLock::new(None)),
+            blockstore,
+            record_receiver,
+            poh_recorder: Arc::new(RwLock::new(poh_recorder)),
+            leader_schedule_cache,
+            sharable_banks: bank_forks.read().unwrap().sharable_banks(),
+            alpenglow_slot_clock: SharedAlpenglowSlotClock::default(),
+            bank_forks: bank_forks.clone(),
+            bank_forks_controller: test_bank_forks_controller(bank_forks.clone()),
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            entry_notification_sender: None,
+            banking_tracer: BankingTracer::new_disabled(),
+            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
+            reward_certs_requestor,
+            banking_stage_sender,
+            metrics: LoopMetrics::default(),
+            genesis_cert_block_marker: test_genesis_cert_block_marker(),
+        };
+        TestContext {
+            ctx,
+            record_sender,
+            entry_receiver,
+            banking_stage_receiver,
+            leader_window_info_sender,
+            _reward_requests: reward_requests,
+        }
     }
 
     fn leader_window_info(start_slot: Slot, parent_slot: Slot) -> LeaderWindowInfo {
@@ -1676,55 +1754,15 @@ mod tests {
         root_bank.freeze();
         let bank_forks = BankForks::new_rw_arc(root_bank);
         let root_bank = bank_forks.read().unwrap().root_bank();
-        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
 
-        let exit = Arc::new(AtomicBool::new(false));
-        let poh_config = PohConfig::default();
-        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
-            root_bank.tick_height(),
-            root_bank.last_blockhash(),
-            root_bank.clone(),
-            Some((1, 1)),
-            root_bank.ticks_per_slot(),
-            blockstore.clone(),
-            &leader_schedule_cache,
-            &poh_config,
-            exit.clone(),
-        );
-        poh_recorder.enable_alpenglow();
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
-
-        let (_record_sender, record_receiver) = record_channels(false);
-        let (_leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
-        let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
-        let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
-        let (reward_certs_requestor, _receiver) = CertsRequestor::new();
-
-        let mut ctx = LeaderContext {
-            exit,
-            my_pubkey,
-            leader_window_info_receiver,
-            pending_parent_ready: None,
-            highest_parent_ready: Arc::new(RwLock::new((0, Block::new_unique(0)))),
-            highest_finalized: Arc::new(RwLock::new(None)),
-            blockstore,
-            record_receiver,
-            poh_recorder,
-            leader_schedule_cache,
-            sharable_banks: bank_forks.read().unwrap().sharable_banks(),
-            alpenglow_slot_clock: SharedAlpenglowSlotClock::default(),
-            bank_forks: bank_forks.clone(),
-            bank_forks_controller,
-            rpc_subscriptions: None,
-            slot_status_notifier: None,
-            entry_notification_sender: None,
-            banking_tracer: BankingTracer::new_disabled(),
-            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
-            reward_certs_requestor,
-            banking_stage_sender,
-            metrics: LoopMetrics::default(),
-            genesis_cert_block_marker: test_genesis_cert_block_marker(),
-        };
+        let TestContext {
+            mut ctx,
+            record_sender: _record_sender,
+            entry_receiver: _entry_receiver,
+            banking_stage_receiver: _banking_stage_receiver,
+            leader_window_info_sender: _leader_window_info_sender,
+            _reward_requests,
+        } = test_context(my_pubkey, bank_forks.clone(), blockstore, (1, 1));
 
         create_and_insert_leader_bank(1, root_bank.clone(), 0, true, &mut ctx).unwrap();
         assert!(ctx.poh_recorder.read().unwrap().has_bank());
@@ -1777,7 +1815,6 @@ mod tests {
         root_bank.freeze();
         let bank_forks = BankForks::new_rw_arc(root_bank);
         let root_bank = bank_forks.read().unwrap().root_bank();
-        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
         let parent_bank = Bank::new_from_parent(
             root_bank.clone(),
             SlotLeader {
@@ -1790,56 +1827,16 @@ mod tests {
         bank_forks.write().unwrap().insert(parent_bank);
         let parent_bank = bank_forks.read().unwrap().get(1).unwrap();
 
-        let exit = Arc::new(AtomicBool::new(false));
-        let poh_config = PohConfig::default();
-        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
-            root_bank.tick_height(),
-            root_bank.last_blockhash(),
-            root_bank,
-            Some((2, 2)),
-            parent_bank.ticks_per_slot(),
-            blockstore.clone(),
-            &leader_schedule_cache,
-            &poh_config,
-            exit.clone(),
-        );
-        poh_recorder.enable_alpenglow();
+        let TestContext {
+            mut ctx,
+            record_sender: _record_sender,
+            entry_receiver,
+            banking_stage_receiver: _banking_stage_receiver,
+            leader_window_info_sender: _leader_window_info_sender,
+            _reward_requests,
+        } = test_context(my_pubkey, bank_forks.clone(), blockstore, (2, 2));
         drop(entry_receiver);
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
-
-        let (_record_sender, record_receiver) = record_channels(false);
-        let (_leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
-        let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
-        let mut genesis_cert_block_marker = test_genesis_cert_block_marker();
-        genesis_cert_block_marker.slot = parent_bank.slot();
-        let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
-        let (reward_certs_requestor, _receiver) = CertsRequestor::new();
-
-        let mut ctx = LeaderContext {
-            exit,
-            my_pubkey,
-            leader_window_info_receiver,
-            pending_parent_ready: None,
-            highest_parent_ready: Arc::new(RwLock::new((0, Block::new_unique(0)))),
-            highest_finalized: Arc::new(RwLock::new(None)),
-            blockstore,
-            record_receiver,
-            poh_recorder,
-            leader_schedule_cache,
-            sharable_banks: bank_forks.read().unwrap().sharable_banks(),
-            alpenglow_slot_clock: SharedAlpenglowSlotClock::default(),
-            bank_forks: bank_forks.clone(),
-            bank_forks_controller,
-            rpc_subscriptions: None,
-            slot_status_notifier: None,
-            entry_notification_sender: None,
-            banking_tracer: BankingTracer::new_disabled(),
-            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
-            reward_certs_requestor,
-            banking_stage_sender,
-            metrics: LoopMetrics::default(),
-            genesis_cert_block_marker,
-        };
+        ctx.genesis_cert_block_marker.slot = parent_bank.slot();
 
         let err = create_and_insert_leader_bank(2, parent_bank, 0, true, &mut ctx).unwrap_err();
         assert!(matches!(
@@ -1862,55 +1859,16 @@ mod tests {
         root_bank.freeze();
         let bank_forks = BankForks::new_rw_arc(root_bank);
         let root_bank = bank_forks.read().unwrap().root_bank();
-        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
 
-        let exit = Arc::new(AtomicBool::new(false));
-        let poh_config = PohConfig::default();
-        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
-            root_bank.tick_height(),
-            root_bank.last_blockhash(),
-            root_bank.clone(),
-            Some((1, 1)),
-            root_bank.ticks_per_slot(),
-            blockstore.clone(),
-            &leader_schedule_cache,
-            &poh_config,
-            exit.clone(),
-        );
-        poh_recorder.enable_alpenglow();
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
-
-        let (record_sender, record_receiver) = record_channels(false);
-        let (_leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
-        let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
-        let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
-        let (reward_certs_requestor, _reward_request_receiver) = CertsRequestor::new();
-
-        let mut ctx = LeaderContext {
-            exit,
-            my_pubkey,
-            leader_window_info_receiver,
-            pending_parent_ready: None,
-            highest_parent_ready: Arc::new(RwLock::new((2, Block::new_unique(0)))),
-            highest_finalized: Arc::new(RwLock::new(None)),
-            blockstore,
-            record_receiver,
-            poh_recorder,
-            leader_schedule_cache,
-            sharable_banks: bank_forks.read().unwrap().sharable_banks(),
-            alpenglow_slot_clock: SharedAlpenglowSlotClock::default(),
-            bank_forks: bank_forks.clone(),
-            bank_forks_controller,
-            rpc_subscriptions: None,
-            slot_status_notifier: None,
-            entry_notification_sender: None,
-            banking_tracer: BankingTracer::new_disabled(),
-            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
-            reward_certs_requestor,
-            banking_stage_sender,
-            metrics: LoopMetrics::default(),
-            genesis_cert_block_marker: test_genesis_cert_block_marker(),
-        };
+        let TestContext {
+            mut ctx,
+            record_sender,
+            entry_receiver: _entry_receiver,
+            banking_stage_receiver: _banking_stage_receiver,
+            leader_window_info_sender: _leader_window_info_sender,
+            _reward_requests,
+        } = test_context(my_pubkey, bank_forks.clone(), blockstore, (1, 1));
+        *ctx.highest_parent_ready.write().unwrap() = (2, Block::new_unique(0));
 
         create_and_insert_leader_bank(1, root_bank, 0, true, &mut ctx).unwrap();
         let bank_id = ctx.poh_recorder.read().unwrap().bank().unwrap().bank_id();
@@ -1942,15 +1900,20 @@ mod tests {
 
     #[test]
     fn test_sad_leader_handover_same_parent_slot() {
-        test_sad_leader_handover(1);
+        test_sad_leader_handover(1, false);
     }
 
     #[test]
     fn test_sad_leader_handover_different_parent_slot() {
-        test_sad_leader_handover(3);
+        test_sad_leader_handover(3, false);
     }
 
-    fn test_sad_leader_handover(optimistic_parent_slot: Slot) {
+    #[test]
+    fn test_sad_leader_handover_expired_parent_ready() {
+        test_sad_leader_handover(1, true);
+    }
+
+    fn test_sad_leader_handover(optimistic_parent_slot: Slot, expired_parent_ready: bool) {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let my_pubkey = Pubkey::new_unique();
@@ -1960,8 +1923,6 @@ mod tests {
         root_bank.freeze();
         let bank_forks = BankForks::new_rw_arc(root_bank);
         let root_bank = bank_forks.read().unwrap().root_bank();
-
-        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
 
         let new_parent_slot = 1;
         let new_parent_hash = Hash::new_unique();
@@ -2005,67 +1966,31 @@ mod tests {
             new_parent.last_blockhash()
         );
 
-        let exit = Arc::new(AtomicBool::new(false));
-        let poh_config = PohConfig::default();
-        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
-            root_bank.tick_height(),
-            root_bank.last_blockhash(),
-            root_bank.clone(),
-            Some((4, 7)),
-            root_bank.ticks_per_slot(),
-            blockstore.clone(),
-            &leader_schedule_cache,
-            &poh_config,
-            exit.clone(),
+        let TestContext {
+            mut ctx,
+            record_sender,
+            entry_receiver,
+            banking_stage_receiver,
+            leader_window_info_sender,
+            _reward_requests,
+        } = test_context(my_pubkey, bank_forks.clone(), blockstore, (4, 7));
+        let shared_leader_state = ctx.poh_recorder.read().unwrap().shared_leader_state();
+        *ctx.highest_parent_ready.write().unwrap() = (
+            4,
+            Block {
+                slot: new_parent_slot,
+                block_id: new_parent_hash,
+            },
         );
-        poh_recorder.enable_alpenglow();
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
-        let shared_leader_state = poh_recorder.read().unwrap().shared_leader_state();
-
-        let (record_sender, record_receiver) = record_channels(false);
-        let (leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
-        let (banking_stage_sender, banking_stage_receiver) = BankingTracer::channel_for_test();
-        let bank_forks_controller = Arc::new(TestBankForksController {
-            bank_forks: bank_forks.clone(),
-            shared_leader_state: Some(shared_leader_state.clone()),
-        });
-        let (reward_certs_requestor, _receiver) = CertsRequestor::new();
         let (entry_notification_sender, entry_notification_receiver) = bounded(1);
-
-        let mut ctx = LeaderContext {
-            exit,
-            my_pubkey,
-            leader_window_info_receiver,
-            pending_parent_ready: None,
-            highest_parent_ready: Arc::new(RwLock::new((
-                4,
-                Block {
-                    slot: new_parent_slot,
-                    block_id: new_parent_hash,
-                },
-            ))),
-            highest_finalized: Arc::new(RwLock::new(None)),
-            blockstore,
-            record_receiver,
-            poh_recorder,
-            leader_schedule_cache,
-            sharable_banks: bank_forks.read().unwrap().sharable_banks(),
-            alpenglow_slot_clock: SharedAlpenglowSlotClock::default(),
-            bank_forks: bank_forks.clone(),
-            bank_forks_controller,
-            rpc_subscriptions: None,
-            slot_status_notifier: None,
-            entry_notification_sender: Some(entry_notification_sender),
-            banking_tracer: BankingTracer::new_disabled(),
-            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
-            reward_certs_requestor,
-            banking_stage_sender,
-            metrics: LoopMetrics::default(),
-            genesis_cert_block_marker: test_genesis_cert_block_marker(),
-        };
+        ctx.entry_notification_sender = Some(entry_notification_sender);
 
         let leader_slot = 4;
         create_and_insert_leader_bank(leader_slot, optimistic_parent, 0, false, &mut ctx).unwrap();
+        ctx.bank_forks_controller = Arc::new(TestBankForksController {
+            bank_forks: bank_forks.clone(),
+            shared_leader_state: Some(shared_leader_state.clone()),
+        });
         let optimistic_bank = ctx.poh_recorder.read().unwrap().bank().unwrap();
         let optimistic_bank_id = optimistic_bank.bank_id();
         const ENTRY_BYTES_CONSUMED_BEFORE_HANDOVER: u64 = 1_024;
@@ -2160,7 +2085,11 @@ mod tests {
             ))
             .unwrap();
 
-        let parent_ready_started_at = Instant::now();
+        let parent_ready_started_at = if expired_parent_ready {
+            Instant::now() - Duration::from_secs(60)
+        } else {
+            Instant::now()
+        };
         let parent_ready = LeaderWindowInfo {
             start_slot: leader_slot,
             end_slot: 7,
@@ -2170,7 +2099,7 @@ mod tests {
             },
             block_timer: parent_ready_started_at,
         };
-        let new_bank = handle_parent_ready(
+        let result = handle_parent_ready(
             &mut ctx,
             &mut SlotMetrics::new(leader_slot, true),
             parent_ready,
@@ -2180,9 +2109,28 @@ mod tests {
             },
             vec![accumulated_tx.clone()],
             &mut Instant::now(),
-        )
-        .unwrap()
-        .expect("sad handover should recreate the leader bank");
+        );
+        let old_bank = optimistic_leader_state.working_bank().unwrap();
+        assert_eq!(old_bank.bank_id(), optimistic_bank_id);
+        assert!(old_bank.try_enter_transaction_execution().is_none());
+        if expired_parent_ready {
+            assert!(matches!(
+                result,
+                Err(PohRecorderError::ResetBankError(_, _))
+            ));
+            let leader_state = shared_leader_state.load();
+            assert!(leader_state.working_bank().is_none());
+            assert_eq!(leader_state.bank_slot(), None);
+            assert!(leader_state.atomic_batches_enabled());
+            assert!(!ctx.poh_recorder.read().unwrap().has_bank());
+            assert!(ctx.bank_forks.read().unwrap().get(leader_slot).is_none());
+            assert!(ctx.record_receiver.is_shutdown());
+            assert!(ctx.record_receiver.is_safe_to_restart());
+            return;
+        }
+        let new_bank = result
+            .unwrap()
+            .expect("sad handover should recreate the leader bank");
 
         assert_eq!(new_bank.slot(), leader_slot);
         assert_eq!(new_bank.parent_slot(), new_parent_slot);
@@ -2196,8 +2144,8 @@ mod tests {
                 .atomic_batches_enabled()
         );
 
-        // The replacement fork does not contain `fork_payer`. Verify the real consume worker
-        // rejects the entire atomic batch rather than committing its valid prefix.
+        // Reject the provisional batch on the replacement fork, then verify a valid control
+        // transaction commits through the real consume worker.
         let (replay_vote_sender, _replay_vote_receiver) = bounded(1);
         let worker_exit = Arc::new(AtomicBool::default());
         let worker = ConsumeWorker::new(
@@ -2215,43 +2163,73 @@ mod tests {
         let worker_handle = thread::spawn(move || worker.run());
 
         let replacement_decision = BufferedPacketsDecision::Consume(new_bank.clone());
-        bam_scheduler
-            .receive_completed(&mut container, &replacement_decision)
-            .unwrap();
-        bam_scheduler.schedule(&mut container, 0, u64::MAX).unwrap();
-
-        let result_deadline = Instant::now() + Duration::from_secs(5);
-        let response = loop {
+        let control_recipient = Pubkey::new_unique();
+        let control = [(
+            runtime_transfer(&genesis.mint_keypair, control_recipient, recent_blockhash),
+            MaxAge::MAX,
+        )]
+        .into_iter()
+        .collect();
+        for (seq_id, batch) in [(71, None), (73, Some(control))] {
+            if let Some(batch) = batch {
+                container
+                    .insert_new_batch(batch, u64::MAX, true, leader_slot, seq_id)
+                    .unwrap();
+            }
             bam_scheduler
                 .receive_completed(&mut container, &replacement_decision)
                 .unwrap();
-            if let Ok(response) = response_receiver.try_recv() {
-                break response;
+            bam_scheduler.schedule(&mut container, 0, u64::MAX).unwrap();
+
+            let result_deadline = Instant::now() + Duration::from_secs(5);
+            let response = loop {
+                bam_scheduler
+                    .receive_completed(&mut container, &replacement_decision)
+                    .unwrap();
+                if let Ok(response) = response_receiver.try_recv() {
+                    break response;
+                }
+                assert!(
+                    Instant::now() < result_deadline,
+                    "timed out waiting for atomic batch result"
+                );
+                thread::sleep(Duration::from_millis(1));
+            };
+            for record in ctx.record_receiver.inner().try_iter() {
+                assert_eq!(record.bank_id, new_bank.bank_id());
+                ctx.record_receiver.on_received_record();
+                ctx.poh_recorder
+                    .write()
+                    .unwrap()
+                    .record(record.bank_id, record.mixin, record.transactions)
+                    .unwrap();
             }
-            assert!(
-                Instant::now() < result_deadline,
-                "timed out waiting for atomic batch result"
-            );
-            thread::sleep(Duration::from_millis(1));
-        };
+            let BamOutboundMessage::AtomicTxnBatchResult(result) = response else {
+                panic!("expected atomic transaction batch result");
+            };
+            assert_eq!(result.seq_id, seq_id);
+            if seq_id == 71 {
+                assert!(matches!(result.result, Some(NotCommitted(_))));
+                assert_eq!(
+                    new_bank.entry_bytes_budget().consumed(),
+                    ENTRY_BYTES_CONSUMED_BEFORE_HANDOVER
+                );
+            } else {
+                assert!(matches!(result.result, Some(Committed(_))));
+            }
+        }
         worker_exit.store(true, Ordering::Relaxed);
         worker_handle.join().unwrap().unwrap();
 
-        let BamOutboundMessage::AtomicTxnBatchResult(result) = response else {
-            panic!("expected atomic transaction batch result");
-        };
-        assert_eq!(result.seq_id, 71);
-        assert!(matches!(result.result, Some(NotCommitted(_))));
         assert_eq!(new_bank.get_balance(&first_recipient), 0);
+        assert_eq!(new_bank.get_balance(&control_recipient), 1);
 
-        assert_eq!(
-            new_bank.entry_bytes_budget().consumed(),
-            ENTRY_BYTES_CONSUMED_BEFORE_HANDOVER
-        );
+        let entry_bytes_consumed = new_bank.entry_bytes_budget().consumed();
+        assert!(entry_bytes_consumed > ENTRY_BYTES_CONSUMED_BEFORE_HANDOVER);
         assert!(
             new_bank
                 .entry_bytes_budget()
-                .reserve(new_bank.max_entry_bytes_per_slot() - ENTRY_BYTES_CONSUMED_BEFORE_HANDOVER)
+                .reserve(new_bank.max_entry_bytes_per_slot() - entry_bytes_consumed)
                 .is_ok()
         );
         assert!(new_bank.entry_bytes_budget().reserve(1).is_err());

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -207,7 +207,7 @@ pub struct PohRecorder {
     tick_cache: Vec<(Entry, u64)>, // cache of entry and its tick_height
     /// This stores the current working bank + scheduler and other metadata,
     /// if they exist.
-    /// This field MUST be kept consistent with the `shared_leader_state` field.
+    /// This field MUST match `shared_leader_state` outside bank replacement.
     working_bank: Option<WorkingBank>,
     shared_leader_state: SharedLeaderState,
     working_bank_sender: Sender<WorkingBankEntryOrMarker>,
@@ -560,6 +560,10 @@ impl PohRecorder {
         }
 
         self.notify_replay_wakeup();
+    }
+
+    pub fn set_bank_replacement(&mut self) {
+        self.shared_leader_state.set_bank_replacement();
     }
 
     /// Returns tick_height - does not update the internal state for tick_height.
@@ -1194,6 +1198,7 @@ impl SharedLeaderState {
     ) -> Self {
         let inner = LeaderState {
             working_bank: None,
+            bank_replacement: AtomicBool::new(false),
             atomic_batches_enabled: AtomicBool::new(true),
             tick_height: AtomicU64::new(tick_height),
             leader_first_tick_height,
@@ -1211,6 +1216,12 @@ impl SharedLeaderState {
         self.0.store(state)
     }
 
+    /// Marks a same-slot bank replacement.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    fn set_bank_replacement(&self) {
+        self.load().bank_replacement.store(true, Ordering::Relaxed);
+    }
+
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn increment_tick_height(&self) {
         let inner = self.0.load();
@@ -1220,6 +1231,7 @@ impl SharedLeaderState {
 
 pub struct LeaderState {
     working_bank: Option<Arc<Bank>>,
+    bank_replacement: AtomicBool,
     atomic_batches_enabled: AtomicBool,
     tick_height: AtomicU64,
     leader_first_tick_height: Option<u64>,
@@ -1253,6 +1265,7 @@ impl LeaderState {
     ) -> Self {
         Self {
             working_bank,
+            bank_replacement: AtomicBool::new(false),
             atomic_batches_enabled: AtomicBool::new(atomic_batches_enabled),
             tick_height: AtomicU64::new(tick_height),
             leader_first_tick_height,
@@ -1261,7 +1274,13 @@ impl LeaderState {
     }
 
     pub fn working_bank(&self) -> Option<&Arc<Bank>> {
-        self.working_bank.as_ref()
+        self.working_bank
+            .as_ref()
+            .filter(|_| !self.bank_replacement.load(Ordering::Relaxed))
+    }
+
+    pub fn bank_slot(&self) -> Option<Slot> {
+        self.working_bank.as_ref().map(|bank| bank.slot())
     }
 
     pub fn atomic_batches_enabled(&self) -> bool {

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -308,6 +308,25 @@ impl PohRecorder {
 
     // synchronize PoH with a bank
     pub fn reset(&mut self, reset_bank: Arc<Bank>, next_leader_slot: Option<(Slot, Slot)>) {
+        self.reset_internal(reset_bank, next_leader_slot, None);
+    }
+
+    /// Reset PoH while preserving the slot of a bank being replaced.
+    pub fn reset_for_bank_replacement(
+        &mut self,
+        reset_bank: Arc<Bank>,
+        next_leader_slot: Option<(Slot, Slot)>,
+    ) {
+        let bank_slot = self.shared_leader_state.load().bank_slot();
+        self.reset_internal(reset_bank, next_leader_slot, bank_slot);
+    }
+
+    fn reset_internal(
+        &mut self,
+        reset_bank: Arc<Bank>,
+        next_leader_slot: Option<(Slot, Slot)>,
+        bank_slot: Option<Slot>,
+    ) {
         self.clear_bank(false);
         let tick_height = self.reset_poh(reset_bank, true);
 
@@ -318,12 +337,15 @@ impl PohRecorder {
         // Above call to `clear_bank` did not set the shared state,
         // nor did `reset_poh` update the tick_height.
         // Do the atomic swap of state here to reflect the reset.
-        self.shared_leader_state.store(Arc::new(LeaderState::new(
+        let mut leader_state = LeaderState::new_with_atomic_batches_enabled(
             None,
             tick_height,
             leader_first_tick_height,
             next_leader_slot,
-        )));
+            bank_slot.is_none(),
+        );
+        leader_state.bank_slot = bank_slot;
+        self.shared_leader_state.store(Arc::new(leader_state));
 
         self.leader_last_tick_height = leader_last_tick_height;
     }
@@ -1196,14 +1218,12 @@ impl SharedLeaderState {
         leader_first_tick_height: Option<u64>,
         next_leader_slot_range: Option<(Slot, Slot)>,
     ) -> Self {
-        let inner = LeaderState {
-            working_bank: None,
-            bank_replacement: AtomicBool::new(false),
-            atomic_batches_enabled: AtomicBool::new(true),
-            tick_height: AtomicU64::new(tick_height),
+        let inner = LeaderState::new(
+            None,
+            tick_height,
             leader_first_tick_height,
             next_leader_slot_range,
-        };
+        );
         Self(Arc::new(ArcSwap::from_pointee(inner)))
     }
 
@@ -1219,7 +1239,15 @@ impl SharedLeaderState {
     /// Marks a same-slot bank replacement.
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn set_bank_replacement(&self) {
-        self.load().bank_replacement.store(true, Ordering::Relaxed);
+        let state = self.load();
+        self.0.store(Arc::new(LeaderState {
+            working_bank: None,
+            bank_slot: state.bank_slot(),
+            atomic_batches_enabled: AtomicBool::new(false),
+            tick_height: AtomicU64::new(state.tick_height()),
+            leader_first_tick_height: state.leader_first_tick_height(),
+            next_leader_slot_range: state.next_leader_slot_range(),
+        }));
     }
 
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -1231,7 +1259,7 @@ impl SharedLeaderState {
 
 pub struct LeaderState {
     working_bank: Option<Arc<Bank>>,
-    bank_replacement: AtomicBool,
+    bank_slot: Option<Slot>,
     atomic_batches_enabled: AtomicBool,
     tick_height: AtomicU64,
     leader_first_tick_height: Option<u64>,
@@ -1264,8 +1292,8 @@ impl LeaderState {
         atomic_batches_enabled: bool,
     ) -> Self {
         Self {
+            bank_slot: working_bank.as_ref().map(|bank| bank.slot()),
             working_bank,
-            bank_replacement: AtomicBool::new(false),
             atomic_batches_enabled: AtomicBool::new(atomic_batches_enabled),
             tick_height: AtomicU64::new(tick_height),
             leader_first_tick_height,
@@ -1274,13 +1302,11 @@ impl LeaderState {
     }
 
     pub fn working_bank(&self) -> Option<&Arc<Bank>> {
-        self.working_bank
-            .as_ref()
-            .filter(|_| !self.bank_replacement.load(Ordering::Relaxed))
+        self.working_bank.as_ref()
     }
 
     pub fn bank_slot(&self) -> Option<Slot> {
-        self.working_bank.as_ref().map(|bank| bank.slot())
+        self.bank_slot
     }
 
     pub fn atomic_batches_enabled(&self) -> bool {
@@ -2117,8 +2143,33 @@ mod tests {
 
         poh_recorder.set_bank_for_test(bank.clone());
         assert_eq!(bank.slot(), 0);
+        let shared_leader_state = poh_recorder.shared_leader_state();
+        let old_state = shared_leader_state.load();
+        poh_recorder.set_bank_replacement();
+        assert!(Arc::ptr_eq(old_state.working_bank().unwrap(), &bank));
+        assert!(old_state.atomic_batches_enabled());
+        let replacement_state = shared_leader_state.load();
+        assert!(replacement_state.working_bank().is_none());
+        assert_eq!(replacement_state.bank_slot(), Some(0));
+        assert!(!replacement_state.atomic_batches_enabled());
+        assert_eq!(replacement_state.tick_height(), old_state.tick_height());
+        assert_eq!(
+            replacement_state.leader_first_tick_height(),
+            old_state.leader_first_tick_height()
+        );
+        assert_eq!(
+            replacement_state.next_leader_slot_range(),
+            old_state.next_leader_slot_range()
+        );
+        poh_recorder.reset_for_bank_replacement(bank.clone(), Some((4, 4)));
+        let reconstructed_state = shared_leader_state.load();
+        assert!(reconstructed_state.working_bank().is_none());
+        assert_eq!(reconstructed_state.bank_slot(), Some(0));
+        assert!(!reconstructed_state.atomic_batches_enabled());
         poh_recorder.reset(bank, Some((4, 4)));
         assert!(poh_recorder.working_bank.is_none());
+        assert_eq!(shared_leader_state.load().bank_slot(), None);
+        assert!(shared_leader_state.load().atomic_batches_enabled());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- mark same-slot replacement before clearing the retiring bank
- hide the retiring bank while retaining its slot for queued BAM work
- clear replacement state naturally when the new bank is published
- reset PoH and leader state if bank reconstruction fails