### PR TITLE
ci: Update nightly rebase matrix channels

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -32,20 +32,14 @@ jobs:
           - branch: master
             upstream_branch: master
             upstream_repo: https://github.com/anza-xyz/agave.git
-          - branch: v3.1
-            upstream_branch: v3.1
-            upstream_repo: https://github.com/anza-xyz/agave.git
-          - branch: v3.0
-            upstream_branch: v3.0
-            upstream_repo: https://github.com/anza-xyz/agave.git
-          - branch: v4.0
-            upstream_branch: v4.0
-            upstream_repo: https://github.com/anza-xyz/agave.git
           - branch: v4.1
             upstream_branch: v4.1
             upstream_repo: https://github.com/anza-xyz/agave.git
           - branch: v4.2
             upstream_branch: v4.2
+            upstream_repo: https://github.com/anza-xyz/agave.git
+          - branch: v4.3
+            upstream_branch: v4.3
             upstream_repo: https://github.com/anza-xyz/agave.git
       fail-fast: false
     steps:


### PR DESCRIPTION
Add v4.3, missed when the channel was cut. Drop v3.0, v3.1 and v4.0, which are EoL upstream.