### PR TITLE
MEV-12682: gate BAM work until leader bank resolution

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -719,7 +719,6 @@ impl BankingStage {
                             work_sender,
                             finished_work_receiver,
                             bam_dependencies.outbound_sender.clone(),
-                            bam_scheduler_bank_forks.clone(),
                             bam_shared_leader_state.clone(),
                         );
                         let receive_and_buffer = BamReceiveAndBuffer::new(

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -210,7 +210,7 @@ impl BamReceiveAndBuffer {
                 }
             }
 
-            let working_bank = loop {
+            let (working_bank, bank_checks_enabled) = loop {
                 if exit.load(Ordering::Relaxed) || shutdown.load(Ordering::Relaxed) {
                     return;
                 }
@@ -281,6 +281,7 @@ impl BamReceiveAndBuffer {
                                 max_schedule_slot,
                                 (&root_bank, &working_bank),
                                 &blacklisted_accounts,
+                                bank_checks_enabled,
                                 &mut metrics,
                             ));
                         stats.accumulate(parse_stats);
@@ -320,17 +321,17 @@ impl BamReceiveAndBuffer {
     fn select_parsing_bank(
         bank_forks: &RwLock<BankForks>,
         shared_leader_state: Option<&SharedLeaderState>,
-    ) -> Option<Arc<Bank>> {
+    ) -> Option<(Arc<Bank>, bool)> {
         if let Some(shared_leader_state) = shared_leader_state {
             let leader_state = shared_leader_state.load();
             if let Some(working_bank) = leader_state.working_bank() {
-                return Some(working_bank.clone());
+                return Some((working_bank.clone(), leader_state.atomic_batches_enabled()));
             }
             if leader_state.bank_slot().is_some() {
                 return None;
             }
         }
-        Some(bank_forks.read().unwrap().working_bank())
+        Some((bank_forks.read().unwrap().working_bank(), true))
     }
 
     fn send_no_leader_slot_txn_batch_result(&self, seq_id: u32) {
@@ -380,6 +381,7 @@ impl BamReceiveAndBuffer {
         max_schedule_slot: u64,
         (root_bank, working_bank): (&Bank, &Bank),
         blacklisted_accounts: &HashSet<Pubkey>,
+        bank_checks_enabled: bool,
         metrics: &mut BamReceiveAndBufferMetrics,
     ) -> (Result<ParsedBatch, Reason>, ReceivingStats) {
         let mut stats = ReceivingStats::default();
@@ -527,33 +529,37 @@ impl BamReceiveAndBuffer {
                 );
             }
 
-            // Check 4: Ensure valid blockhash and blockhash is not too old
-            let lock_results: [_; 1] = core::array::from_fn(|_| Ok(()));
-            let (check_results, duration_us) = measure_us!(working_bank.check_transactions(
-                std::slice::from_ref(&view),
-                &lock_results,
-                MAX_PROCESSING_AGE,
-                true,
-                &mut TransactionErrorMetrics::default(),
-            ));
-            metrics.increment_check_transactions_us(duration_us);
-            if let Some(Err(err)) = check_results.first() {
-                let reason = convert_txn_error_to_proto(err.clone());
-                stats.num_dropped_on_age += 1;
-                return (
-                    Err(Reason::TransactionError(
-                        jito_protos::proto::bam_types::TransactionError {
-                            index: index as u32,
-                            reason: reason as i32,
-                        },
-                    )),
-                    stats,
-                );
+            // Fork-dependent checks wait for resolution. The scheduler and worker validate
+            // held batches against the resolved bank before execution.
+            if bank_checks_enabled {
+                // Check 4: Ensure valid blockhash and blockhash is not too old
+                let lock_results: [_; 1] = core::array::from_fn(|_| Ok(()));
+                let (check_results, duration_us) = measure_us!(working_bank.check_transactions(
+                    std::slice::from_ref(&view),
+                    &lock_results,
+                    MAX_PROCESSING_AGE,
+                    true,
+                    &mut TransactionErrorMetrics::default(),
+                ));
+                metrics.increment_check_transactions_us(duration_us);
+                if let Some(Err(err)) = check_results.first() {
+                    let reason = convert_txn_error_to_proto(err.clone());
+                    stats.num_dropped_on_age += 1;
+                    return (
+                        Err(Reason::TransactionError(
+                            jito_protos::proto::bam_types::TransactionError {
+                                index: index as u32,
+                                reason: reason as i32,
+                            },
+                        )),
+                        stats,
+                    );
+                }
             }
 
             // Check 5: Ensure the seed fee payer has enough to pay for transaction fees.
             // Downstream fee payers may be funded by earlier transactions in the same bundle.
-            if index == 0 {
+            if bank_checks_enabled && index == 0 {
                 let (result, duration_us) = measure_us!(Consumer::check_fee_payer_unlocked(
                     working_bank,
                     &view,
@@ -1563,7 +1569,10 @@ pub(super) mod tests {
         assert_ne!(old_bank.bank_id(), bank.bank_id());
         let mut shared = SharedLeaderState::new(0, None, None);
         let parsing_state = shared.clone();
-        let select = || BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(&parsing_state));
+        let select = || {
+            BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(&parsing_state))
+                .map(|(bank, _)| bank)
+        };
         let (_exit, mut receiver, mut container, mut responses) = setup_bam_receive_and_buffer(
             receiver,
             bank_forks.clone(),
@@ -1826,12 +1835,75 @@ pub(super) mod tests {
                 max_schedule_slot,
                 (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &HashSet::new(),
+                true,
                 &mut stats,
             );
 
             assert!(result.is_err());
             assert_eq!(stats.num_dropped_on_fee_payer, 1);
             assert!(matches!(result.err().unwrap(), Reason::TransactionError(_)));
+        }
+    }
+
+    #[test]
+    fn test_unresolved_bank_defers_fork_checks() {
+        let (bank_forks, mint) = test_bank_forks();
+        let bank = bank_forks.read().unwrap().working_bank();
+        let processed = transfer(&mint, &Pubkey::new_unique(), 1, bank.last_blockhash());
+        bank.process_transaction(&processed).unwrap();
+        let transactions = [
+            processed,
+            transfer(&mint, &Pubkey::new_unique(), 1, Hash::new_unique()),
+            transfer(
+                &Keypair::new(),
+                &Pubkey::new_unique(),
+                1,
+                bank.last_blockhash(),
+            ),
+        ];
+        let mut shared = SharedLeaderState::new(0, None, None);
+        shared.store(Arc::new(LeaderState::new_with_atomic_batches_enabled(
+            Some(bank.clone()),
+            0,
+            None,
+            None,
+            false,
+        )));
+        let (selected_bank, bank_checks_enabled) =
+            BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(&shared)).unwrap();
+        assert!(Arc::ptr_eq(&selected_bank, &bank));
+        assert!(!bank_checks_enabled);
+        shared.load().enable_atomic_batches();
+        // Resolution after selection cannot change the policy captured for this bank.
+        assert!(!bank_checks_enabled);
+        assert!(
+            BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(&shared))
+                .unwrap()
+                .1
+        );
+
+        for bank_checks_enabled in [false, true] {
+            for revert_on_error in [false, true] {
+                for transaction in &transactions {
+                    let batch =
+                        batch_with_transaction(&VersionedTransaction::from(transaction.clone()));
+                    let mut metrics = BamReceiveAndBufferMetrics::default();
+                    let (verified, _) = run_batch_verify(vec![batch], bank.slot(), &mut metrics);
+                    let (mut packets, _, seq_id, max_schedule_slot) =
+                        verified.into_iter().next().unwrap().unwrap();
+                    let (result, _) = BamReceiveAndBuffer::parse_batch(
+                        &mut packets,
+                        seq_id,
+                        revert_on_error,
+                        max_schedule_slot,
+                        (&bank_forks.read().unwrap().root_bank(), &selected_bank),
+                        &HashSet::new(),
+                        bank_checks_enabled,
+                        &mut metrics,
+                    );
+                    assert_eq!(result.is_err(), bank_checks_enabled);
+                }
+            }
         }
     }
 
@@ -1885,6 +1957,7 @@ pub(super) mod tests {
                 max_schedule_slot,
                 (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &HashSet::new(),
+                true,
                 &mut stats,
             );
 
@@ -1983,6 +2056,7 @@ pub(super) mod tests {
                 max_schedule_slot,
                 (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &blacklisted_accounts,
+                true,
                 &mut stats,
             );
 
@@ -2042,6 +2116,7 @@ pub(super) mod tests {
                 max_schedule_slot,
                 (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &HashSet::new(),
+                true,
                 &mut stats,
             );
 

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -331,7 +331,11 @@ impl BamReceiveAndBuffer {
                 return None;
             }
         }
-        Some((bank_forks.read().unwrap().working_bank(), true))
+        // BankForks can expose a provisional bank before its leader state is published.
+        Some((
+            bank_forks.read().unwrap().working_bank(),
+            shared_leader_state.is_none(),
+        ))
     }
 
     fn send_no_leader_slot_txn_batch_result(&self, seq_id: u32) {
@@ -1842,6 +1846,62 @@ pub(super) mod tests {
             assert!(result.is_err());
             assert_eq!(stats.num_dropped_on_fee_payer, 1);
             assert!(matches!(result.err().unwrap(), Reason::TransactionError(_)));
+        }
+    }
+
+    #[test]
+    fn test_unpublished_bank_defers_fork_checks() {
+        let (bank_forks, mint) = test_bank_forks();
+        let root = bank_forks.read().unwrap().root_bank();
+        let optimistic_parent = child_bank(&root, 1);
+        let transaction = transfer(&mint, &Pubkey::new_unique(), 1, root.last_blockhash());
+        optimistic_parent.process_transaction(&transaction).unwrap();
+        let provisional = Bank::new_from_parent(optimistic_parent, SlotLeader::new_unique(), 4)
+            .mark_leader_bank();
+        let provisional = bank_forks
+            .write()
+            .unwrap()
+            .insert(provisional)
+            .clone_without_scheduler();
+        let replacement = child_bank(&root, 4);
+        let shared = SharedLeaderState::new(0, None, None);
+
+        // BCL has inserted the provisional bank into BankForks, but has not yet
+        // called set_bank_with_atomic_batches_enabled(..., false).
+        let (selected, enabled) =
+            BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(&shared)).unwrap();
+        assert!(Arc::ptr_eq(&selected, &provisional));
+        let (without_shared, checks_without_shared) =
+            BamReceiveAndBuffer::select_parsing_bank(&bank_forks, None).unwrap();
+        assert!(Arc::ptr_eq(&without_shared, &provisional));
+        for revert_on_error in [false, true] {
+            let parse = |bank: &Bank, checks| {
+                let mut batch =
+                    batch_with_transaction(&VersionedTransaction::from(transaction.clone()));
+                batch.max_schedule_slot = 4;
+                let mut metrics = BamReceiveAndBufferMetrics::default();
+                let (verified, _) = run_batch_verify(vec![batch], 4, &mut metrics);
+                let (mut packets, _, seq_id, max_schedule_slot) =
+                    verified.into_iter().next().unwrap().unwrap();
+                BamReceiveAndBuffer::parse_batch(
+                    &mut packets,
+                    seq_id,
+                    revert_on_error,
+                    max_schedule_slot,
+                    (&root, bank),
+                    &HashSet::new(),
+                    checks,
+                    &mut metrics,
+                )
+                .0
+            };
+            assert!(parse(&selected, enabled).is_ok());
+            assert!(parse(&replacement, true).is_ok());
+            assert!(matches!(
+                parse(&without_shared, checks_without_shared),
+                Err(Reason::TransactionError(error))
+                    if error.reason == TransactionErrorReason::AlreadyProcessed as i32
+            ));
         }
     }
 

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -33,16 +33,12 @@ use {
     solana_nohash_hasher::IntMap,
     solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::Pubkey,
-    solana_runtime::bank_forks::BankForks,
+    solana_runtime::bank::Bank,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction_error::TransactionError,
-    std::{
-        borrow::Borrow,
-        sync::{Arc, RwLock},
-        time::Instant,
-    },
+    std::{borrow::Borrow, time::Instant},
     tokio::sync::mpsc::Sender as TokioSender,
 };
 
@@ -63,14 +59,6 @@ fn passthrough_priority(
 
 pub const MAX_PACKETS_PER_BUNDLE: usize = 5; // copied from BundleStorage::MAX_PACKETS_PER_BUNDLE
 
-// Sized from 30 days of mainnet data ending 2026-08-18. Atomic-only ClickHouse counts of distinct
-// `(source, seq_id)` batches per validator-slot had p99=149, p99.9=236, 99.94% <=256, and max=540.
-// The full-slot count conservatively upper-bounds the pre-ParentReady subset stored here.
-// Mainnet-validator Influx `bam_connection-metrics.bundle_received` active 25 ms samples, which
-// also include non-atomic batches, had p99=183, p99.9=272, 99.86% <=256, and max=881. Thus 256
-// keeps the atomic p99.9 inline in 4 KiB while rarer bursts spill safely.
-const DEFERRED_ATOMIC_BATCHES_INLINE_CAPACITY: usize = 256;
-
 pub struct BamScheduler<Tx: TransactionWithMeta> {
     consume_work_sender: Sender<ConsumeWork<Tx>>,
     finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
@@ -89,11 +77,8 @@ pub struct BamScheduler<Tx: TransactionWithMeta> {
 
     // Reusable objects to avoid allocations
     reusable_consume_work: Vec<ConsumeWork<Tx>>,
-    deferred_atomic_batches:
-        SmallVec<[TransactionPriorityId; DEFERRED_ATOMIC_BATCHES_INLINE_CAPACITY]>,
 
     extra_checks_enabled: bool,
-    bank_forks: Arc<RwLock<BankForks>>,
     shared_leader_state: SharedLeaderState,
 }
 
@@ -112,7 +97,6 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         consume_work_sender: Sender<ConsumeWork<Tx>>,
         finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
         response_sender: TokioSender<BamOutboundMessage>,
-        bank_forks: Arc<RwLock<BankForks>>,
         shared_leader_state: SharedLeaderState,
     ) -> Self {
         Self {
@@ -129,9 +113,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             last_schedule_time: Instant::now(),
             slot: None,
             reusable_consume_work: Vec::new(),
-            deferred_atomic_batches: SmallVec::new(),
             extra_checks_enabled: true,
-            bank_forks,
             shared_leader_state,
         }
     }
@@ -151,29 +133,21 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
     }
 
     /// Insert all incoming transactions into the `PrioGraph`.
-    fn pull_into_prio_graph<S: StateContainer<Tx>>(&mut self, container: &mut S) {
-        let Some(slot) = self.slot else {
-            warn!("Slot is not set, cannot pull transactions into prio-graph");
-            return;
-        };
-
-        let working_bank = self.bank_forks.read().unwrap().working_bank();
-        let atomic_batches_enabled = self.shared_leader_state.load().atomic_batches_enabled();
-        self.deferred_atomic_batches.clear();
+    fn pull_into_prio_graph<S: StateContainer<Tx>>(
+        &mut self,
+        container: &mut S,
+        working_bank: &Bank,
+    ) {
+        let slot = working_bank.slot();
 
         while let Some(next_batch_id) = container.pop() {
-            let Some((batch_ids, revert_on_error, max_schedule_slot, seq_id)) =
+            let Some((batch_ids, _, max_schedule_slot, seq_id)) =
                 container.get_batch(next_batch_id.id)
             else {
                 error!("Batch {} not found in container", next_batch_id.id);
                 container.remove_by_id(next_batch_id.id);
                 continue;
             };
-
-            if revert_on_error && !atomic_batches_enabled {
-                self.deferred_atomic_batches.push(next_batch_id);
-                continue;
-            }
 
             if max_schedule_slot < slot {
                 // If the slot has changed, we cannot schedule this batch
@@ -226,24 +200,17 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                 Self::get_transactions_account_access(txns.into_iter()),
             );
         }
-
-        // Atomic batches must wait until ParentReady confirms or replaces the provisional bank.
-        // Non-atomic batches can still be rescheduled after sad handover.
-        container.push_ids_into_queue(self.deferred_atomic_batches.drain(..));
     }
 
     fn send_to_workers(
         &mut self,
         container: &mut impl StateContainer<Tx>,
         num_scheduled: &mut usize,
+        working_bank: &Bank,
     ) {
-        let Some(slot) = self.slot else {
-            warn!("Slot is not set, cannot schedule transactions");
-            return;
-        };
+        let slot = working_bank.slot();
 
         let now = Instant::now();
-        let working_bank = self.bank_forks.read().unwrap().working_bank();
         while let Some(id) = self.prio_graph.pop() {
             let (batch_ids, revert_on_error, max_schedule_slot, seq_id) =
                 container.get_batch(id.id).unwrap();
@@ -729,8 +696,16 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for BamScheduler<Tx> {
 
         let mut num_scheduled = 0;
 
-        self.pull_into_prio_graph(container);
-        self.send_to_workers(container, &mut num_scheduled);
+        // Pin both validation passes to the same resolved bank, even if BankForks advances.
+        let leader_state = self.shared_leader_state.load();
+        if leader_state.atomic_batches_enabled()
+            && let Some(bank) = leader_state.working_bank()
+            && !bank.is_complete()
+            && Some(bank.slot()) == self.slot
+        {
+            self.pull_into_prio_graph(container, bank);
+            self.send_to_workers(container, &mut num_scheduled, bank);
+        }
 
         // TODO(seg): Double check the zeros here
         Ok(SchedulingSummary {
@@ -838,6 +813,7 @@ mod tests {
                 },
                 tests::create_slow_genesis_config,
                 transaction_scheduler::{
+                    bam_receive_and_buffer::tests::set_leader_bank,
                     bam_scheduler::{BamScheduler, MAX_PACKETS_PER_BUNDLE},
                     scheduler::Scheduler,
                     transaction_state_container::{StateContainer, TransactionStateContainer},
@@ -886,12 +862,16 @@ mod tests {
         let (consume_work_sender, consume_work_receiver) = unbounded();
         let (finished_consume_work_sender, finished_consume_work_receiver) = unbounded();
         let (response_sender, response_receiver) = tokio::sync::mpsc::channel(100);
+        let mut shared_leader_state = SharedLeaderState::new(0, None, None);
+        set_leader_bank(
+            &mut shared_leader_state,
+            Some(bank_forks.read().unwrap().working_bank()),
+        );
         let scheduler = BamScheduler::new(
             consume_work_sender,
             finished_consume_work_receiver,
             response_sender,
-            bank_forks.clone(),
-            SharedLeaderState::new(0, None, None),
+            shared_leader_state,
         );
         TestScheduler {
             scheduler,
@@ -978,6 +958,140 @@ mod tests {
         let mut container = TransactionStateContainer::with_capacity(100);
         let result = scheduler.schedule(&mut container, 0, 0).unwrap();
         assert_eq!(result.num_scheduled, 0);
+    }
+
+    #[test]
+    fn test_unresolved_bank_behavior() {
+        let (bank_forks, _) = test_bank_forks();
+        let bank = bank_forks.read().unwrap().working_bank();
+        let mut shared_leader_state = SharedLeaderState::new(0, None, None);
+        shared_leader_state.store(Arc::new(LeaderState::new_with_atomic_batches_enabled(
+            Some(bank.clone()),
+            0,
+            None,
+            None,
+            false,
+        )));
+        let mut test = create_test_scheduler(1, &bank_forks);
+        test.scheduler.shared_leader_state = shared_leader_state.clone();
+        test.scheduler.extra_checks_enabled = false;
+        let mut container = TransactionStateContainer::with_capacity(10 * 1024);
+        for (fifo_index, (revert_on_error, seq_id)) in
+            [(true, 71), (false, 72)].into_iter().enumerate()
+        {
+            let transaction = prioritized_tranfers(
+                &Keypair::new(),
+                [Pubkey::new_unique()],
+                1_000,
+                u64::from(seq_id),
+            );
+            container
+                .insert_new_batch(
+                    smallvec::smallvec![(transaction, MaxAge::MAX)],
+                    u64::MAX - fifo_index as u64,
+                    revert_on_error,
+                    bank.slot(),
+                    seq_id,
+                )
+                .unwrap();
+        }
+        test.scheduler
+            .receive_completed(
+                &mut container,
+                &BufferedPacketsDecision::Consume(bank.clone()),
+            )
+            .unwrap();
+
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        assert_eq!(container.queue_size(), 2);
+        assert!(test.consume_work_receivers[0].try_recv().is_err());
+        assert!(test.response_receiver.try_recv().is_err());
+
+        // A stale Consume decision must not dispatch through the no-bank replacement gap.
+        shared_leader_state.set_bank_replacement();
+        assert_eq!(
+            test.scheduler
+                .schedule(&mut container, 0, 0)
+                .unwrap()
+                .num_scheduled,
+            0
+        );
+        assert_eq!(container.queue_size(), 2);
+
+        // A held controller iteration preserves work through resolution.
+        set_leader_bank(&mut shared_leader_state, Some(bank.clone()));
+        test.scheduler
+            .receive_completed(&mut container, &BufferedPacketsDecision::Hold)
+            .unwrap();
+        assert_eq!(test.scheduler.slot, Some(bank.slot()));
+        assert_eq!(container.queue_size(), 2);
+
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        assert_eq!(container.queue_size(), 0);
+        let atomic_work = test.consume_work_receivers[0].try_recv().unwrap();
+        let non_atomic_work = test.consume_work_receivers[0].try_recv().unwrap();
+        assert!(atomic_work.revert_on_error);
+        assert!(!non_atomic_work.revert_on_error);
+        assert!(test.consume_work_receivers[0].try_recv().is_err());
+        assert!(test.response_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_scheduler_validates_selected_leader_bank() {
+        let (bank_forks, mint) = test_bank_forks();
+        let bank = Arc::new(Bank::new_from_parent(
+            bank_forks.read().unwrap().working_bank(),
+            solana_leader_schedule::SlotLeader::new_unique(),
+            1,
+        ));
+        bank.register_unique_recent_blockhash_for_test();
+        let mut test = create_test_scheduler(1, &bank_forks);
+        set_leader_bank(&mut test.scheduler.shared_leader_state, Some(bank.clone()));
+        let transaction = solana_system_transaction::transfer(
+            &mint,
+            &Pubkey::new_unique(),
+            1,
+            bank.last_blockhash(),
+        );
+        let mut container = TransactionStateContainer::with_capacity(10);
+        container
+            .insert_new_batch(
+                smallvec::smallvec![(
+                    RuntimeTransaction::from_transaction_for_tests(transaction),
+                    MaxAge::MAX
+                )],
+                u64::MAX,
+                false,
+                bank.slot(),
+                1,
+            )
+            .unwrap();
+        test.scheduler
+            .receive_completed(
+                &mut container,
+                &BufferedPacketsDecision::Consume(bank.clone()),
+            )
+            .unwrap();
+        // BankForks still exposes a different bank which cannot validate this blockhash.
+        assert_ne!(
+            bank.bank_id(),
+            bank_forks.read().unwrap().working_bank().bank_id()
+        );
+        assert_eq!(
+            test.scheduler
+                .schedule(&mut container, 0, 0)
+                .unwrap()
+                .num_scheduled,
+            1
+        );
+        assert_eq!(
+            test.consume_work_receivers[0]
+                .try_recv()
+                .unwrap()
+                .target_slot,
+            bank.slot()
+        );
+        assert!(test.response_receiver.try_recv().is_err());
     }
 
     #[test]
@@ -1292,14 +1406,13 @@ mod tests {
             (&keypair_a, vec![Pubkey::new_unique()], 1000, 0, u64::MAX),
             (&keypair_b, vec![Pubkey::new_unique()], 2000, 1, u64::MAX),
         ]);
-        scheduler.pull_into_prio_graph(&mut container);
+        scheduler.pull_into_prio_graph(&mut container, &bank);
         assert!(
             !scheduler.prio_graph.is_empty(),
             "Prio graph should have transactions"
         );
 
-        let leader_state = LeaderState::new(Some(bank), 0, None, None);
-        scheduler.shared_leader_state.store(Arc::new(leader_state));
+        set_leader_bank(&mut scheduler.shared_leader_state, Some(bank));
         scheduler.shared_leader_state.set_bank_replacement();
         scheduler
             .receive_completed(&mut container, &BufferedPacketsDecision::Hold)
@@ -1369,7 +1482,7 @@ mod tests {
         container.insert_new_batch(txns_max_age, priority, false, u64::MAX, 0);
 
         // Must not panic; the bundle becomes a single schedulable node.
-        scheduler.pull_into_prio_graph(&mut container);
+        scheduler.pull_into_prio_graph(&mut container, &bank);
 
         assert!(
             !scheduler.prio_graph.is_empty(),

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -1504,7 +1504,6 @@ mod tests {
             consume_work_sender,
             finished_work_receiver,
             response_sender,
-            bank_forks.clone(),
             shared_leader_state.clone(),
         );
 

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -2004,7 +2004,7 @@ mod tests {
         );
         let optimistic_leader_state = shared_leader_state.load();
 
-        // Both atomic transactions are valid on the optimistic fork: they reference its
+        // Both batch types are valid on the optimistic fork: they reference its
         // unique recent blockhash, which the replacement fork does not know. (Account state
         // cannot distinguish the forks in the same-parent-slot variant because same-slot
         // banks share accounts-db storage.) The scheduler must hold them until ParentReady
@@ -2034,7 +2034,7 @@ mod tests {
         container
             .insert_new_batch(
                 [(
-                    runtime_transfer(&ordinary_payer, Pubkey::new_unique(), recent_blockhash),
+                    runtime_transfer(&ordinary_payer, Pubkey::new_unique(), optimistic_blockhash),
                     MaxAge::MAX,
                 )]
                 .into_iter()
@@ -2048,12 +2048,11 @@ mod tests {
 
         let (consume_work_sender, consume_work_receiver) = unbounded();
         let (finished_work_sender, finished_work_receiver) = unbounded();
-        let (response_sender, mut response_receiver) = tokio::sync::mpsc::channel(1);
+        let (response_sender, mut response_receiver) = tokio::sync::mpsc::channel(2);
         let mut bam_scheduler = BamScheduler::new(
             consume_work_sender,
             finished_work_receiver,
             response_sender,
-            ctx.bank_forks.clone(),
             shared_leader_state.clone(),
         );
         let optimistic_decision = BufferedPacketsDecision::Consume(optimistic_bank);
@@ -2061,8 +2060,8 @@ mod tests {
             .receive_completed(&mut container, &optimistic_decision)
             .unwrap();
         bam_scheduler.schedule(&mut container, 0, u64::MAX).unwrap();
-        assert_eq!(container.queue_size(), 1);
-        assert!(!consume_work_receiver.try_recv().unwrap().revert_on_error);
+        assert_eq!(container.queue_size(), 2);
+        assert!(consume_work_receiver.try_recv().is_err());
         assert!(response_receiver.try_recv().is_err());
 
         let accumulated_tx = versioned_transfer(1);
@@ -2144,7 +2143,7 @@ mod tests {
                 .atomic_batches_enabled()
         );
 
-        // Reject the provisional batch on the replacement fork, then verify a valid control
+        // Reject both provisional batches on the replacement fork, then verify a valid control
         // transaction commits through the real consume worker.
         let (replay_vote_sender, _replay_vote_receiver) = bounded(1);
         let worker_exit = Arc::new(AtomicBool::default());
@@ -2170,7 +2169,7 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        for (seq_id, batch) in [(71, None), (73, Some(control))] {
+        for (seq_id, batch) in [(71, None), (72, None), (73, Some(control))] {
             if let Some(batch) = batch {
                 container
                     .insert_new_batch(batch, u64::MAX, true, leader_slot, seq_id)
@@ -2208,7 +2207,7 @@ mod tests {
                 panic!("expected atomic transaction batch result");
             };
             assert_eq!(result.seq_id, seq_id);
-            if seq_id == 71 {
+            if seq_id != 73 {
                 assert!(matches!(result.result, Some(NotCommitted(_))));
                 assert_eq!(
                     new_bank.entry_bytes_budget().consumed(),


### PR DESCRIPTION
MEV-12682 / JSA-24: during fast Alpenglow handover, BAM could validate or execute against a provisional bank and return a terminal result for work that should run on its replacement.

Hold both atomic and ordinary BAM batches until the leader bank resolves. Capture the parser bank and resolution flag together, deferring blockhash/status-cache and seed fee-payer checks while unresolved. Use one resolved, active bank matching the scheduler slot for both scheduler validation passes and dispatch; this also removes both scheduler BankForks reads.

Reuse master's retained bank_slot and Hold handling through replacement gaps. Remove the obsolete atomic-only deferred queue. Regression coverage includes deferred parser failures, selected-bank validation, stale Consume during replacement, and both sad-handover variants with provisional rejection and a successful control transaction.

Validation: 55 BAM, scheduler-controller, and block-creation-loop tests passed. Pinned-nightly Clippy (--lib --tests -- -D warnings) and workspace formatting passed.