### PR TITLE
ci: Run duplicate-shreds on fewer cores 

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,8 +1,17 @@
+experimental = ["wrapper-scripts"]
+
 [store]
 dir = "target/nextest"
 
 [test-groups]
 build-sbf = { max-threads = 1 }
+
+# test_duplicate_shreds_broadcast_leader's dump-then-repair recovery loses a
+# shred-arrival race on wide/fast hosts (EPYC 9575F 128t CI agents fail ~98%
+# per attempt; <=16-thread hosts pass reliably). Clamp its CPU affinity to a
+# laptop-class core count until the upstream repair-retry budget is hardened.
+[scripts.wrapper.clamp-cpus]
+command = "taskset -c 0-15"
 
 [profile.ci]
 failure-output = "immediate-final"
@@ -75,6 +84,11 @@ slow-timeout = { period = "60s", terminate-after = 3 }
 [[profile.ci.overrides]]
 filter = 'package(solana-local-cluster) & test(/^test_duplicate_shreds_broadcast_leader$/)'
 slow-timeout = { period = "60s", terminate-after = 10 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_duplicate_shreds_broadcast_leader$/)'
+platform = 'cfg(target_os = "linux")'
+run-wrapper = "clamp-cpus"
 
 [[profile.ci.overrides]]
 filter = 'package(solana-local-cluster)'


### PR DESCRIPTION
test_duplicate_shreds_broadcast_leader loses a shred-arrival race on wide/fast CI hosts: the conflicting duplicate version lands before the slot is full, the slot is dead-marked at insert (`mark_slot_dead_if_not_full`), and the dump-then-repair loop exhausts its 10-attempt budget (`MAX_REPAIR_RETRY_LOOP_ATTEMPTS`). Per-attempt failure is ~98% on the 128-thread EPYC 9575F agents (slc/ny), ~50% on the 48-64-thread agents (ci-*), ~0% at laptop-class core counts. All involved code is byte-identical to upstream; #14885 does not cover this mode.

Wrap the test in `taskset -c 0-15` via a nextest wrapper script (nextest 0.9.137, `experimental = ["wrapper-scripts"]`), scoped to Linux so local macOS runs are unaffected. Remove once the upstream repair-retry budget is hardened.