### PR TITLE
banking_stage: preserve BAM cost admission order (JSA-72)

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -679,6 +679,11 @@ impl BankingStage {
             let (finished_work_sender, finished_work_receiver) = unbounded();
 
             // Spawn the worker threads
+            let consumer = Consumer::new(
+                self.committer.clone(),
+                self.transaction_recorder.clone(),
+                self.log_messages_bytes_limit,
+            );
             let mut worker_metrics = Vec::with_capacity(num_workers);
             for index in 0..num_workers {
                 let id = index + BAM_METRICS_ID_OFFSET as usize;
@@ -686,11 +691,7 @@ impl BankingStage {
                     id as u32,
                     exit.clone(),
                     work_receiver.clone(),
-                    Consumer::new(
-                        self.committer.clone(),
-                        self.transaction_recorder.clone(),
-                        self.log_messages_bytes_limit,
-                    ),
+                    consumer.clone(),
                     finished_work_sender.clone(),
                     self.poh_recorder.read().unwrap().shared_leader_state(),
                     tip_processing_dependencies.clone(),
@@ -711,6 +712,7 @@ impl BankingStage {
             let bam_scheduler_exit = exit.clone();
             let bam_scheduler_bank_forks = self.bank_forks.clone();
             let bam_shared_leader_state = self.poh_recorder.read().unwrap().shared_leader_state();
+            let tip_processing = tip_processing_dependencies.map(|tips| (consumer, tips));
             threads.push(
                 Builder::new()
                     .name("solBamSched".to_string())
@@ -720,6 +722,7 @@ impl BankingStage {
                             finished_work_receiver,
                             bam_dependencies.outbound_sender.clone(),
                             bam_shared_leader_state.clone(),
+                            tip_processing,
                         );
                         let receive_and_buffer = BamReceiveAndBuffer::new(
                             bam_scheduler_exit.clone(),

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -687,14 +687,13 @@ impl BankingStage {
             let mut worker_metrics = Vec::with_capacity(num_workers);
             for index in 0..num_workers {
                 let id = index + BAM_METRICS_ID_OFFSET as usize;
-                let consume_worker = ConsumeWorker::new_with_tip_processing_deps(
+                let consume_worker = ConsumeWorker::new(
                     id as u32,
                     exit.clone(),
                     work_receiver.clone(),
                     consumer.clone(),
                     finished_work_sender.clone(),
                     self.poh_recorder.read().unwrap().shared_leader_state(),
-                    tip_processing_dependencies.clone(),
                 );
 
                 worker_metrics.push(consume_worker.metrics_handle());

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -719,7 +719,6 @@ impl BankingStage {
                             work_sender,
                             finished_work_receiver,
                             bam_dependencies.outbound_sender.clone(),
-                            bam_scheduler_bank_forks.clone(),
                             bam_shared_leader_state.clone(),
                         );
                         let receive_and_buffer = BamReceiveAndBuffer::new(

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -147,7 +147,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
     #[allow(clippy::result_large_err)]
     fn consume(
         &self,
-        work: ConsumeWork<Tx>,
+        mut work: ConsumeWork<Tx>,
     ) -> Result<ProcessingStatus<Tx>, ConsumeWorkerError<Tx>> {
         let Some(leader_state) = active_leader_state(&self.shared_leader_state) else {
             return Ok(ProcessingStatus::CouldNotProcess(work));
@@ -182,6 +182,14 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             .num_messages_processed
             .fetch_add(1, Ordering::Relaxed);
 
+        // The scheduler already reserved cost on this exact bank, in scheduling order. Taking
+        // the admission out of the work marks the reservation as settled by this worker; work
+        // that goes back still carrying one is released by the scheduler.
+        let admission_results = work
+            .admission
+            .take_if(|admission| admission.0.bank_id() == bank.bank_id())
+            .map(|(_, results)| results);
+        // A stale admission stays attached; admit locally on the replacement bank as before.
         let output = self
             .consumer
             .process_and_record_aged_transactions_with_policy(
@@ -194,6 +202,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
                 },
                 None, // bundle account locker checked in scheduler
                 work.revert_on_error,
+                admission_results,
             );
         self.metrics.update_for_consume(&output);
         self.metrics.has_data.store(true, Ordering::Relaxed);
@@ -661,6 +670,7 @@ pub(crate) mod external {
                         &execution_flags,
                         Some(&self.bundle_account_locker),
                         false,
+                        None,
                     );
 
                 self.metrics.update_for_consume(&output);
@@ -1889,7 +1899,7 @@ fn try_drain_iter<T>(work: T, receiver: &Receiver<T>) -> impl Iterator<Item = T>
 }
 
 /// Returns an active leader state if available, otherwise None.
-fn active_leader_state(
+pub(super) fn active_leader_state(
     shared_leader_state: &SharedLeaderState,
 ) -> Option<arc_swap::Guard<Arc<LeaderState>>> {
     let guard = shared_leader_state.load();
@@ -2449,6 +2459,7 @@ mod tests {
         crate::{
             banking_stage::{
                 committer::Committer,
+                qos_service::QosService,
                 scheduler_messages::{MaxAge, TransactionBatchId},
                 tests::{create_slow_genesis_config, sanitize_transactions},
             },
@@ -2499,6 +2510,7 @@ mod tests {
                 atomic::{AtomicBool, AtomicU8},
             },
         },
+        test_case::test_case,
     };
 
     // Helper struct to create tests that hold channels, files, etc.
@@ -2650,6 +2662,7 @@ mod tests {
             revert_on_error: false,
             respond_with_extra_info: false,
             max_schedule_slot: None,
+            admission: None,
         };
         consume_sender.send(work).unwrap();
         let consumed = consumed_receiver.recv().unwrap();
@@ -2699,6 +2712,7 @@ mod tests {
                     revert_on_error: false,
                     respond_with_extra_info: false,
                     max_schedule_slot: None,
+                    admission: None,
                 })
                 .unwrap();
         }
@@ -2761,6 +2775,7 @@ mod tests {
                 revert_on_error: false,
                 respond_with_extra_info: false,
                 max_schedule_slot: None,
+                admission: None,
             })
             .unwrap();
 
@@ -2827,6 +2842,7 @@ mod tests {
             revert_on_error: false,
             respond_with_extra_info: false,
             max_schedule_slot: None,
+            admission: None,
         };
         consume_sender.send(work).unwrap();
         let consumed = consumed_receiver.recv().unwrap();
@@ -2837,6 +2853,114 @@ mod tests {
 
         drop(test_frame);
         let _ = worker_thread.join().unwrap();
+    }
+
+    #[test_case(None, false; "ordinary")]
+    #[test_case(Some(true), false; "same_bank")]
+    #[test_case(Some(false), false; "replacement_bank")]
+    #[test_case(Some(true), true; "complete_bank")]
+    fn test_worker_consume(admission_matches: Option<bool>, bank_complete: bool) {
+        let (mut test_frame, worker) = setup_test_frame(false);
+        let TestFrame {
+            mint_keypair,
+            genesis_config,
+            bank,
+            record_receiver,
+            shared_leader_state,
+            consumed_receiver,
+            ..
+        } = &mut test_frame;
+        shared_leader_state.store(Arc::new(LeaderState::new(
+            Some(bank.clone()),
+            bank.tick_height(),
+            None,
+            None,
+        )));
+        record_receiver.restart(bank.bank_id());
+
+        let pubkey1 = Pubkey::new_unique();
+        let transactions = sanitize_transactions(vec![system_transaction::transfer(
+            mint_keypair,
+            &pubkey1,
+            1,
+            genesis_config.hash(),
+        )]);
+        let (admission, estimate) = match admission_matches {
+            None => (None, 0),
+            Some(true) => {
+                let (results, estimate) = QosService::try_admit_transactions(
+                    bank,
+                    &transactions,
+                    std::iter::repeat(Ok(())),
+                    0,
+                )
+                .unwrap();
+                (Some((Arc::clone(bank), results)), estimate)
+            }
+            Some(false) => (
+                Some((Arc::new(Bank::new_for_tests(genesis_config)), vec![Ok(())])),
+                0,
+            ),
+        };
+        if bank_complete {
+            bank.fill_bank_with_ticks_for_tests();
+        }
+
+        let work = ConsumeWork {
+            target_slot: bank.slot(),
+            batch_id: TransactionBatchId::new(0),
+            ids: vec![0],
+            transactions,
+            max_ages: vec![MaxAge {
+                sanitized_epoch: bank.epoch(),
+                alt_invalidation_slot: bank.slot(),
+            }],
+            revert_on_error: false,
+            respond_with_extra_info: true,
+            max_schedule_slot: Some(bank.slot()),
+            admission,
+        };
+        if let ProcessingStatus::CouldNotProcess(work) = worker.consume(work).unwrap() {
+            worker.retry(work).unwrap();
+        }
+
+        let consumed = consumed_receiver.recv().unwrap();
+        let results = consumed.extra_info.unwrap().processed_results;
+        let tracker = bank.read_cost_tracker().unwrap();
+        assert_eq!(consumed.work.batch_id, TransactionBatchId::new(0));
+        assert_eq!(consumed.work.ids, vec![0]);
+        if bank_complete {
+            assert_eq!(
+                consumed.retryable_indexes,
+                vec![RetryableIndex::new(0, true)]
+            );
+            let returned_admission = consumed.work.admission.as_ref().unwrap();
+            assert_eq!(returned_admission.0.bank_id(), bank.bank_id());
+            assert_eq!(returned_admission.1, vec![Ok(())]);
+            assert!(matches!(
+                &results[0],
+                TransactionResult::NotCommitted(NotCommittedReason::PohTimeout)
+            ));
+            assert_eq!(bank.get_balance(&pubkey1), 0);
+            assert_eq!(tracker.block_cost(), estimate);
+            assert_eq!(tracker.in_flight_transaction_count(), 1);
+        } else {
+            assert!(consumed.retryable_indexes.is_empty());
+            assert_eq!(
+                consumed.work.admission.is_none(),
+                admission_matches != Some(false)
+            );
+            assert!(matches!(
+                &results[0],
+                TransactionResult::Committed(result) if result.execution_success
+            ));
+            assert_eq!(bank.get_balance(&pubkey1), 1);
+            assert!(tracker.block_cost() > 0);
+            if admission_matches == Some(true) {
+                assert!(tracker.block_cost() <= estimate);
+            }
+            assert_eq!(tracker.in_flight_transaction_count(), 0);
+        }
     }
 
     #[test]
@@ -2886,6 +3010,7 @@ mod tests {
                 revert_on_error: false,
                 respond_with_extra_info: false,
                 max_schedule_slot: None,
+                admission: None,
             })
             .unwrap();
 
@@ -2956,6 +3081,7 @@ mod tests {
                 revert_on_error: false,
                 respond_with_extra_info: false,
                 max_schedule_slot: None,
+                admission: None,
             })
             .unwrap();
 
@@ -2969,6 +3095,7 @@ mod tests {
                 revert_on_error: false,
                 respond_with_extra_info: false,
                 max_schedule_slot: None,
+                admission: None,
             })
             .unwrap();
         let consumed = consumed_receiver.recv().unwrap();
@@ -3115,6 +3242,7 @@ mod tests {
                 revert_on_error: false,
                 respond_with_extra_info: false,
                 max_schedule_slot: None,
+                admission: None,
             })
             .unwrap();
 
@@ -3217,6 +3345,7 @@ mod tests {
                 revert_on_error: false,
                 respond_with_extra_info: true,
                 max_schedule_slot: None,
+                admission: None,
             })
             .unwrap();
 

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -8,15 +8,11 @@ use {
             TransactionResult,
         },
     },
-    crate::{
-        bam_dependencies::BamConnectionState,
-        banking_stage::consumer::{ExecutionFlags, RetryableIndex, TipProcessingDependencies},
-    },
+    crate::banking_stage::consumer::{ExecutionFlags, RetryableIndex, TipProcessingDependencies},
     crossbeam_channel::{Receiver, SendError, Sender, TryRecvError},
     jito_protos::proto::bam_types::TransactionCommittedResult,
     solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
     solana_pubkey::Pubkey,
-    solana_runtime::bank::Bank,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     solana_time_utils::AtomicInterval,
@@ -165,18 +161,6 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             return self.retry(work);
         }
 
-        // Best-effort tip-program upkeep for batches that touch tip accounts.
-        if !self.maybe_run_tip_programs(bank, &work.transactions) {
-            error!(
-                "Error running tip programs for transactions: {:?}",
-                work.transactions
-            );
-            datapoint_error!(
-                "consume-worker-error",
-                ("error", "tip_programs_error", String),
-            );
-        }
-
         self.metrics
             .count_metrics
             .num_messages_processed
@@ -189,6 +173,12 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             .admission
             .take_if(|admission| admission.0.bank_id() == bank.bank_id())
             .map(|(_, results)| results);
+        if admission_results.is_none()
+            && let Some(tips) = &self.tip_processing_dependencies
+            && !tips.process_tip_programs(&self.consumer, bank)
+        {
+            return self.retry(work);
+        }
         // A stale admission stays attached; admit locally on the replacement bank as before.
         let output = self
             .consumer
@@ -219,104 +209,6 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             extra_info,
         })?;
         Ok(ProcessingStatus::Processed)
-    }
-
-    /// Best-effort per-slot tip-program maintenance for batches that touch tip accounts.
-    ///
-    /// Returns `true` when tip deps are disabled, no tip account is touched, tips were already
-    /// updated for this bank, or the best-effort upkeep path reaches the end.
-    /// Bundle-construction errors from init/crank bundle creation are non-fatal (crank errors are
-    /// logged), and this path still records the bank as updated.
-    ///
-    /// Returns `false` when required upkeep transactions fail to commit, or when block-builder
-    /// info is unavailable.
-    fn maybe_run_tip_programs(&self, bank: &Arc<Bank>, txs: &[impl TransactionWithMeta]) -> bool {
-        let Some(TipProcessingDependencies {
-            tip_manager,
-            last_tip_updated_bank,
-            block_builder_fee_info,
-            bam_enabled,
-            cluster_info,
-            bundle_account_locker,
-        }) = &self.tip_processing_dependencies
-        else {
-            return true;
-        };
-
-        // Return true if no tip accounts touched
-        let tip_accounts = tip_manager.get_tip_accounts();
-        if !txs
-            .iter()
-            .flat_map(|tx| tx.account_keys().iter())
-            .any(|key| tip_accounts.contains(key))
-        {
-            return true;
-        }
-
-        if bam_enabled.load(Ordering::Acquire) != BamConnectionState::Connected as u8 {
-            return true;
-        }
-
-        let mut last_tip_updated_bank_guard = last_tip_updated_bank.lock().unwrap();
-        if *last_tip_updated_bank_guard == Some((bank.slot(), bank.bank_id())) {
-            return true;
-        }
-
-        let keypair = cluster_info.keypair();
-        let initialize_tip_programs_bundle =
-            tip_manager.get_initialize_tip_programs_bundle(bank, &keypair);
-        if let Ok(init_bundle) = initialize_tip_programs_bundle {
-            let result = self.consumer.process_and_record_transactions_with_policy(
-                bank,
-                &init_bundle,
-                Some(bundle_account_locker),
-                true,
-            );
-            if result
-                .execute_and_commit_transactions_output
-                .commit_transactions_result
-                .map_or(true, |results| {
-                    results
-                        .iter()
-                        .any(|r| matches!(r, CommitTransactionDetails::NotCommitted(_)))
-                })
-            {
-                return false;
-            }
-        }
-
-        let block_builder_fee_info = block_builder_fee_info.load();
-        if block_builder_fee_info.block_builder == Pubkey::default() {
-            return false;
-        }
-        match tip_manager.get_tip_programs_crank_bundle(bank, &keypair, &block_builder_fee_info) {
-            Ok(tip_crank_bundle) => {
-                let result = self.consumer.process_and_record_transactions_with_policy(
-                    bank,
-                    &tip_crank_bundle,
-                    Some(bundle_account_locker),
-                    true,
-                );
-                if result
-                    .execute_and_commit_transactions_output
-                    .commit_transactions_result
-                    .map_or(true, |results| {
-                        results
-                            .iter()
-                            .any(|r| matches!(r, CommitTransactionDetails::NotCommitted(_)))
-                    })
-                {
-                    return false;
-                }
-            }
-            Err(e) => {
-                error!("error getting tip programs crank bundle: {e:?}");
-                // ignore this error for now so tips can get processed
-            }
-        }
-
-        *last_tip_updated_bank_guard = Some((bank.slot(), bank.bank_id()));
-        true
     }
 
     /// Builds `FinishedConsumeWorkExtraInfo` from consume output for BAM responses.
@@ -2459,9 +2351,15 @@ mod tests {
         crate::{
             banking_stage::{
                 committer::Committer,
+                decision_maker::BufferedPacketsDecision,
                 qos_service::QosService,
                 scheduler_messages::{MaxAge, TransactionBatchId},
-                tests::{create_slow_genesis_config, sanitize_transactions},
+                tests::{create_slow_genesis_config_with_leader, sanitize_transactions},
+                transaction_scheduler::{
+                    bam_scheduler::BamScheduler,
+                    scheduler::Scheduler,
+                    transaction_state_container::{StateContainer, TransactionStateContainer},
+                },
             },
             bundle_stage::bundle_account_locker::BundleAccountLocker,
             proxy::block_engine_stage::BlockBuilderFeeInfo,
@@ -2472,8 +2370,9 @@ mod tests {
         },
         arc_swap::ArcSwap,
         crossbeam_channel::{bounded, unbounded},
-        solana_account::Account,
+        solana_account::{Account, AccountSharedData},
         solana_clock::Slot,
+        solana_cost_model::cost_tracker::CostTrackerLimits,
         solana_genesis_config::GenesisConfig,
         solana_gossip::{cluster_info::ClusterInfo, node::Node},
         solana_keypair::Keypair,
@@ -2505,10 +2404,7 @@ mod tests {
         solana_transaction_error::TransactionError,
         std::{
             collections::HashSet,
-            sync::{
-                Mutex, RwLock,
-                atomic::{AtomicBool, AtomicU8},
-            },
+            sync::{Mutex, RwLock, atomic::AtomicBool},
         },
         test_case::test_case,
     };
@@ -2534,16 +2430,22 @@ mod tests {
         TestFrame,
         ConsumeWorker<RuntimeTransaction<SanitizedTransaction>>,
     ) {
+        let leader_keypair = Keypair::new();
         let GenesisConfigInfo {
             mut genesis_config,
             mint_keypair,
             voting_keypair,
             ..
-        } = create_slow_genesis_config(10_000_000_000);
+        } = create_slow_genesis_config_with_leader(10_000_000_000, &leader_keypair.pubkey());
         if default_rent {
+            agave_logger::setup();
             // this is needed when you need to access accountsdb (0 lamports accounts don't get written to accountsdb)
             // if you don't have this, have fun debugging for a few hours :angry:
             genesis_config.rent = Rent::default();
+            genesis_config.accounts.insert(
+                leader_keypair.pubkey(),
+                Account::new(1_000_000_000, 0, &solana_system_interface::program::id()),
+            );
         }
         genesis_config.accounts.extend(
             spl_programs(&genesis_config.rent)
@@ -2568,10 +2470,10 @@ mod tests {
         let shared_leader_state = SharedLeaderState::new(0, None, None);
 
         let cluster_info = {
-            let node = Node::new_localhost_with_pubkey(&mint_keypair.pubkey());
+            let node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
             Arc::new(ClusterInfo::new(
                 node.info.clone(),
-                Arc::new(mint_keypair.insecure_clone()),
+                Arc::new(leader_keypair),
                 SocketAddrSpace::Unspecified,
             ))
         };
@@ -2585,7 +2487,7 @@ mod tests {
             consumer,
             consumed_sender,
             shared_leader_state.clone(),
-            Some(TipProcessingDependencies {
+            default_rent.then(|| TipProcessingDependencies {
                 tip_manager: TipManager::new(TipManagerConfig {
                     tip_payment_program_id: Pubkey::new_from_array(
                         *jito_tip_payment::id().as_array(),
@@ -2599,12 +2501,11 @@ mod tests {
                         commission_bps: 0,
                     },
                 }),
-                last_tip_updated_bank: Arc::new(Mutex::new(None)),
+                tip_programs_lock: Arc::new(Mutex::new(())),
                 block_builder_fee_info: Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
                     block_builder: mint_keypair.pubkey(),
                     block_builder_commission: 0,
                 })),
-                bam_enabled: Arc::new(AtomicU8::new(BamConnectionState::Connected as u8)),
                 cluster_info,
                 bundle_account_locker: BundleAccountLocker::default(),
             }),
@@ -2626,9 +2527,30 @@ mod tests {
         )
     }
 
-    #[test]
-    fn test_worker_consume_no_bank() {
-        let (test_frame, worker) = setup_test_frame(false);
+    fn block_costs(bank: &Bank) -> (u64, usize) {
+        let tracker = bank.read_cost_tracker().unwrap();
+        (tracker.block_cost(), tracker.in_flight_transaction_count())
+    }
+
+    impl TestFrame {
+        fn activate_bank(&mut self) {
+            self.shared_leader_state.store(Arc::new(LeaderState::new(
+                Some(self.bank.clone()),
+                self.bank.tick_height(),
+                None,
+                None,
+            )));
+            self.record_receiver.restart(self.bank.bank_id());
+        }
+    }
+
+    #[test_case(false; "no_bank")]
+    #[test_case(true; "complete_preadmitted_bank")]
+    fn test_worker_consume_no_bank(complete_bank: bool) {
+        let (mut test_frame, worker) = setup_test_frame(false);
+        if complete_bank {
+            test_frame.activate_bank();
+        }
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -2653,6 +2575,19 @@ mod tests {
             sanitized_epoch: bank.epoch(),
             alt_invalidation_slot: bank.slot(),
         };
+        let (admission, expected_costs) = if complete_bank {
+            let (results, estimate) = QosService::try_admit_transactions(
+                bank,
+                &transactions,
+                std::iter::repeat(Ok(())),
+                0,
+            )
+            .unwrap();
+            bank.fill_bank_with_ticks_for_tests();
+            (Some((bank.clone(), results)), (estimate, 1))
+        } else {
+            (None, (0, 0))
+        };
         let work = ConsumeWork {
             target_slot: bank.slot(),
             batch_id: bid,
@@ -2660,9 +2595,9 @@ mod tests {
             transactions,
             max_ages: vec![max_age],
             revert_on_error: false,
-            respond_with_extra_info: false,
+            respond_with_extra_info: complete_bank,
             max_schedule_slot: None,
-            admission: None,
+            admission,
         };
         consume_sender.send(work).unwrap();
         let consumed = consumed_receiver.recv().unwrap();
@@ -2673,6 +2608,17 @@ mod tests {
             consumed.retryable_indexes,
             vec![RetryableIndex::new(0, true)]
         );
+        assert_eq!(consumed.work.admission.is_some(), complete_bank);
+        if let Some((owner, results)) = consumed.work.admission {
+            assert_eq!(owner.bank_id(), bank.bank_id());
+            assert_eq!(results, vec![Ok(())]);
+            assert!(matches!(
+                consumed.extra_info.unwrap().processed_results[0],
+                TransactionResult::NotCommitted(NotCommittedReason::PohTimeout)
+            ));
+        }
+        assert_eq!(bank.get_balance(&pubkey1), 0);
+        assert_eq!(block_costs(bank), expected_costs);
 
         drop(test_frame);
         let _ = worker_thread.join().unwrap();
@@ -2853,114 +2799,6 @@ mod tests {
 
         drop(test_frame);
         let _ = worker_thread.join().unwrap();
-    }
-
-    #[test_case(None, false; "ordinary")]
-    #[test_case(Some(true), false; "same_bank")]
-    #[test_case(Some(false), false; "replacement_bank")]
-    #[test_case(Some(true), true; "complete_bank")]
-    fn test_worker_consume(admission_matches: Option<bool>, bank_complete: bool) {
-        let (mut test_frame, worker) = setup_test_frame(false);
-        let TestFrame {
-            mint_keypair,
-            genesis_config,
-            bank,
-            record_receiver,
-            shared_leader_state,
-            consumed_receiver,
-            ..
-        } = &mut test_frame;
-        shared_leader_state.store(Arc::new(LeaderState::new(
-            Some(bank.clone()),
-            bank.tick_height(),
-            None,
-            None,
-        )));
-        record_receiver.restart(bank.bank_id());
-
-        let pubkey1 = Pubkey::new_unique();
-        let transactions = sanitize_transactions(vec![system_transaction::transfer(
-            mint_keypair,
-            &pubkey1,
-            1,
-            genesis_config.hash(),
-        )]);
-        let (admission, estimate) = match admission_matches {
-            None => (None, 0),
-            Some(true) => {
-                let (results, estimate) = QosService::try_admit_transactions(
-                    bank,
-                    &transactions,
-                    std::iter::repeat(Ok(())),
-                    0,
-                )
-                .unwrap();
-                (Some((Arc::clone(bank), results)), estimate)
-            }
-            Some(false) => (
-                Some((Arc::new(Bank::new_for_tests(genesis_config)), vec![Ok(())])),
-                0,
-            ),
-        };
-        if bank_complete {
-            bank.fill_bank_with_ticks_for_tests();
-        }
-
-        let work = ConsumeWork {
-            target_slot: bank.slot(),
-            batch_id: TransactionBatchId::new(0),
-            ids: vec![0],
-            transactions,
-            max_ages: vec![MaxAge {
-                sanitized_epoch: bank.epoch(),
-                alt_invalidation_slot: bank.slot(),
-            }],
-            revert_on_error: false,
-            respond_with_extra_info: true,
-            max_schedule_slot: Some(bank.slot()),
-            admission,
-        };
-        if let ProcessingStatus::CouldNotProcess(work) = worker.consume(work).unwrap() {
-            worker.retry(work).unwrap();
-        }
-
-        let consumed = consumed_receiver.recv().unwrap();
-        let results = consumed.extra_info.unwrap().processed_results;
-        let tracker = bank.read_cost_tracker().unwrap();
-        assert_eq!(consumed.work.batch_id, TransactionBatchId::new(0));
-        assert_eq!(consumed.work.ids, vec![0]);
-        if bank_complete {
-            assert_eq!(
-                consumed.retryable_indexes,
-                vec![RetryableIndex::new(0, true)]
-            );
-            let returned_admission = consumed.work.admission.as_ref().unwrap();
-            assert_eq!(returned_admission.0.bank_id(), bank.bank_id());
-            assert_eq!(returned_admission.1, vec![Ok(())]);
-            assert!(matches!(
-                &results[0],
-                TransactionResult::NotCommitted(NotCommittedReason::PohTimeout)
-            ));
-            assert_eq!(bank.get_balance(&pubkey1), 0);
-            assert_eq!(tracker.block_cost(), estimate);
-            assert_eq!(tracker.in_flight_transaction_count(), 1);
-        } else {
-            assert!(consumed.retryable_indexes.is_empty());
-            assert_eq!(
-                consumed.work.admission.is_none(),
-                admission_matches != Some(false)
-            );
-            assert!(matches!(
-                &results[0],
-                TransactionResult::Committed(result) if result.execution_success
-            ));
-            assert_eq!(bank.get_balance(&pubkey1), 1);
-            assert!(tracker.block_cost() > 0);
-            if admission_matches == Some(true) {
-                assert!(tracker.block_cost() <= estimate);
-            }
-            assert_eq!(tracker.in_flight_transaction_count(), 0);
-        }
     }
 
     #[test]
@@ -3299,79 +3137,334 @@ mod tests {
         assert_eq!(sleep_duration, MAX_SLEEP_DURATION);
     }
 
-    #[test]
-    fn test_handle_tip_programs() {
-        let (mut test_frame, worker) = setup_test_frame(true);
-        let worker_thread = std::thread::spawn(move || worker.run());
-        let TestFrame {
-            mint_keypair,
-            consume_sender,
-            consumed_receiver,
-            bank,
-            shared_leader_state,
-            record_receiver,
-            ..
-        } = &mut test_frame;
-        shared_leader_state.store(Arc::new(LeaderState::new(
-            Some(bank.clone()),
-            bank.tick_height(),
-            None,
-            None,
-        )));
-        record_receiver.restart(bank.bank_id());
-
-        assert!(bank.slot() > 0);
-        assert!(bank.epoch() > 0);
-
-        let tx = system_transaction::transfer(
-            mint_keypair,
-            &Pubkey::find_program_address(
-                &[b"TIP_ACCOUNT_0"],
-                &Pubkey::new_from_array(*jito_tip_payment::id().as_array()),
+    #[test_case(None, false; "scheduler")]
+    #[test_case(Some(true), false; "replacement_worker")]
+    #[test_case(Some(false), false; "replacement_failure")]
+    #[test_case(Some(true), true; "reconnect_between_fallback_workers")]
+    fn test_tip_preparation_precedes_bam_admission(
+        replacement_succeeds: Option<bool>,
+        reconnect_between_workers: bool,
+    ) {
+        let (mut frame, worker) = setup_test_frame(true);
+        frame.activate_bank();
+        let tips = worker.tip_processing_dependencies.as_ref().unwrap();
+        assert!(tips.process_tip_programs(&worker.consumer, &frame.bank));
+        frame.record_receiver.drain().for_each(drop);
+        let parent = frame.bank.clone();
+        frame.bank = Arc::new(Bank::new_from_parent(
+            parent.clone(),
+            SlotLeader::new_unique(),
+            parent.slot() + parent.get_epoch_info().slots_in_epoch,
+        ));
+        frame.activate_bank();
+        let bank = frame.bank.clone();
+        let set_builder = |block_builder| {
+            tips.block_builder_fee_info
+                .store(Arc::new(BlockBuilderFeeInfo {
+                    block_builder,
+                    block_builder_commission: 0,
+                }))
+        };
+        set_builder(tips.cluster_info.id());
+        let config = |bank: &Bank| {
+            JitoTipPaymentConfig::from_account_shared_data(
+                &bank
+                    .get_account(&tips.tip_manager.tip_payment_config_pubkey())
+                    .unwrap(),
+                &jito_tip_payment::id(),
             )
-            .0,
-            1,
+            .unwrap()
+        };
+        let recipient = Pubkey::new_unique();
+        let amount = bank.get_minimum_balance_for_rent_exemption(0);
+        let mut transactions = sanitize_transactions(vec![system_transaction::transfer(
+            &frame.mint_keypair,
+            &recipient,
+            amount,
             bank.last_blockhash(),
+        )]);
+        if reconnect_between_workers {
+            transactions.extend(sanitize_transactions(vec![system_transaction::transfer(
+                &tips.cluster_info.keypair(),
+                &Pubkey::new_unique(),
+                amount,
+                bank.last_blockhash(),
+            )]));
+        }
+        // The first BAM batch has no tip account, but must not get ahead of the crank.
+        let crank = tips
+            .tip_manager
+            .get_tip_programs_crank_bundle(
+                &bank,
+                &tips.cluster_info.keypair(),
+                &tips.block_builder_fee_info.load(),
+            )
+            .unwrap();
+        let estimated_cost = |txs: &[RuntimeTransaction<SanitizedTransaction>]| -> u64 {
+            QosService::compute_transaction_costs(
+                &bank.feature_set,
+                txs.iter(),
+                std::iter::repeat(Ok(())),
+            )
+            .iter()
+            .map(|cost| cost.as_ref().unwrap().sum())
+            .sum()
+        };
+        let limit = estimated_cost(&crank);
+        bank.write_cost_tracker()
+            .unwrap()
+            .set_limits(CostTrackerLimits::new(u64::MAX, limit, u64::MAX));
+        let estimate = estimated_cost(&transactions);
+        // BAM fits alone, but reserving it first would leave less than the crank estimate.
+        assert!(0 < estimate && estimate < limit);
+
+        let (response_sender, _responses) = tokio::sync::mpsc::channel(4);
+        let mut scheduler = BamScheduler::new(
+            frame.consume_sender.clone(),
+            frame.consumed_receiver.clone(),
+            response_sender,
+            frame.shared_leader_state.clone(),
+            Some((worker.consumer.clone(), tips.clone())),
         );
-
-        let runtime_tx = RuntimeTransaction::from_transaction_for_tests(tx);
-        consume_sender
-            .send(ConsumeWork {
-                target_slot: bank.slot(),
-                batch_id: TransactionBatchId::new(1),
-                ids: vec![0],
-                transactions: vec![runtime_tx.clone()],
-                max_ages: vec![MaxAge::MAX],
-                revert_on_error: false,
-                respond_with_extra_info: true,
-                max_schedule_slot: None,
-                admission: None,
-            })
+        let mut container = TransactionStateContainer::with_capacity(4);
+        for (index, tx) in transactions.into_iter().enumerate() {
+            container
+                .insert_new_batch(
+                    [(tx, MaxAge::MAX)].into_iter().collect(),
+                    u64::MAX - index as u64,
+                    false,
+                    bank.slot(),
+                    index as u32,
+                )
+                .unwrap();
+        }
+        let decision = BufferedPacketsDecision::Consume(bank.clone());
+        scheduler
+            .receive_completed(&mut container, &decision)
             .unwrap();
-
-        let consumed = consumed_receiver
-            .recv_timeout(Duration::from_secs(30))
-            .unwrap();
-        assert_eq!(consumed.retryable_indexes.len(), 0);
-        assert_eq!(consumed.work.transactions.len(), 1);
+        set_builder(Pubkey::default());
+        for _ in 0..2 {
+            assert_eq!(
+                scheduler
+                    .schedule(&mut container, bank.slot(), u64::MAX)
+                    .unwrap()
+                    .num_scheduled,
+                0
+            );
+            assert!(worker.consume_receiver.try_recv().is_err());
+            assert_eq!(block_costs(&bank), (0, 0));
+        }
+        set_builder(tips.cluster_info.id());
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while scheduler
+            .schedule(&mut container, bank.slot(), u64::MAX)
+            .unwrap()
+            .num_scheduled
+            == 0
+        {
+            assert!(Instant::now() < deadline, "tip preparation did not recover");
+            std::thread::yield_now();
+        }
+        let work = worker.consume_receiver.try_recv().unwrap();
+        let second_work =
+            reconnect_between_workers.then(|| worker.consume_receiver.try_recv().unwrap());
+        assert_eq!(work.admission.as_ref().unwrap().1, vec![Ok(())]);
+        let signature = *work.transactions[0].signature();
+        assert_eq!(config(&bank).block_builder(), tips.cluster_info.id());
         assert_eq!(
-            consumed.work.transactions[0].signature(),
-            runtime_tx.signature()
+            config(&bank).tip_receiver(),
+            tips.tip_manager.get_my_tip_distribution_pda(bank.epoch())
         );
+        let records: Vec<_> = frame.record_receiver.drain().collect();
+        assert_eq!(records.len(), 1);
+        assert!(!records[0].reschedule_on_sad_handover);
+        assert_eq!(
+            records[0].transactions,
+            crank
+                .iter()
+                .map(|tx| tx.to_versioned_transaction())
+                .collect::<Vec<_>>()
+        );
+        let prepared_cost = block_costs(&bank).0 - estimate;
 
-        let tip_payment_config_account = bank
-            .get_account(&JitoTipPaymentConfig::find_program_address(&jito_tip_payment::id()).0)
+        if let Some(succeeds) = replacement_succeeds {
+            frame.bank = Arc::new(Bank::new_from_parent(
+                parent,
+                SlotLeader::new_unique(),
+                bank.slot(),
+            ));
+            assert_ne!(frame.bank.bank_id(), bank.bank_id());
+            frame.activate_bank();
+            set_builder(if succeeds {
+                frame.mint_keypair.pubkey()
+            } else {
+                Pubkey::default()
+            });
+        }
+        worker.consume(work).unwrap();
+        let finished = frame.consumed_receiver.try_recv().unwrap();
+        let succeeded = replacement_succeeds != Some(false);
+        assert_eq!(
+            frame.bank.get_balance(&recipient),
+            if succeeded { amount } else { 0 }
+        );
+        assert_eq!(
+            finished.work.admission.is_some(),
+            replacement_succeeds.is_some()
+        );
+        assert!(
+            matches!(
+                &finished.extra_info.as_ref().unwrap().processed_results[0],
+                TransactionResult::Committed(result) if succeeded && result.execution_success
+            ) || matches!(
+                &finished.extra_info.as_ref().unwrap().processed_results[0],
+                TransactionResult::NotCommitted(NotCommittedReason::PohTimeout) if !succeeded
+            )
+        );
+        let records: Vec<_> = frame.record_receiver.drain().collect();
+        if succeeded {
+            assert_eq!(
+                records.last().unwrap().transactions[0].signatures[0],
+                signature
+            );
+            assert_eq!(
+                config(&frame.bank).block_builder(),
+                tips.block_builder_fee_info.load().block_builder
+            );
+        } else {
+            assert!(records.is_empty());
+            assert_eq!(block_costs(&frame.bank), (0, 0));
+        }
+        worker.consumed_sender.send(finished).unwrap();
+        let decision = BufferedPacketsDecision::Consume(frame.bank.clone());
+        scheduler
+            .receive_completed(&mut container, &decision)
             .unwrap();
+        if let Some(work) = second_work {
+            // Reconnect before all old-bank work drains: the second fallback must recheck B
+            // itself, because the scheduler cannot adopt B yet.
+            assert!(scheduler.has_in_flight_transactions());
+            set_builder(tips.cluster_info.id());
+            worker.consume(work).unwrap();
+            assert_eq!(config(&frame.bank).block_builder(), tips.cluster_info.id());
+            let finished = frame.consumed_receiver.try_recv().unwrap();
+            assert!(finished.work.admission.is_some());
+            assert!(
+                matches!(&finished.extra_info.as_ref().unwrap().processed_results[0],
+                TransactionResult::Committed(result) if result.execution_success)
+            );
+            assert_eq!(frame.record_receiver.drain().count(), 2);
+            worker.consumed_sender.send(finished).unwrap();
+            scheduler
+                .receive_completed(&mut container, &decision)
+                .unwrap();
+        }
+        assert_eq!(block_costs(&bank).1, 0);
+        if replacement_succeeds.is_some() {
+            assert_eq!(block_costs(&bank).0, prepared_cost);
+        }
+        assert_eq!(block_costs(&frame.bank).1, 0);
+        let settled = block_costs(&frame.bank);
+        if replacement_succeeds == Some(true) {
+            // The fallback prepared B using Block Engine metadata while BAM was disconnected.
+            // Reconnection publishes BAM's builder before the scheduler first adopts B.
+            set_builder(tips.cluster_info.id());
+        }
+        scheduler
+            .schedule(&mut container, frame.bank.slot(), u64::MAX)
+            .unwrap();
+        if replacement_succeeds == Some(true) && !reconnect_between_workers {
+            assert_eq!(config(&frame.bank).block_builder(), tips.cluster_info.id());
+            assert!(block_costs(&frame.bank).0 > settled.0);
+            assert_eq!(block_costs(&frame.bank).1, 0);
+            assert_eq!(frame.record_receiver.drain().count(), 1);
+        } else {
+            assert_eq!(block_costs(&frame.bank), settled);
+            assert!(frame.record_receiver.try_recv().is_err());
+        }
+    }
 
-        let tip_payment_config = JitoTipPaymentConfig::from_account_shared_data(
-            &tip_payment_config_account,
-            &jito_tip_payment::id(),
-        )
-        .unwrap();
+    #[test_case("builder")]
+    #[test_case("construction")]
+    #[test_case("recording")]
+    #[test_case("cost")]
+    #[test_case("account_lock")]
+    #[test_case("execution")]
+    fn test_tip_preparation_failure_is_retryable(failure: &str) {
+        let (mut frame, worker) = setup_test_frame(true);
+        frame.activate_bank();
+        let tips = worker.tip_processing_dependencies.as_ref().unwrap();
+        assert!(tips.process_tip_programs(&worker.consumer, &frame.bank));
+        frame.record_receiver.drain().for_each(drop);
+        // Earlier success must not mask metadata or account changes on this same Bank.
+        let bank = &frame.bank;
+        let config_key = tips.tip_manager.tip_payment_config_pubkey();
+        let original = bank.get_account(&config_key).unwrap();
+        let cost = block_costs(bank).0;
+        let transaction_count = bank.transaction_count();
+        let payer_balance = bank.get_balance(&tips.cluster_info.id());
+        tips.block_builder_fee_info
+            .store(Arc::new(BlockBuilderFeeInfo {
+                block_builder: if failure == "builder" {
+                    Pubkey::default()
+                } else {
+                    tips.cluster_info.id()
+                },
+                block_builder_commission: if failure == "execution" { 101 } else { 0 },
+            }));
+        match failure {
+            "construction" => bank.store_account(
+                &config_key,
+                &AccountSharedData::new(1, 8, &jito_tip_payment::id()),
+            ),
+            "recording" => frame.record_receiver.shutdown(),
+            "account_lock" => tips
+                .bundle_account_locker
+                .account_locks()
+                .lock_accounts([std::iter::once((&config_key, true))]),
+            "cost" => bank
+                .write_cost_tracker()
+                .unwrap()
+                .set_limits(CostTrackerLimits::new(u64::MAX, cost, u64::MAX)),
+            _ => {}
+        }
+        assert!(!tips.process_tip_programs(&worker.consumer, bank));
+        if failure != "construction" {
+            assert_eq!(bank.get_account(&config_key).unwrap(), original);
+        }
+        assert_eq!(bank.transaction_count(), transaction_count);
+        assert_eq!(bank.get_balance(&tips.cluster_info.id()), payer_balance);
+        assert_eq!(block_costs(bank), (cost, 0));
+        assert!(frame.record_receiver.try_recv().is_err());
+        if failure == "account_lock" {
+            tips.bundle_account_locker
+                .account_locks()
+                .unlock_accounts([std::iter::once((&config_key, true))]);
+        }
+        bank.store_account(&config_key, &original);
+        frame.record_receiver.restart(bank.bank_id());
+        bank.write_cost_tracker()
+            .unwrap()
+            .set_limits(CostTrackerLimits::new(u64::MAX, u64::MAX, u64::MAX));
+        tips.block_builder_fee_info
+            .store(Arc::new(BlockBuilderFeeInfo {
+                block_builder: tips.cluster_info.id(),
+                block_builder_commission: 0,
+            }));
+        assert!(tips.process_tip_programs(&worker.consumer, bank));
+        assert_eq!(frame.record_receiver.drain().count(), 1);
+        assert!(tips.process_tip_programs(&worker.consumer, bank));
+        assert!(frame.record_receiver.try_recv().is_err());
+    }
 
-        assert_eq!(tip_payment_config.block_builder(), mint_keypair.pubkey(),);
-
-        drop(test_frame);
-        let _ = worker_thread.join().unwrap();
+    #[test]
+    fn test_tip_preparation_with_free_rent() {
+        let (mut frame, worker) = setup_test_frame(true);
+        frame.genesis_config.rent = Rent::free();
+        let bank = Arc::new(Bank::new_for_tests(&frame.genesis_config));
+        let tips = worker.tip_processing_dependencies.as_ref().unwrap();
+        assert!(tips.process_tip_programs(&worker.consumer, &bank));
+        assert_eq!(block_costs(&bank), (0, 0));
+        assert!(frame.record_receiver.try_recv().is_err());
     }
 }

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -2555,6 +2555,7 @@ mod tests {
                 &transactions,
                 std::iter::repeat(Ok(())),
                 0,
+                false,
             )
             .unwrap();
             bank.fill_bank_with_ticks_for_tests();
@@ -2585,7 +2586,7 @@ mod tests {
         assert_eq!(consumed.work.admission.is_some(), complete_bank);
         if let Some((owner, results)) = consumed.work.admission {
             assert_eq!(owner.bank_id(), bank.bank_id());
-            assert_eq!(results, vec![Ok(())]);
+            assert_eq!(results.as_slice(), &[Ok(())]);
             assert!(matches!(
                 consumed.extra_info.unwrap().processed_results[0],
                 TransactionResult::NotCommitted(NotCommittedReason::PohTimeout)
@@ -3242,7 +3243,7 @@ mod tests {
         let mut work = worker.consume_receiver.try_recv().unwrap();
         let mut second_work =
             reconnect_between_workers.then(|| worker.consume_receiver.try_recv().unwrap());
-        assert_eq!(work.admission.as_ref().unwrap().1, vec![Ok(())]);
+        assert_eq!(work.admission.as_ref().unwrap().1.as_slice(), &[Ok(())]);
         let signature = *work.transactions[0].signature();
         assert_eq!(config(&bank).block_builder(), tips.cluster_info.id());
         assert_eq!(

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -169,17 +169,19 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
         // The scheduler already reserved cost on this exact bank, in scheduling order. Taking
         // the admission out of the work marks the reservation as settled by this worker; work
         // that goes back still carrying one is released by the scheduler.
-        let admission_results = work
-            .admission
-            .take_if(|admission| admission.0.bank_id() == bank.bank_id())
-            .map(|(_, results)| results);
+        if let Some((owner, _)) = &work.admission
+            && owner.bank_id() != bank.bank_id()
+        {
+            // A replacement Bank needs ordered admission again, through the scheduler.
+            return self.retry(work);
+        }
+        let admission_results = work.admission.take().map(|(_, results)| results);
         if admission_results.is_none()
             && let Some(tips) = &self.tip_processing_dependencies
             && !tips.process_tip_programs(&self.consumer, bank)
         {
             return self.retry(work);
         }
-        // A stale admission stays attached; admit locally on the replacement bank as before.
         let output = self
             .consumer
             .process_and_record_aged_transactions_with_policy(
@@ -1791,7 +1793,7 @@ fn try_drain_iter<T>(work: T, receiver: &Receiver<T>) -> impl Iterator<Item = T>
 }
 
 /// Returns an active leader state if available, otherwise None.
-pub(super) fn active_leader_state(
+fn active_leader_state(
     shared_leader_state: &SharedLeaderState,
 ) -> Option<arc_swap::Guard<Arc<LeaderState>>> {
     let guard = shared_leader_state.load();
@@ -3139,8 +3141,8 @@ mod tests {
 
     #[test_case(None, false; "scheduler")]
     #[test_case(Some(true), false; "replacement_worker")]
-    #[test_case(Some(false), false; "replacement_failure")]
-    #[test_case(Some(true), true; "reconnect_between_fallback_workers")]
+    #[test_case(Some(false), false; "replacement_preparation_recovers")]
+    #[test_case(Some(true), true; "reconnect_between_returned_workers")]
     fn test_tip_preparation_precedes_bam_admission(
         replacement_succeeds: Option<bool>,
         reconnect_between_workers: bool,
@@ -3238,35 +3240,35 @@ mod tests {
                 )
                 .unwrap();
         }
+        let schedule = |scheduler: &mut BamScheduler<_>,
+                        container: &mut TransactionStateContainer<_>| {
+            scheduler
+                .schedule(container, bank.slot(), u64::MAX)
+                .unwrap()
+                .num_scheduled
+        };
+        let wait_for_scheduling =
+            |scheduler: &mut BamScheduler<_>, container: &mut TransactionStateContainer<_>| {
+                let deadline = Instant::now() + Duration::from_secs(5);
+                while schedule(scheduler, container) == 0 {
+                    assert!(Instant::now() < deadline, "tip preparation did not recover");
+                    std::thread::yield_now();
+                }
+            };
         let decision = BufferedPacketsDecision::Consume(bank.clone());
         scheduler
             .receive_completed(&mut container, &decision)
             .unwrap();
         set_builder(Pubkey::default());
         for _ in 0..2 {
-            assert_eq!(
-                scheduler
-                    .schedule(&mut container, bank.slot(), u64::MAX)
-                    .unwrap()
-                    .num_scheduled,
-                0
-            );
+            assert_eq!(schedule(&mut scheduler, &mut container), 0);
             assert!(worker.consume_receiver.try_recv().is_err());
             assert_eq!(block_costs(&bank), (0, 0));
         }
         set_builder(tips.cluster_info.id());
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while scheduler
-            .schedule(&mut container, bank.slot(), u64::MAX)
-            .unwrap()
-            .num_scheduled
-            == 0
-        {
-            assert!(Instant::now() < deadline, "tip preparation did not recover");
-            std::thread::yield_now();
-        }
-        let work = worker.consume_receiver.try_recv().unwrap();
-        let second_work =
+        wait_for_scheduling(&mut scheduler, &mut container);
+        let mut work = worker.consume_receiver.try_recv().unwrap();
+        let mut second_work =
             reconnect_between_workers.then(|| worker.consume_receiver.try_recv().unwrap());
         assert_eq!(work.admission.as_ref().unwrap().1, vec![Ok(())]);
         let signature = *work.transactions[0].signature();
@@ -3300,60 +3302,69 @@ mod tests {
             } else {
                 Pubkey::default()
             });
-        }
-        worker.consume(work).unwrap();
-        let finished = frame.consumed_receiver.try_recv().unwrap();
-        let succeeded = replacement_succeeds != Some(false);
-        assert_eq!(
-            frame.bank.get_balance(&recipient),
-            if succeeded { amount } else { 0 }
-        );
-        assert_eq!(
-            finished.work.admission.is_some(),
-            replacement_succeeds.is_some()
-        );
-        assert!(
-            matches!(
-                &finished.extra_info.as_ref().unwrap().processed_results[0],
-                TransactionResult::Committed(result) if succeeded && result.execution_success
-            ) || matches!(
-                &finished.extra_info.as_ref().unwrap().processed_results[0],
-                TransactionResult::NotCommitted(NotCommittedReason::PohTimeout) if !succeeded
-            )
-        );
-        let records: Vec<_> = frame.record_receiver.drain().collect();
-        if succeeded {
-            assert_eq!(
-                records.last().unwrap().transactions[0].signatures[0],
-                signature
-            );
+            // Return later work first. Neither worker may admit locally on the replacement.
+            let returned_work = second_work.take().into_iter().chain(std::iter::once(work));
+            let decision = BufferedPacketsDecision::Consume(frame.bank.clone());
+            for returned in returned_work {
+                worker.consume(returned).unwrap();
+                assert_eq!(block_costs(&frame.bank), (0, 0));
+                assert!(frame.record_receiver.try_recv().is_err());
+                scheduler
+                    .receive_completed(&mut container, &decision)
+                    .unwrap();
+                if scheduler.has_in_flight_transactions() {
+                    assert_eq!(schedule(&mut scheduler, &mut container), 0,);
+                    // Reconnection changes metadata while another old admission is outstanding.
+                    set_builder(tips.cluster_info.id());
+                }
+            }
+            assert_eq!(block_costs(&bank), (prepared_cost, 0));
+            if !succeeds {
+                assert_eq!(schedule(&mut scheduler, &mut container), 0,);
+                assert!(worker.consume_receiver.try_recv().is_err());
+                assert_eq!(block_costs(&frame.bank), (0, 0));
+                set_builder(frame.mint_keypair.pubkey());
+            }
+            wait_for_scheduling(&mut scheduler, &mut container);
             assert_eq!(
                 config(&frame.bank).block_builder(),
                 tips.block_builder_fee_info.load().block_builder
             );
-        } else {
-            assert!(records.is_empty());
-            assert_eq!(block_costs(&frame.bank), (0, 0));
-        }
-        worker.consumed_sender.send(finished).unwrap();
-        let decision = BufferedPacketsDecision::Consume(frame.bank.clone());
-        scheduler
-            .receive_completed(&mut container, &decision)
-            .unwrap();
-        if let Some(work) = second_work {
-            // Reconnect before all old-bank work drains: the second fallback must recheck B
-            // itself, because the scheduler cannot adopt B yet.
-            assert!(scheduler.has_in_flight_transactions());
-            set_builder(tips.cluster_info.id());
-            worker.consume(work).unwrap();
-            assert_eq!(config(&frame.bank).block_builder(), tips.cluster_info.id());
-            let finished = frame.consumed_receiver.try_recv().unwrap();
-            assert!(finished.work.admission.is_some());
-            assert!(
-                matches!(&finished.extra_info.as_ref().unwrap().processed_results[0],
-                TransactionResult::Committed(result) if result.execution_success)
+            frame.record_receiver.drain().for_each(drop);
+            work = worker.consume_receiver.try_recv().unwrap();
+            assert_eq!(
+                work.admission.as_ref().unwrap().0.bank_id(),
+                frame.bank.bank_id()
             );
-            assert_eq!(frame.record_receiver.drain().count(), 2);
+            assert_eq!(*work.transactions[0].signature(), signature);
+            second_work =
+                reconnect_between_workers.then(|| worker.consume_receiver.try_recv().unwrap());
+        }
+        let decision = BufferedPacketsDecision::Consume(frame.bank.clone());
+        for (index, work) in std::iter::once(work).chain(second_work).enumerate() {
+            if index > 0 {
+                assert!(scheduler.has_in_flight_transactions());
+            }
+            worker.consume(work).unwrap();
+            if index > 0 {
+                assert_eq!(config(&frame.bank).block_builder(), tips.cluster_info.id());
+            }
+            let finished = frame.consumed_receiver.try_recv().unwrap();
+            assert_eq!(frame.bank.get_balance(&recipient), amount);
+            assert!(finished.work.admission.is_none());
+            assert!(matches!(
+                &finished.extra_info.as_ref().unwrap().processed_results[0],
+                TransactionResult::Committed(result) if result.execution_success
+            ));
+            let records: Vec<_> = frame.record_receiver.drain().collect();
+            assert_eq!(records.len(), 1);
+            if index == 0 {
+                assert_eq!(records[0].transactions[0].signatures[0], signature);
+            }
+            assert_eq!(
+                config(&frame.bank).block_builder(),
+                tips.block_builder_fee_info.load().block_builder
+            );
             worker.consumed_sender.send(finished).unwrap();
             scheduler
                 .receive_completed(&mut container, &decision)
@@ -3365,23 +3376,11 @@ mod tests {
         }
         assert_eq!(block_costs(&frame.bank).1, 0);
         let settled = block_costs(&frame.bank);
-        if replacement_succeeds == Some(true) {
-            // The fallback prepared B using Block Engine metadata while BAM was disconnected.
-            // Reconnection publishes BAM's builder before the scheduler first adopts B.
-            set_builder(tips.cluster_info.id());
-        }
         scheduler
             .schedule(&mut container, frame.bank.slot(), u64::MAX)
             .unwrap();
-        if replacement_succeeds == Some(true) && !reconnect_between_workers {
-            assert_eq!(config(&frame.bank).block_builder(), tips.cluster_info.id());
-            assert!(block_costs(&frame.bank).0 > settled.0);
-            assert_eq!(block_costs(&frame.bank).1, 0);
-            assert_eq!(frame.record_receiver.drain().count(), 1);
-        } else {
-            assert_eq!(block_costs(&frame.bank), settled);
-            assert!(frame.record_receiver.try_recv().is_err());
-        }
+        assert_eq!(block_costs(&frame.bank), settled);
+        assert!(frame.record_receiver.try_recv().is_err());
     }
 
     #[test_case("builder")]

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -8,7 +8,7 @@ use {
             TransactionResult,
         },
     },
-    crate::banking_stage::consumer::{ExecutionFlags, RetryableIndex, TipProcessingDependencies},
+    crate::banking_stage::consumer::{ExecutionFlags, RetryableIndex},
     crossbeam_channel::{Receiver, SendError, Sender, TryRecvError},
     jito_protos::proto::bam_types::TransactionCommittedResult,
     solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
@@ -55,8 +55,6 @@ pub(crate) struct ConsumeWorker<Tx> {
 
     shared_leader_state: SharedLeaderState,
     metrics: Arc<ConsumeWorkerMetrics>,
-
-    tip_processing_dependencies: Option<TipProcessingDependencies>,
 }
 
 impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
@@ -75,27 +73,6 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             consumed_sender,
             shared_leader_state,
             metrics: Arc::new(ConsumeWorkerMetrics::new(id)),
-            tip_processing_dependencies: None,
-        }
-    }
-
-    pub fn new_with_tip_processing_deps(
-        id: u32,
-        exit: Arc<AtomicBool>,
-        consume_receiver: Receiver<ConsumeWork<Tx>>,
-        consumer: Consumer,
-        consumed_sender: Sender<FinishedConsumeWork<Tx>>,
-        shared_leader_state: SharedLeaderState,
-        tip_processing_dependencies: Option<TipProcessingDependencies>,
-    ) -> Self {
-        Self {
-            exit,
-            consume_receiver,
-            consumer,
-            consumed_sender,
-            shared_leader_state,
-            metrics: Arc::new(ConsumeWorkerMetrics::new(id)),
-            tip_processing_dependencies,
         }
     }
 
@@ -176,12 +153,6 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             return self.retry(work);
         }
         let admission_results = work.admission.take().map(|(_, results)| results);
-        if admission_results.is_none()
-            && let Some(tips) = &self.tip_processing_dependencies
-            && !tips.process_tip_programs(&self.consumer, bank)
-        {
-            return self.retry(work);
-        }
         let output = self
             .consumer
             .process_and_record_aged_transactions_with_policy(
@@ -2353,6 +2324,7 @@ mod tests {
         crate::{
             banking_stage::{
                 committer::Committer,
+                consumer::TipProcessingDependencies,
                 decision_maker::BufferedPacketsDecision,
                 qos_service::QosService,
                 scheduler_messages::{MaxAge, TransactionBatchId},
@@ -2406,7 +2378,7 @@ mod tests {
         solana_transaction_error::TransactionError,
         std::{
             collections::HashSet,
-            sync::{Mutex, RwLock, atomic::AtomicBool},
+            sync::{RwLock, atomic::AtomicBool},
         },
         test_case::test_case,
     };
@@ -2414,6 +2386,7 @@ mod tests {
     // Helper struct to create tests that hold channels, files, etc.
     // such that our tests can be more easily set up and run.
     struct TestFrame {
+        tip_processing_dependencies: Option<TipProcessingDependencies>,
         mint_keypair: Keypair,
         genesis_config: GenesisConfig,
         bank: Arc<Bank>,
@@ -2482,39 +2455,38 @@ mod tests {
 
         let (consume_sender, consume_receiver) = unbounded();
         let (consumed_sender, consumed_receiver) = unbounded();
-        let worker = ConsumeWorker::new_with_tip_processing_deps(
+        let worker = ConsumeWorker::new(
             0,
             Arc::new(AtomicBool::new(false)),
             consume_receiver,
             consumer,
             consumed_sender,
             shared_leader_state.clone(),
-            default_rent.then(|| TipProcessingDependencies {
-                tip_manager: TipManager::new(TipManagerConfig {
-                    tip_payment_program_id: Pubkey::new_from_array(
-                        *jito_tip_payment::id().as_array(),
-                    ),
-                    tip_distribution_program_id: Pubkey::new_from_array(
-                        *jito_tip_distribution::id().as_array(),
-                    ),
-                    tip_distribution_account_config: TipDistributionAccountConfig {
-                        merkle_root_upload_authority: mint_keypair.pubkey(),
-                        vote_account: voting_keypair.pubkey(),
-                        commission_bps: 0,
-                    },
-                }),
-                tip_programs_lock: Arc::new(Mutex::new(())),
-                block_builder_fee_info: Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
-                    block_builder: mint_keypair.pubkey(),
-                    block_builder_commission: 0,
-                })),
-                cluster_info,
-                bundle_account_locker: BundleAccountLocker::default(),
-            }),
         );
 
         (
             TestFrame {
+                tip_processing_dependencies: default_rent.then(|| TipProcessingDependencies {
+                    tip_manager: TipManager::new(TipManagerConfig {
+                        tip_payment_program_id: Pubkey::new_from_array(
+                            *jito_tip_payment::id().as_array(),
+                        ),
+                        tip_distribution_program_id: Pubkey::new_from_array(
+                            *jito_tip_distribution::id().as_array(),
+                        ),
+                        tip_distribution_account_config: TipDistributionAccountConfig {
+                            merkle_root_upload_authority: mint_keypair.pubkey(),
+                            vote_account: voting_keypair.pubkey(),
+                            commission_bps: 0,
+                        },
+                    }),
+                    block_builder_fee_info: Arc::new(ArcSwap::from_pointee(BlockBuilderFeeInfo {
+                        block_builder: mint_keypair.pubkey(),
+                        block_builder_commission: 0,
+                    })),
+                    cluster_info,
+                    bundle_account_locker: BundleAccountLocker::default(),
+                }),
                 mint_keypair,
                 genesis_config,
                 bank,
@@ -3149,7 +3121,7 @@ mod tests {
     ) {
         let (mut frame, worker) = setup_test_frame(true);
         frame.activate_bank();
-        let tips = worker.tip_processing_dependencies.as_ref().unwrap();
+        let tips = frame.tip_processing_dependencies.take().unwrap();
         assert!(tips.process_tip_programs(&worker.consumer, &frame.bank));
         frame.record_receiver.drain().for_each(drop);
         let parent = frame.bank.clone();
@@ -3392,7 +3364,7 @@ mod tests {
     fn test_tip_preparation_failure_is_retryable(failure: &str) {
         let (mut frame, worker) = setup_test_frame(true);
         frame.activate_bank();
-        let tips = worker.tip_processing_dependencies.as_ref().unwrap();
+        let tips = frame.tip_processing_dependencies.take().unwrap();
         assert!(tips.process_tip_programs(&worker.consumer, &frame.bank));
         frame.record_receiver.drain().for_each(drop);
         // Earlier success must not mask metadata or account changes on this same Bank.
@@ -3461,7 +3433,7 @@ mod tests {
         let (mut frame, worker) = setup_test_frame(true);
         frame.genesis_config.rent = Rent::free();
         let bank = Arc::new(Bank::new_for_tests(&frame.genesis_config));
-        let tips = worker.tip_processing_dependencies.as_ref().unwrap();
+        let tips = frame.tip_processing_dependencies.take().unwrap();
         assert!(tips.process_tip_programs(&worker.consumer, &bank));
         assert_eq!(block_costs(&bank), (0, 0));
         assert!(frame.record_receiver.try_recv().is_err());

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -187,6 +187,7 @@ impl Consumer {
             bank,
             txs,
             check_results,
+            None,
             &ExecutionFlags {
                 drop_on_failure: revert_on_error,
                 all_or_nothing: revert_on_error,
@@ -212,10 +213,11 @@ impl Consumer {
         flags: &ExecutionFlags,
     ) -> ProcessTransactionBatchOutput {
         self.process_and_record_aged_transactions_with_policy(
-            bank, txs, max_ages, flags, None, false,
+            bank, txs, max_ages, flags, None, false, None,
         )
     }
 
+    /// Supplied admission results must have reserved costs on `bank`; this call settles them.
     pub fn process_and_record_aged_transactions_with_policy(
         &self,
         bank: &Bank,
@@ -224,7 +226,19 @@ impl Consumer {
         flags: &ExecutionFlags,
         bundle_account_locker: Option<&BundleAccountLocker>,
         revert_on_error: bool,
+        admission_results: Option<Vec<Result<(), TransactionError>>>,
     ) -> ProcessTransactionBatchOutput {
+        if let Some(results) = admission_results {
+            return self.process_and_record_transactions_with_pre_results(
+                bank,
+                txs,
+                results.into_iter(),
+                Some(max_ages),
+                flags,
+                bundle_account_locker,
+                revert_on_error,
+            );
+        }
         // Need to filter out transactions since they were sanitized earlier.
         // This means that the transaction may cross and epoch boundary (not allowed),
         //  or account lookup tables may have been closed.
@@ -239,6 +253,7 @@ impl Consumer {
             bank,
             txs,
             pre_results,
+            None,
             flags,
             bundle_account_locker,
             revert_on_error,
@@ -250,6 +265,7 @@ impl Consumer {
         bank: &Bank,
         txs: &[impl TransactionWithMeta],
         pre_results: impl Iterator<Item = Result<(), TransactionError>>,
+        preadmitted: Option<&[MaxAge]>,
         flags: &ExecutionFlags,
         bundle_account_locker: Option<&BundleAccountLocker>,
         revert_on_error: bool,
@@ -257,11 +273,18 @@ impl Consumer {
         let (
             (transaction_qos_cost_results, cost_model_throttled_transactions_count),
             cost_model_us,
-        ) = measure_us!(QosService::select_and_accumulate_transaction_costs(
-            bank,
-            txs,
-            pre_results,
-        ));
+        ) = measure_us!(match preadmitted {
+            Some(_) => {
+                let costs = QosService::compute_transaction_costs(
+                    &bank.feature_set,
+                    txs.iter(),
+                    pre_results,
+                );
+                let rejected = costs.iter().filter(|cost| cost.is_err()).count() as u64;
+                (costs, rejected)
+            }
+            None => QosService::select_and_accumulate_transaction_costs(bank, txs, pre_results),
+        });
 
         // Only lock accounts for those transactions are selected for the block;
         // Once accounts are locked, other threads cannot encode transactions that will modify the
@@ -272,9 +295,17 @@ impl Consumer {
                 txs,
                 transaction_qos_cost_results
                     .iter()
-                    .zip(txs.iter())
-                    .map(|(r, tx)| match r {
+                    .zip(txs.iter().enumerate())
+                    .map(|(r, (index, tx))| match r {
                         Ok(_cost) => {
+                            if let Some(max_ages) = preadmitted {
+                                let max_age = max_ages[index];
+                                bank.resanitize_transaction_minimally(
+                                    tx,
+                                    max_age.sanitized_epoch,
+                                    max_age.alt_invalidation_slot,
+                                )?;
+                            }
                             let Some(l_bundle_account_locker) = &l_bundle_account_locker else {
                                 return Ok(());
                             };
@@ -1568,8 +1599,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_write_persist_loaded_addresses() {
+    #[test_case(false; "persist_loaded_addresses")]
+    #[test_case(true; "preadmitted_lookup_invalidated")]
+    fn test_write_persist_loaded_addresses(invalidate_lookup: bool) {
         let (transaction_status_sender, transaction_status_receiver) = bounded(1024);
         let tss = Some(TransactionStatusSender {
             sender: transaction_status_sender,
@@ -1623,6 +1655,59 @@ mod tests {
             &ReservedAccountKeys::empty_key_set(),
         )
         .unwrap();
+
+        if invalidate_lookup {
+            let transactions = std::slice::from_ref(&sanitized_tx);
+            let max_age = MaxAge {
+                sanitized_epoch: bank.epoch(),
+                // Reload the lookup table during minimal resanitization.
+                alt_invalidation_slot: bank.slot() - 1,
+            };
+            let resanitize = || {
+                bank.resanitize_transaction_minimally(
+                    &sanitized_tx,
+                    max_age.sanitized_epoch,
+                    max_age.alt_invalidation_slot,
+                )
+            };
+            let (admission_results, _) = QosService::try_admit_transactions(
+                &bank,
+                transactions,
+                std::iter::once(resanitize()),
+                0,
+            )
+            .unwrap();
+            assert_eq!(admission_results, vec![Ok(())]);
+            // The lookup changes after admission, so the worker must recheck and release it.
+            bank.store_account(
+                &address_table_key,
+                &AccountSharedData::new(1, 0, &system_program::id()),
+            );
+            let expected_error = resanitize().unwrap_err();
+            let output = consumer.process_and_record_aged_transactions_with_policy(
+                &bank,
+                transactions,
+                &[max_age],
+                &ExecutionFlags {
+                    drop_on_failure: false,
+                    all_or_nothing: false,
+                },
+                None,
+                false,
+                Some(admission_results),
+            );
+            assert_eq!(
+                output
+                    .execute_and_commit_transactions_output
+                    .commit_transactions_result
+                    .unwrap(),
+                vec![CommitTransactionDetails::NotCommitted(expected_error)]
+            );
+            let tracker = bank.read_cost_tracker().unwrap();
+            assert_eq!(tracker.block_cost(), 0);
+            assert_eq!(tracker.in_flight_transaction_count(), 0);
+            return;
+        }
         let batch_transactions_inner = [&sanitized_tx]
             .into_iter()
             .map(|tx| tx.clone().into_inner_transaction())
@@ -1650,6 +1735,84 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(committed_transaction.status.is_ok());
+    }
+
+    #[test_case(false; "partial_batch")]
+    #[test_case(true; "revert_on_error")]
+    fn test_preadmitted_rejection_preserves_batch_policy(revert_on_error: bool) {
+        let TestFrame {
+            mint_keypair,
+            bank,
+            consumer,
+            record_receiver: _record_receiver,
+            ..
+        } = setup_test(None);
+        let low_payer = Keypair::new();
+        bank.transfer(1_000, &mint_keypair, &low_payer.pubkey())
+            .unwrap();
+        let high_recipient = Pubkey::new_unique();
+        let low_recipient = Pubkey::new_unique();
+        let transactions = sanitize_transactions(vec![
+            system_transaction::transfer(&mint_keypair, &high_recipient, 1, bank.last_blockhash()),
+            system_transaction::transfer(&low_payer, &low_recipient, 1, bank.last_blockhash()),
+        ]);
+        // A scheduler rejection stays final even if the bank has room when the worker runs.
+        let (admission_results, _) = QosService::try_admit_transactions(
+            &bank,
+            &transactions,
+            [Err(TransactionError::WouldExceedMaxBlockCostLimit), Ok(())].into_iter(),
+            0,
+        )
+        .unwrap();
+        let max_age = MaxAge {
+            sanitized_epoch: bank.epoch(),
+            alt_invalidation_slot: bank.slot(),
+        };
+        let output = consumer.process_and_record_aged_transactions_with_policy(
+            &bank,
+            &transactions,
+            &[max_age; 2],
+            &ExecutionFlags {
+                drop_on_failure: revert_on_error,
+                all_or_nothing: revert_on_error,
+            },
+            None,
+            revert_on_error,
+            Some(admission_results),
+        );
+        assert_eq!(output.cost_model_throttled_transactions_count, 1);
+        assert_eq!(
+            output
+                .execute_and_commit_transactions_output
+                .retryable_transaction_indexes,
+            vec![RetryableIndex::new(0, false)]
+        );
+        let results = output
+            .execute_and_commit_transactions_output
+            .commit_transactions_result
+            .unwrap();
+        assert!(matches!(
+            results[0],
+            CommitTransactionDetails::NotCommitted(TransactionError::WouldExceedMaxBlockCostLimit)
+        ));
+        assert_eq!(bank.get_balance(&high_recipient), 0);
+        let tracker = bank.read_cost_tracker().unwrap();
+        if revert_on_error {
+            assert!(matches!(
+                results[1],
+                CommitTransactionDetails::NotCommitted(TransactionError::CommitCancelled)
+            ));
+            assert_eq!(bank.get_balance(&low_recipient), 0);
+            assert_eq!(tracker.block_cost(), 0);
+        } else {
+            assert!(matches!(
+                results[1],
+                CommitTransactionDetails::Committed { .. }
+            ));
+            assert_eq!(bank.get_balance(&low_recipient), 1);
+            assert!(tracker.block_cost() > 0);
+        }
+        assert_eq!(tracker.in_flight_transaction_count(), 0);
     }
 
     #[test]

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -273,7 +273,7 @@ impl Consumer {
         flags: &ExecutionFlags,
         bundle_account_locker: Option<&BundleAccountLocker>,
         revert_on_error: bool,
-        admission_results: Option<Vec<Result<(), TransactionError>>>,
+        admission_results: Option<SmallVec<[Result<(), TransactionError>; 1]>>,
     ) -> ProcessTransactionBatchOutput {
         if let Some(results) = admission_results {
             return self.process_and_record_transactions_with_pre_results(
@@ -1722,9 +1722,10 @@ mod tests {
                 transactions,
                 std::iter::once(resanitize()),
                 0,
+                false,
             )
             .unwrap();
-            assert_eq!(admission_results, vec![Ok(())]);
+            assert_eq!(admission_results.as_slice(), &[Ok(())]);
             // The lookup changes after admission, so the worker must recheck and release it.
             bank.store_account(
                 &address_table_key,
@@ -1809,6 +1810,7 @@ mod tests {
             &transactions,
             [Err(TransactionError::WouldExceedMaxBlockCostLimit), Ok(())].into_iter(),
             0,
+            revert_on_error,
         )
         .unwrap();
         let max_age = MaxAge {
@@ -1827,7 +1829,10 @@ mod tests {
             revert_on_error,
             Some(admission_results),
         );
-        assert_eq!(output.cost_model_throttled_transactions_count, 1);
+        assert_eq!(
+            output.cost_model_throttled_transactions_count,
+            if revert_on_error { 2 } else { 1 },
+        );
         assert_eq!(
             output
                 .execute_and_commit_transactions_output

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -12,13 +12,13 @@ use {
     arc_swap::ArcSwap,
     smallvec::SmallVec,
     solana_accounts_db::accounts::TransactionAccountLocksIterator,
-    solana_clock::{BankId, Slot},
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure_us,
     solana_poh::{
         poh_recorder::PohRecorderError,
         transaction_recorder::{RecordTransactionsTimings, TransactionRecorder},
     },
+    solana_pubkey::Pubkey,
     solana_runtime::{
         bank::{
             Bank, LoadAndExecuteTransactionsOutput, entry_bytes_budget::EntryBytesReserveError,
@@ -38,7 +38,7 @@ use {
     solana_vote::vote_parser,
     std::{
         num::Saturating,
-        sync::{Arc, Mutex, atomic::AtomicU8},
+        sync::{Arc, Mutex},
     },
 };
 
@@ -118,13 +118,67 @@ pub struct LeaderProcessedTransactionCounts {
 #[derive(Clone)]
 pub struct TipProcessingDependencies {
     pub tip_manager: TipManager,
-    pub last_tip_updated_bank: Arc<Mutex<Option<(Slot, BankId)>>>,
+    pub tip_programs_lock: Arc<Mutex<()>>,
     pub block_builder_fee_info: Arc<ArcSwap<BlockBuilderFeeInfo>>,
-    pub bam_enabled: Arc<AtomicU8>,
     pub cluster_info: Arc<ClusterInfo>,
     pub bundle_account_locker: BundleAccountLocker,
 }
 
+impl TipProcessingDependencies {
+    /// Prepare this exact Bank before admitting BAM work, including worker handover fallback.
+    pub(super) fn process_tip_programs(&self, consumer: &Consumer, bank: &Arc<Bank>) -> bool {
+        // Fallbacks can straddle a BAM reconnect on one Bank. Recheck its actual configuration
+        // each time; matching preadmitted workers already skip this path.
+        let _tip_programs_guard = self.tip_programs_lock.lock().unwrap();
+        let bank_key = (bank.slot(), bank.bank_id());
+        // Match BundleStage's local-cluster policy: free-rent PDAs are discarded by AccountsDb.
+        if bank.rent_collector().rent.minimum_balance(0) == 0 {
+            return true;
+        }
+        let builder = self.block_builder_fee_info.load();
+        if builder.block_builder == Pubkey::default() {
+            return false;
+        }
+        let keypair = self.cluster_info.keypair();
+        let process = |bundle: crate::tip_manager::Result<SmallVec<[_; 2]>>| {
+            let Ok(bundle) = bundle else {
+                debug!("tip bundle construction failed for bank {bank_key:?}: {bundle:?}");
+                return false;
+            };
+            if bundle.is_empty() {
+                return true;
+            }
+            let results = consumer
+                .process_and_record_transactions_with_policy(
+                    bank,
+                    &bundle,
+                    Some(&self.bundle_account_locker),
+                    true,
+                )
+                .execute_and_commit_transactions_output
+                .commit_transactions_result;
+            debug!("tip bundle result for bank {bank_key:?}: {results:?}");
+            results.is_ok_and(|results| {
+                results.iter().all(|result| {
+                    matches!(
+                        result,
+                        CommitTransactionDetails::Committed { result: Ok(()), .. }
+                    )
+                })
+            })
+        };
+        // Crank construction reads the accounts created by initialization; keep it lazy.
+        process(
+            self.tip_manager
+                .get_initialize_tip_programs_bundle(bank, &keypair),
+        ) && process(
+            self.tip_manager
+                .get_tip_programs_crank_bundle(bank, &keypair, &builder),
+        )
+    }
+}
+
+#[derive(Clone)]
 pub struct Consumer {
     committer: Committer,
     transaction_recorder: TransactionRecorder,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -36,10 +36,7 @@ use {
     },
     solana_transaction_error::TransactionError,
     solana_vote::vote_parser,
-    std::{
-        num::Saturating,
-        sync::{Arc, Mutex},
-    },
+    std::{num::Saturating, sync::Arc},
 };
 
 /// Consumer will create chunks of transactions from buffer with up to this size.
@@ -118,18 +115,14 @@ pub struct LeaderProcessedTransactionCounts {
 #[derive(Clone)]
 pub struct TipProcessingDependencies {
     pub tip_manager: TipManager,
-    pub tip_programs_lock: Arc<Mutex<()>>,
     pub block_builder_fee_info: Arc<ArcSwap<BlockBuilderFeeInfo>>,
     pub cluster_info: Arc<ClusterInfo>,
     pub bundle_account_locker: BundleAccountLocker,
 }
 
 impl TipProcessingDependencies {
-    /// Prepare this exact Bank before admitting BAM work, including worker handover fallback.
+    /// Prepare this exact Bank on the scheduler thread before admitting BAM work.
     pub(super) fn process_tip_programs(&self, consumer: &Consumer, bank: &Arc<Bank>) -> bool {
-        // Fallbacks can straddle a BAM reconnect on one Bank. Recheck its actual configuration
-        // each time; matching preadmitted workers already skip this path.
-        let _tip_programs_guard = self.tip_programs_lock.lock().unwrap();
         let bank_key = (bank.slot(), bank.bank_id());
         // Match BundleStage's local-cluster policy: free-rent PDAs are discarded by AccountsDb.
         if bank.rent_collector().rent.minimum_balance(0) == 0 {

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -8,7 +8,9 @@ use {
     agave_feature_set::FeatureSet,
     smallvec::SmallVec,
     solana_cost_model::{
-        cost_model::CostModel, cost_tracker::UpdatedCosts, transaction_cost::TransactionCost,
+        cost_model::CostModel,
+        cost_tracker::{CostTrackerError, UpdatedCosts},
+        transaction_cost::TransactionCost,
     },
     solana_runtime::bank::Bank,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -54,9 +56,53 @@ impl QosService {
         )
     }
 
+    /// Reserves transaction costs in order and returns the decisions and reserved-cost sum.
+    /// A block-limit shortfall covered by unsettled estimates rolls back this attempt and returns
+    /// `None`; every other rejection is final.
+    pub(super) fn try_admit_transactions(
+        bank: &Bank,
+        transactions: &[impl TransactionWithMeta],
+        pre_results: impl Iterator<Item = transaction::Result<()>>,
+        inflight_reserved_cost: u64,
+    ) -> Option<(Vec<transaction::Result<()>>, u64)> {
+        let transaction_costs =
+            Self::compute_transaction_costs(&bank.feature_set, transactions.iter(), pre_results);
+
+        let mut cost_tracker = bank.write_cost_tracker().unwrap();
+        let mut results = Vec::with_capacity(transaction_costs.len());
+        let mut reserved_cost = 0;
+        for cost_result in &transaction_costs {
+            results.push(match cost_result {
+                Err(err) => Err(err.clone()),
+                Ok(cost) => match cost_tracker.try_add(cost) {
+                    Ok(_) => {
+                        reserved_cost += cost.sum();
+                        Ok(())
+                    }
+                    Err(CostTrackerError::WouldExceedBlockMaxLimit)
+                        if cost_tracker.block_cost().saturating_add(cost.sum())
+                            - cost_tracker.block_cost_limit()
+                            <= inflight_reserved_cost =>
+                    {
+                        for (result, cost) in results.iter().zip(&transaction_costs) {
+                            if let (Ok(()), Ok(cost)) = (result, cost) {
+                                cost_tracker.remove(cost);
+                            }
+                        }
+                        return None;
+                    }
+                    Err(err) => Err(TransactionError::from(err)),
+                },
+            });
+        }
+        cost_tracker.add_transactions_in_flight(results.iter().flatten().count());
+        drop(cost_tracker);
+        Some((results, reserved_cost))
+    }
+
     // invoke cost_model to calculate cost for the given list of transactions that have not
     // been filtered out already.
-    fn compute_transaction_costs<'a, Tx: TransactionWithMeta>(
+    pub(super) fn compute_transaction_costs<'a, Tx: TransactionWithMeta>(
         feature_set: &FeatureSet,
         transactions: impl Iterator<Item = &'a Tx>,
         pre_results: impl Iterator<Item = transaction::Result<()>>,

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -68,8 +68,8 @@ impl QosService {
         let transaction_costs =
             Self::compute_transaction_costs(&bank.feature_set, transactions.iter(), pre_results);
 
-        let mut cost_tracker = bank.write_cost_tracker().unwrap();
         let mut results = Vec::with_capacity(transaction_costs.len());
+        let mut cost_tracker = bank.write_cost_tracker().unwrap();
         let mut reserved_cost = 0;
         for cost_result in &transaction_costs {
             results.push(match cost_result {
@@ -96,7 +96,6 @@ impl QosService {
             });
         }
         cost_tracker.add_transactions_in_flight(results.iter().flatten().count());
-        drop(cost_tracker);
         Some((results, reserved_cost))
     }
 

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -58,17 +58,19 @@ impl QosService {
 
     /// Reserves transaction costs in order and returns the decisions and reserved-cost sum.
     /// A block-limit shortfall covered by unsettled estimates rolls back this attempt and returns
-    /// `None`; every other rejection is final.
+    /// `None`. Atomic batches only defer if their known costs could fit after refunds;
+    /// a final atomic rejection releases its reservations and cancels its accepted transactions.
     pub(super) fn try_admit_transactions(
         bank: &Bank,
         transactions: &[impl TransactionWithMeta],
         pre_results: impl Iterator<Item = transaction::Result<()>>,
         inflight_reserved_cost: u64,
-    ) -> Option<(Vec<transaction::Result<()>>, u64)> {
+        revert_on_error: bool,
+    ) -> Option<(SmallVec<[transaction::Result<()>; 1]>, u64)> {
         let transaction_costs =
             Self::compute_transaction_costs(&bank.feature_set, transactions.iter(), pre_results);
 
-        let mut results = Vec::with_capacity(transaction_costs.len());
+        let mut results = SmallVec::with_capacity(transaction_costs.len());
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         let mut reserved_cost = 0;
         for cost_result in &transaction_costs {
@@ -82,7 +84,16 @@ impl QosService {
                     Err(CostTrackerError::WouldExceedBlockMaxLimit)
                         if cost_tracker.block_cost().saturating_add(cost.sum())
                             - cost_tracker.block_cost_limit()
-                            <= inflight_reserved_cost =>
+                            <= inflight_reserved_cost
+                            && (!revert_on_error
+                                // Exclude this attempt's prefix and all earlier estimates.
+                                // Estimates can already be settled before their completion arrives.
+                                || transaction_costs.iter().flatten().fold(
+                                    cost_tracker.block_cost()
+                                        .saturating_sub(reserved_cost)
+                                        .saturating_sub(inflight_reserved_cost),
+                                    |total, cost| total.saturating_add(cost.sum()),
+                                ) <= cost_tracker.block_cost_limit()) =>
                     {
                         for (result, cost) in results.iter().zip(&transaction_costs) {
                             if let (Ok(()), Ok(cost)) = (result, cost) {
@@ -94,6 +105,16 @@ impl QosService {
                     Err(err) => Err(TransactionError::from(err)),
                 },
             });
+        }
+        if revert_on_error && results.iter().any(Result::is_err) {
+            // These transactions cannot commit; do not hold capacity until the worker responds.
+            for (result, cost) in results.iter_mut().zip(&transaction_costs) {
+                if let (Ok(()), Ok(cost)) = (&*result, cost) {
+                    cost_tracker.remove(cost);
+                    *result = Err(TransactionError::CommitCancelled);
+                }
+            }
+            reserved_cost = 0;
         }
         cost_tracker.add_transactions_in_flight(results.iter().flatten().count());
         Some((results, reserved_cost))

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -2,8 +2,9 @@ use {
     crate::banking_stage::consumer::RetryableIndex,
     jito_protos::proto::bam_types::TransactionCommittedResult,
     solana_clock::{Epoch, Slot},
-    solana_transaction_error::TransactionError,
-    std::fmt::Display,
+    solana_runtime::bank::Bank,
+    solana_transaction_error::{TransactionError, TransactionResult as CostResult},
+    std::{fmt::Display, sync::Arc},
 };
 
 /// A unique identifier for a transaction batch.
@@ -57,6 +58,8 @@ pub struct ConsumeWork<Tx> {
     pub revert_on_error: bool,
     pub respond_with_extra_info: bool,
     pub max_schedule_slot: Option<Slot>,
+    /// Admission bank and cost results, taken when settled or returned for release.
+    pub admission: Option<(Arc<Bank>, Vec<CostResult<()>>)>,
 }
 
 /// Message: [Worker -> Scheduler]

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -1,6 +1,7 @@
 use {
     crate::banking_stage::consumer::RetryableIndex,
     jito_protos::proto::bam_types::TransactionCommittedResult,
+    smallvec::SmallVec,
     solana_clock::{Epoch, Slot},
     solana_runtime::bank::Bank,
     solana_transaction_error::{TransactionError, TransactionResult as CostResult},
@@ -59,7 +60,7 @@ pub struct ConsumeWork<Tx> {
     pub respond_with_extra_info: bool,
     pub max_schedule_slot: Option<Slot>,
     /// Admission bank and cost results, taken when settled or returned for release.
-    pub admission: Option<(Arc<Bank>, Vec<CostResult<()>>)>,
+    pub admission: Option<(Arc<Bank>, SmallVec<[CostResult<()>; 1]>)>,
 }
 
 /// Message: [Worker -> Scheduler]

--- a/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_receive_and_buffer.rs
@@ -210,7 +210,7 @@ impl BamReceiveAndBuffer {
                 }
             }
 
-            let working_bank = loop {
+            let (working_bank, bank_checks_enabled) = loop {
                 if exit.load(Ordering::Relaxed) || shutdown.load(Ordering::Relaxed) {
                     return;
                 }
@@ -281,6 +281,7 @@ impl BamReceiveAndBuffer {
                                 max_schedule_slot,
                                 (&root_bank, &working_bank),
                                 &blacklisted_accounts,
+                                bank_checks_enabled,
                                 &mut metrics,
                             ));
                         stats.accumulate(parse_stats);
@@ -320,17 +321,17 @@ impl BamReceiveAndBuffer {
     fn select_parsing_bank(
         bank_forks: &RwLock<BankForks>,
         shared_leader_state: Option<&SharedLeaderState>,
-    ) -> Option<Arc<Bank>> {
+    ) -> Option<(Arc<Bank>, bool)> {
         if let Some(shared_leader_state) = shared_leader_state {
             let leader_state = shared_leader_state.load();
             if let Some(working_bank) = leader_state.working_bank() {
-                return Some(working_bank.clone());
+                return Some((working_bank.clone(), leader_state.atomic_batches_enabled()));
             }
             if leader_state.bank_slot().is_some() {
                 return None;
             }
         }
-        Some(bank_forks.read().unwrap().working_bank())
+        Some((bank_forks.read().unwrap().working_bank(), true))
     }
 
     fn send_no_leader_slot_txn_batch_result(&self, seq_id: u32) {
@@ -380,6 +381,7 @@ impl BamReceiveAndBuffer {
         max_schedule_slot: u64,
         (root_bank, working_bank): (&Bank, &Bank),
         blacklisted_accounts: &HashSet<Pubkey>,
+        bank_checks_enabled: bool,
         metrics: &mut BamReceiveAndBufferMetrics,
     ) -> (Result<ParsedBatch, Reason>, ReceivingStats) {
         let mut stats = ReceivingStats::default();
@@ -527,33 +529,37 @@ impl BamReceiveAndBuffer {
                 );
             }
 
-            // Check 4: Ensure valid blockhash and blockhash is not too old
-            let lock_results: [_; 1] = core::array::from_fn(|_| Ok(()));
-            let (check_results, duration_us) = measure_us!(working_bank.check_transactions(
-                std::slice::from_ref(&view),
-                &lock_results,
-                MAX_PROCESSING_AGE,
-                true,
-                &mut TransactionErrorMetrics::default(),
-            ));
-            metrics.increment_check_transactions_us(duration_us);
-            if let Some(Err(err)) = check_results.first() {
-                let reason = convert_txn_error_to_proto(err.clone());
-                stats.num_dropped_on_age += 1;
-                return (
-                    Err(Reason::TransactionError(
-                        jito_protos::proto::bam_types::TransactionError {
-                            index: index as u32,
-                            reason: reason as i32,
-                        },
-                    )),
-                    stats,
-                );
+            // Fork-dependent checks wait for resolution. The scheduler and worker validate
+            // held batches against the resolved bank before execution.
+            if bank_checks_enabled {
+                // Check 4: Ensure valid blockhash and blockhash is not too old
+                let lock_results: [_; 1] = core::array::from_fn(|_| Ok(()));
+                let (check_results, duration_us) = measure_us!(working_bank.check_transactions(
+                    std::slice::from_ref(&view),
+                    &lock_results,
+                    MAX_PROCESSING_AGE,
+                    true,
+                    &mut TransactionErrorMetrics::default(),
+                ));
+                metrics.increment_check_transactions_us(duration_us);
+                if let Some(Err(err)) = check_results.first() {
+                    let reason = convert_txn_error_to_proto(err.clone());
+                    stats.num_dropped_on_age += 1;
+                    return (
+                        Err(Reason::TransactionError(
+                            jito_protos::proto::bam_types::TransactionError {
+                                index: index as u32,
+                                reason: reason as i32,
+                            },
+                        )),
+                        stats,
+                    );
+                }
             }
 
             // Check 5: Ensure the seed fee payer has enough to pay for transaction fees.
             // Downstream fee payers may be funded by earlier transactions in the same bundle.
-            if index == 0 {
+            if bank_checks_enabled && index == 0 {
                 let (result, duration_us) = measure_us!(Consumer::check_fee_payer_unlocked(
                     working_bank,
                     &view,
@@ -1563,7 +1569,10 @@ pub(super) mod tests {
         assert_ne!(old_bank.bank_id(), bank.bank_id());
         let mut shared = SharedLeaderState::new(0, None, None);
         let parsing_state = shared.clone();
-        let select = || BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(&parsing_state));
+        let select = || {
+            BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(&parsing_state))
+                .map(|(bank, _)| bank)
+        };
         let (_exit, mut receiver, mut container, mut responses) = setup_bam_receive_and_buffer(
             receiver,
             bank_forks.clone(),
@@ -1826,12 +1835,75 @@ pub(super) mod tests {
                 max_schedule_slot,
                 (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &HashSet::new(),
+                true,
                 &mut stats,
             );
 
             assert!(result.is_err());
             assert_eq!(stats.num_dropped_on_fee_payer, 1);
             assert!(matches!(result.err().unwrap(), Reason::TransactionError(_)));
+        }
+    }
+
+    #[test]
+    fn test_unresolved_bank_defers_fork_checks() {
+        let (bank_forks, mint) = test_bank_forks();
+        let bank = bank_forks.read().unwrap().working_bank();
+        let processed = transfer(&mint, &Pubkey::new_unique(), 1, bank.last_blockhash());
+        bank.process_transaction(&processed).unwrap();
+        let transactions = [
+            processed,
+            transfer(&mint, &Pubkey::new_unique(), 1, Hash::new_unique()),
+            transfer(
+                &Keypair::new(),
+                &Pubkey::new_unique(),
+                1,
+                bank.last_blockhash(),
+            ),
+        ];
+        let mut shared = SharedLeaderState::new(0, None, None);
+        shared.store(Arc::new(LeaderState::new_with_atomic_batches_enabled(
+            Some(bank.clone()),
+            0,
+            None,
+            None,
+            false,
+        )));
+        let (selected_bank, bank_checks_enabled) =
+            BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(&shared)).unwrap();
+        assert!(Arc::ptr_eq(&selected_bank, &bank));
+        assert!(!bank_checks_enabled);
+        shared.load().enable_atomic_batches();
+        // Resolution after selection cannot change the policy captured for this bank.
+        assert!(!bank_checks_enabled);
+        assert!(
+            BamReceiveAndBuffer::select_parsing_bank(&bank_forks, Some(&shared))
+                .unwrap()
+                .1
+        );
+
+        for bank_checks_enabled in [false, true] {
+            for revert_on_error in [false, true] {
+                for transaction in &transactions {
+                    let batch =
+                        batch_with_transaction(&VersionedTransaction::from(transaction.clone()));
+                    let mut metrics = BamReceiveAndBufferMetrics::default();
+                    let (verified, _) = run_batch_verify(vec![batch], bank.slot(), &mut metrics);
+                    let (mut packets, _, seq_id, max_schedule_slot) =
+                        verified.into_iter().next().unwrap().unwrap();
+                    let (result, _) = BamReceiveAndBuffer::parse_batch(
+                        &mut packets,
+                        seq_id,
+                        revert_on_error,
+                        max_schedule_slot,
+                        (&bank_forks.read().unwrap().root_bank(), &selected_bank),
+                        &HashSet::new(),
+                        bank_checks_enabled,
+                        &mut metrics,
+                    );
+                    assert_eq!(result.is_err(), bank_checks_enabled);
+                }
+            }
         }
     }
 
@@ -1885,6 +1957,7 @@ pub(super) mod tests {
                 max_schedule_slot,
                 (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &HashSet::new(),
+                true,
                 &mut stats,
             );
 
@@ -1983,6 +2056,7 @@ pub(super) mod tests {
                 max_schedule_slot,
                 (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &blacklisted_accounts,
+                true,
                 &mut stats,
             );
 
@@ -2042,6 +2116,7 @@ pub(super) mod tests {
                 max_schedule_slot,
                 (&bank_forks.root_bank(), &bank_forks.working_bank()),
                 &HashSet::new(),
+                true,
                 &mut stats,
             );
 

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -370,6 +370,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                         )
                     }),
                 self.inflight_reserved_cost,
+                revert_on_error,
             );
             let Some((results, reserved_cost)) = attempt else {
                 debug!(
@@ -1950,7 +1951,7 @@ mod tests {
     }
 
     #[test_case::test_case(1; "single_transaction")]
-    #[test_case::test_case(2; "partial_batch_rollback")]
+    #[test_case::test_case(2; "atomic_prefix_rollback")]
     fn test_deferred_batch_is_final_once_inflight_settles_without_freeing_budget(
         second_batch_size: usize,
     ) {
@@ -1984,17 +1985,121 @@ mod tests {
         assert!(test.scheduler.pending_admission.is_empty());
         let work_b = test.consume_work_receivers[0].try_recv().unwrap();
         assert_eq!(
-            work_b.admission.as_ref().unwrap().1,
-            std::iter::repeat_n(Ok(()), second_batch_size - 1)
-                .chain([Err(TransactionError::WouldExceedMaxBlockCostLimit)])
-                .collect_vec()
+            work_b.admission.as_ref().unwrap().1.as_slice(),
+            std::iter::repeat_n(
+                Err(TransactionError::CommitCancelled),
+                second_batch_size - 1,
+            )
+            .chain([Err(TransactionError::WouldExceedMaxBlockCostLimit)])
+            .collect_vec()
         );
-        assert_eq!(
-            block_cost_and_in_flight(&bank),
-            (estimate * second_batch_size as u64, second_batch_size - 1)
-        );
+        assert_eq!(block_cost_and_in_flight(&bank), (estimate, 0));
         test.scheduler.recycle_work_object(work_b);
         assert_eq!(block_cost_and_in_flight(&bank), (estimate, 0));
+    }
+
+    #[test_case::test_case(false, true; "feasible_atomic_waits")]
+    #[test_case::test_case(true, true; "impossible_atomic_releases_capacity")]
+    #[test_case::test_case(true, false; "partial_batch_waits")]
+    fn test_atomic_admission_preserves_priority_and_releases_failed_costs(
+        impossible_head: bool,
+        revert_on_error: bool,
+    ) {
+        let (mut test, bank) = admission_scheduler();
+        let estimate = estimated_cost(&bank);
+        let transfer = |outputs| {
+            prioritized_tranfers(
+                &Keypair::new(),
+                (0..outputs).map(|_| Pubkey::new_unique()),
+                1000,
+                0,
+            )
+        };
+        // The head fits the whole block limit, but settled work leaves only 3 estimates
+        // available even after every earlier reservation is refunded.
+        let settled = transfer(5);
+        let settled_costs = QosService::compute_transaction_costs(
+            &bank.feature_set,
+            std::iter::once(&settled),
+            std::iter::once(Ok(())),
+        );
+        let settled_cost = settled_costs[0].as_ref().unwrap();
+        let baseline = settled_cost.sum();
+        assert!(baseline > estimate);
+        set_block_cost_limit(&bank, baseline + 3 * estimate);
+        bank.write_cost_tracker()
+            .unwrap()
+            .try_add(settled_cost)
+            .unwrap();
+        let mut container = TransactionStateContainer::with_capacity(8);
+        insert_admission_batch(&mut container, [transfer(1)], 0);
+        container
+            .insert_new_batch(
+                [
+                    transfer(1),
+                    transfer(if impossible_head { 5 } else { 1 }),
+                    transfer(1),
+                ]
+                .into_iter()
+                .map(|tx| (tx, MaxAge::MAX))
+                .collect(),
+                u64::MAX - 1,
+                revert_on_error,
+                u64::MAX,
+                1,
+            )
+            .unwrap();
+        insert_admission_batch(&mut container, [transfer(1)], 2);
+        test.receive_completed(
+            &mut container,
+            &BufferedPacketsDecision::Consume(bank.clone()),
+        );
+
+        let should_defer = !impossible_head || !revert_on_error;
+        assert_eq!(
+            test.schedule(&mut container),
+            if should_defer { 1 } else { 5 }
+        );
+        let work_a = test.consume_work_receivers[0].try_recv().unwrap();
+        if should_defer {
+            // A refund could admit the whole atomic head at equality, or part of a non-atomic
+            // head. Independent C fits now, but must not take priority over that retry.
+            assert_eq!(block_cost_and_in_flight(&bank), (baseline + estimate, 1));
+            assert_eq!(test.scheduler.pending_admission.len(), 1);
+            assert_eq!(test.schedule(&mut container), 0);
+            assert!(test.consume_work_receivers[0].try_recv().is_err());
+        } else {
+            let work_b = test.consume_work_receivers[0].try_recv().unwrap();
+            let work_c = test.consume_work_receivers[0].try_recv().unwrap();
+            assert_eq!(
+                test.scheduler.inflight_batch_info[&work_b.batch_id].batch_priority_ids[0].1,
+                1
+            );
+            assert_eq!(
+                test.scheduler.inflight_batch_info[&work_c.batch_id].batch_priority_ids[0].1,
+                2
+            );
+            assert_eq!(
+                work_b.admission.as_ref().unwrap().1.as_slice(),
+                &[
+                    Err(TransactionError::CommitCancelled),
+                    Err(TransactionError::WouldExceedMaxBlockCostLimit),
+                    Err(TransactionError::CommitCancelled),
+                ]
+            );
+            assert_eq!(work_c.admission.as_ref().unwrap().1.as_slice(), &[Ok(())]);
+            assert!(test.scheduler.pending_admission.is_empty());
+            // B's accepted prefix AND suffix were released before C was admitted, while A
+            // is still outstanding. Returning B must not release either A's or C's cost.
+            test.scheduler.recycle_work_object(work_b);
+            assert_eq!(
+                block_cost_and_in_flight(&bank),
+                (baseline + 2 * estimate, 2)
+            );
+            test.scheduler.recycle_work_object(work_c);
+        }
+        test.scheduler.recycle_work_object(work_a);
+        assert_eq!(block_cost_and_in_flight(&bank), (baseline, 0));
     }
 
     #[test]
@@ -2154,7 +2259,7 @@ mod tests {
             assert_eq!(work.batch_id.0, batch_id);
             let (owner, results) = work.admission.as_ref().unwrap();
             assert_eq!(owner.bank_id(), bank_c.bank_id());
-            assert_eq!(results, &vec![Ok(())]);
+            assert_eq!(results.as_slice(), &[Ok(())]);
             settle_committed(&bank_c, &mut work, 150);
             finish_committed(&mut test, &mut container, &decision, work, 150);
             let (seq_id, result) = next_result(&mut test.response_receiver);

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -12,6 +12,7 @@ use {
     crate::{
         bam_dependencies::BamOutboundMessage,
         banking_stage::{
+            consumer::{Consumer, TipProcessingDependencies},
             decision_maker::BufferedPacketsDecision,
             qos_service::QosService,
             scheduler_messages::{
@@ -31,7 +32,6 @@ use {
     prio_graph::{AccessKind, GraphNode, PrioGraph},
     smallvec::SmallVec,
     solana_clock::{BankId, MAX_PROCESSING_AGE, Slot},
-    solana_measure::measure_us,
     solana_nohash_hasher::IntMap,
     solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::Pubkey,
@@ -40,7 +40,11 @@ use {
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction_error::TransactionError,
-    std::{borrow::Borrow, sync::Arc, time::Instant},
+    std::{
+        borrow::Borrow,
+        sync::Arc,
+        time::{Duration, Instant},
+    },
     tokio::sync::mpsc::Sender as TokioSender,
 };
 
@@ -82,14 +86,15 @@ pub struct BamScheduler<Tx: TransactionWithMeta> {
 
     extra_checks_enabled: bool,
     shared_leader_state: SharedLeaderState,
+    tip_processing: Option<(Consumer, TipProcessingDependencies)>,
+    tip_retry_at: Option<(BankId, Instant)>,
 
-    /// Bank whose cost tracker holds the current reservations.
+    /// Prepared Bank whose cost tracker holds the current reservations.
     admission_bank: Option<(BankId, Slot)>,
     /// Estimated cost reserved on `admission_bank` by dispatched work that has not settled.
     inflight_reserved_cost: u64,
     /// Deferred head-of-line batch and the inflight estimate at its last attempt.
     pending_admission: Option<(TransactionPriorityId, u64)>,
-    admission_us: Histogram,
 }
 
 // A structure to hold information about inflight batches.
@@ -110,6 +115,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
         response_sender: TokioSender<BamOutboundMessage>,
         shared_leader_state: SharedLeaderState,
+        tip_processing: Option<(Consumer, TipProcessingDependencies)>,
     ) -> Self {
         Self {
             consume_work_sender,
@@ -127,10 +133,11 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             reusable_consume_work: Vec::new(),
             extra_checks_enabled: true,
             shared_leader_state,
+            tip_processing,
+            tip_retry_at: None,
             admission_bank: None,
             inflight_reserved_cost: 0,
             pending_admission: None,
-            admission_us: Histogram::new(),
         }
     }
 
@@ -223,9 +230,6 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         container: &mut impl StateContainer<Tx>,
         admission_bank: &Arc<Bank>,
     ) -> Result<usize, SchedulerError> {
-        if self.prio_graph.is_empty() && self.pending_admission.is_none() {
-            return Ok(0);
-        }
         let slot = admission_bank.slot();
 
         if self.admission_bank != Some((admission_bank.bank_id(), slot)) {
@@ -234,7 +238,27 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             if !self.inflight_batch_info.is_empty() {
                 return Ok(0);
             }
+            if self.tip_retry_at.is_some_and(|(bank_id, deadline)| {
+                bank_id == admission_bank.bank_id() && Instant::now() < deadline
+            }) {
+                return Ok(0);
+            }
+            if let Some((consumer, tips)) = &self.tip_processing
+                && !tips.process_tip_programs(consumer, admission_bank)
+            {
+                // The controller busy-polls; do not sign/execute a failing crank every poll.
+                self.tip_retry_at = Some((
+                    admission_bank.bank_id(),
+                    Instant::now() + Duration::from_millis(1),
+                ));
+                return Ok(0);
+            }
+            self.tip_retry_at = None;
             self.admission_bank = Some((admission_bank.bank_id(), slot));
+        }
+
+        if self.prio_graph.is_empty() && self.pending_admission.is_none() {
+            return Ok(0);
         }
 
         let now = Instant::now();
@@ -326,7 +350,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
 
             // Admit cost here, in pop order, so eight workers racing for the cost tracker cannot
             // reorder it.
-            let (attempt, admission_us) = measure_us!(QosService::try_admit_transactions(
+            let attempt = QosService::try_admit_transactions(
                 admission_bank,
                 &work.transactions,
                 work.transactions
@@ -340,8 +364,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                         )
                     }),
                 self.inflight_reserved_cost,
-            ));
-            let _ = self.admission_us.increment(admission_us);
+            );
             let Some((results, reserved_cost)) = attempt else {
                 debug!(
                     "deferring batch {seq_id}: {} in flight",
@@ -778,19 +801,8 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                 self.time_between_schedule_us.maximum().unwrap_or_default(),
                 i64
             ),
-            (
-                "admission_us_p99",
-                self.admission_us.percentile(99.0).unwrap_or_default(),
-                i64
-            ),
-            (
-                "admission_us_max",
-                self.admission_us.maximum().unwrap_or_default(),
-                i64
-            ),
         );
         self.time_between_schedule_us.clear();
-        self.admission_us.clear();
     }
 }
 
@@ -980,12 +992,15 @@ mod tests {
         std::{
             borrow::Borrow,
             sync::{Arc, RwLock},
+            time::{Duration, Instant},
         },
     };
 
     type Tx = RuntimeTransaction<SanitizedTransaction>;
 
     struct TestScheduler {
+        // Banks hold only a weak reference to the program cache fork graph.
+        _bank_forks: Arc<RwLock<BankForks>>,
         scheduler: BamScheduler<RuntimeTransaction<SanitizedTransaction>>,
         consume_work_receivers:
             Vec<crossbeam_channel::Receiver<ConsumeWork<RuntimeTransaction<SanitizedTransaction>>>>,
@@ -1012,8 +1027,10 @@ mod tests {
             finished_consume_work_receiver,
             response_sender,
             shared_leader_state,
+            None,
         );
         TestScheduler {
+            _bank_forks: bank_forks.clone(),
             scheduler,
             consume_work_receivers: (0..num_threads)
                 .map(|_| consume_work_receiver.clone())
@@ -1088,12 +1105,7 @@ mod tests {
     #[test]
     fn test_scheduler_empty() {
         let (bank_forks, _) = test_bank_forks();
-        let TestScheduler {
-            mut scheduler,
-            consume_work_receivers: _,
-            finished_consume_work_sender: _,
-            response_receiver: _,
-        } = create_test_scheduler(4, &bank_forks);
+        let TestScheduler { mut scheduler, .. } = create_test_scheduler(4, &bank_forks);
 
         let mut container = TransactionStateContainer::with_capacity(100);
         let result = scheduler.schedule(&mut container, 0, 0).unwrap();
@@ -1242,6 +1254,7 @@ mod tests {
             consume_work_receivers,
             finished_consume_work_sender,
             mut response_receiver,
+            ..
         } = create_test_scheduler(4, &bank_forks);
         scheduler.extra_checks_enabled = false;
 
@@ -1284,6 +1297,7 @@ mod tests {
         );
 
         // A stale Consume decision must not dispatch without an active leader Bank.
+        scheduler.shared_leader_state = SharedLeaderState::new(0, None, None);
         assert_eq!(
             scheduler
                 .schedule(&mut container, 0, 0)
@@ -1292,7 +1306,10 @@ mod tests {
             0
         );
         assert!(consume_work_receivers[0].try_recv().is_err());
-        set_leader_bank(&mut scheduler.shared_leader_state, Some(decision.bank().unwrap().clone()));
+        set_leader_bank(
+            &mut scheduler.shared_leader_state,
+            Some(decision.bank().unwrap().clone()),
+        );
 
         // Schedule the transactions
         let result = scheduler.schedule(&mut container, 0, 0).unwrap();
@@ -1525,12 +1542,7 @@ mod tests {
     #[test]
     fn test_prio_graph_clears_on_slot_boundary() {
         let (bank_forks, _) = test_bank_forks();
-        let TestScheduler {
-            mut scheduler,
-            consume_work_receivers: _,
-            finished_consume_work_sender: _,
-            response_receiver: _,
-        } = create_test_scheduler(4, &bank_forks);
+        let TestScheduler { mut scheduler, .. } = create_test_scheduler(4, &bank_forks);
         scheduler.extra_checks_enabled = false;
 
         let keypair_a = Keypair::new();
@@ -1645,7 +1657,7 @@ mod tests {
         // A dispatch-time recheck rejects the default blockhash without reserving any cost.
         set_leader_bank(&mut scheduler.shared_leader_state, Some(bank.clone()));
         scheduler.extra_checks_enabled = true;
-        assert_eq!(scheduler.send_to_workers(&mut container).unwrap(), 0);
+        assert_eq!(scheduler.send_to_workers(&mut container, &bank).unwrap(), 0);
         assert!(scheduler.prio_graph.is_empty());
         assert_eq!(container.buffer_size(), 0);
         assert_eq!(block_cost_and_in_flight(&bank), (0, 0));
@@ -1856,6 +1868,7 @@ mod tests {
         let high_info = &test.scheduler.inflight_batch_info[&high_work.batch_id];
         assert_eq!(high_info.batch_priority_ids[0].1, 0);
         assert!(test.scheduler.pending_admission.is_some());
+        assert!(test.scheduler.prio_graph.is_empty());
         assert_eq!(block_cost_and_in_flight(&bank), (high_estimate, 1));
         assert!(test.consume_work_receivers[0].try_recv().is_err());
         assert_eq!(
@@ -2003,7 +2016,21 @@ mod tests {
     fn test_bank_replacement_within_slot_restarts_admission_on_new_bank() {
         let (mut test, mut container, bank_1, _) = setup_two_batches(1);
         let estimate = estimated_cost(&bank_1);
+        // A failed preparation's deadline holds work without popping or reserving it.
+        test.scheduler.tip_retry_at =
+            Some((bank_1.bank_id(), Instant::now() + Duration::from_secs(60)));
+        assert_eq!(
+            test.scheduler
+                .schedule(&mut container, 0, 0)
+                .unwrap()
+                .num_scheduled,
+            0
+        );
+        assert_eq!(block_cost_and_in_flight(&bank_1), (0, 0));
+        assert!(test.consume_work_receivers[0].try_recv().is_err());
+        test.scheduler.tip_retry_at = Some((bank_1.bank_id(), Instant::now()));
         test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        assert!(test.scheduler.tip_retry_at.is_none());
         let work_a = test.consume_work_receivers[0].try_recv().unwrap();
         let work_b = test.consume_work_receivers[0].try_recv().unwrap();
         assert_eq!(block_cost_and_in_flight(&bank_1), (estimate * 2, 2));
@@ -2034,7 +2061,10 @@ mod tests {
             bank_1.slot(),
         ));
         assert_ne!(bank_1b.bank_id(), bank_1.bank_id());
-        set_leader_bank(&mut test.scheduler.shared_leader_state, Some(bank_1b.clone()));
+        set_leader_bank(
+            &mut test.scheduler.shared_leader_state,
+            Some(bank_1b.clone()),
+        );
         let decision = BufferedPacketsDecision::Consume(bank_1b.clone());
         // Old work returned with its admission attached must drain before C can dispatch.
         for (work, remaining) in [(work_a, 1), (work_b, 0)] {
@@ -2052,6 +2082,9 @@ mod tests {
         }
 
         // With both old-bank batches drained, adopt the new bank and admit C.
+        // The previous BankId's retry deadline must not delay replacement preparation.
+        test.scheduler.tip_retry_at =
+            Some((bank_1.bank_id(), Instant::now() + Duration::from_secs(60)));
         test.scheduler
             .receive_completed(&mut container, &decision)
             .unwrap();
@@ -2061,6 +2094,7 @@ mod tests {
         assert_eq!(admission.0.bank_id(), bank_1b.bank_id());
         assert_eq!(test.scheduler.inflight_reserved_cost, estimate);
         assert_eq!(block_cost_and_in_flight(&bank_1b), (estimate, 1));
+        assert!(test.scheduler.tip_retry_at.is_none());
     }
 
     #[test_case::test_case(false; "returned_work")]

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -42,6 +42,7 @@ use {
     solana_transaction_error::TransactionError,
     std::{
         borrow::Borrow,
+        collections::BTreeMap,
         sync::Arc,
         time::{Duration, Instant},
     },
@@ -93,8 +94,8 @@ pub struct BamScheduler<Tx: TransactionWithMeta> {
     admission_bank: Option<(BankId, Slot)>,
     /// Estimated cost reserved on `admission_bank` by dispatched work that has not settled.
     inflight_reserved_cost: u64,
-    /// Deferred head-of-line batch and the inflight estimate at its last attempt.
-    pending_admission: Option<(TransactionPriorityId, u64)>,
+    /// Deferred or returned batches in original dispatch order, with their last attempted estimate.
+    pending_admission: BTreeMap<u64, (TransactionPriorityId, Option<u64>)>,
 }
 
 // A structure to hold information about inflight batches.
@@ -137,7 +138,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             tip_retry_at: None,
             admission_bank: None,
             inflight_reserved_cost: 0,
-            pending_admission: None,
+            pending_admission: BTreeMap::new(),
         }
     }
 
@@ -233,8 +234,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         let slot = admission_bank.slot();
 
         if self.admission_bank != Some((admission_bank.bank_id(), slot)) {
-            // Work admitted before a replacement may admit locally there in worker order.
-            // Keep later work behind it.
+            // Drain old admissions before retrying returned work on a replacement Bank.
             if !self.inflight_batch_info.is_empty() {
                 return Ok(0);
             }
@@ -254,10 +254,14 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                 return Ok(0);
             }
             self.tip_retry_at = None;
+            // Equal inflight totals on a different Bank do not describe the same admission attempt.
+            for (_, attempted_cost) in self.pending_admission.values_mut() {
+                *attempted_cost = None;
+            }
             self.admission_bank = Some((admission_bank.bank_id(), slot));
         }
 
-        if self.prio_graph.is_empty() && self.pending_admission.is_none() {
+        if self.prio_graph.is_empty() && self.pending_admission.is_empty() {
             return Ok(0);
         }
 
@@ -266,17 +270,19 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         loop {
             // A deferred batch holds the head of the line until work on its bank settles or the
             // bank itself changes; either way it gets the next attempt before anything else.
-            let id = if let Some((id, attempted_inflight_cost)) = self.pending_admission {
-                if attempted_inflight_cost == self.inflight_reserved_cost {
+            let (batch_id, id) = if let Some((&batch_id, &(id, attempted_inflight_cost))) =
+                self.pending_admission.first_key_value()
+            {
+                if attempted_inflight_cost == Some(self.inflight_reserved_cost) {
                     return Ok(num_scheduled);
                 }
-                self.pending_admission = None;
-                id
+                self.pending_admission.pop_first();
+                (TransactionBatchId::new(batch_id), id)
             } else {
                 let Some(id) = self.prio_graph.pop() else {
                     return Ok(num_scheduled);
                 };
-                id
+                (self.get_next_schedule_id(), id)
             };
 
             let (batch_ids, revert_on_error, max_schedule_slot, seq_id) =
@@ -341,7 +347,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             let mut work = self.get_or_create_work_object();
             Self::populate_consume_work(
                 &mut work,
-                TransactionBatchId::new(self.next_batch_id),
+                batch_id,
                 &[id],
                 revert_on_error,
                 container,
@@ -378,10 +384,10 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                         .retry_transaction(transaction);
                 }
                 self.recycle_work_object(work);
-                self.pending_admission = Some((id, self.inflight_reserved_cost));
+                self.pending_admission
+                    .insert(batch_id.0, (id, Some(self.inflight_reserved_cost)));
                 return Ok(num_scheduled);
             };
-            work.batch_id = self.get_next_schedule_id();
             work.admission = Some((Arc::clone(admission_bank), results));
             num_scheduled += work.ids.len();
             self.send_to_worker(SmallVec::from([(id, seq_id)]), work, slot, reserved_cost)?;
@@ -439,7 +445,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         })
     }
 
-    fn recycle_work_object(&mut self, mut work: ConsumeWork<Tx>) {
+    fn release_admission(work: &mut ConsumeWork<Tx>) {
         if let Some((bank, results)) = work.admission.take() {
             let costs = QosService::compute_transaction_costs(
                 &bank.feature_set,
@@ -448,6 +454,10 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             );
             QosService::remove_or_update_costs(costs.iter(), None, &bank);
         }
+    }
+
+    fn recycle_work_object(&mut self, mut work: ConsumeWork<Tx>) {
+        Self::release_admission(&mut work);
         work.ids.clear();
         work.transactions.clear();
         work.max_ages.clear();
@@ -651,10 +661,9 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             }
         }
 
-        // A batch deferred on cost admission was popped from the prio-graph but never
-        // dispatched. It gets the same result as everything still queued, and it must be
-        // unblocked so the drain below reaches its dependents.
-        if let Some((pending_id, _)) = self.pending_admission.take() {
+        // Pending admissions still hold their popped graph nodes. Unblock them so the drain
+        // below reaches their dependents, and report the same result as other queued work.
+        while let Some((_, (pending_id, _))) = self.pending_admission.pop_first() {
             self.prio_graph.unblock(&pending_id);
             if let Some((_, _, _, seq_id)) = container.get_batch(pending_id.id) {
                 self.send_no_leader_slot_bundle_result(seq_id);
@@ -867,14 +876,15 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for BamScheduler<Tx> {
         let now = Instant::now();
         while let Ok(result) = self.finished_consume_work_receiver.try_recv() {
             let FinishedConsumeWork {
-                work, extra_info, ..
+                mut work,
+                retryable_indexes,
+                extra_info,
             } = result;
             num_transactions += work.ids.len();
             let batch_id = work.batch_id;
             let revert_on_error = work.revert_on_error;
-            self.recycle_work_object(work);
-
             let Some(inflight_batch_info) = self.inflight_batch_info.remove(&batch_id) else {
+                self.recycle_work_object(work);
                 continue;
             };
 
@@ -884,6 +894,33 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for BamScheduler<Tx> {
             self.inflight_reserved_cost = self
                 .inflight_reserved_cost
                 .saturating_sub(inflight_batch_info.reserved_cost);
+
+            let retry_on_replacement = work.admission.as_ref().is_some_and(|(owner, _)| {
+                let leader_state = self.shared_leader_state.load();
+                Some(inflight_batch_info.slot) == self.slot
+                    && leader_state.bank_slot() == self.slot
+                    && retryable_indexes.len() == work.transactions.len()
+                    && leader_state
+                        .working_bank()
+                        .is_none_or(|bank| bank.bank_id() != owner.bank_id())
+            });
+            if retry_on_replacement {
+                Self::release_admission(&mut work);
+                for (id, transaction) in work.ids.iter().zip(work.transactions.drain(..)) {
+                    container
+                        .get_mut_transaction_state(*id)
+                        .unwrap()
+                        .retry_transaction(transaction);
+                }
+                // Keep the graph node blocked and its original dispatch ID across replacements.
+                self.pending_admission.insert(
+                    batch_id.0,
+                    (inflight_batch_info.batch_priority_ids[0].0, None),
+                );
+                self.recycle_work_object(work);
+                continue;
+            }
+            self.recycle_work_object(work);
 
             let _ = self.time_in_worker_us.increment(
                 now.duration_since(inflight_batch_info.schedule_time)
@@ -1663,6 +1700,46 @@ mod tests {
         assert_eq!(block_cost_and_in_flight(&bank), (0, 0));
     }
 
+    impl TestScheduler {
+        fn schedule(&mut self, container: &mut TransactionStateContainer<Tx>) -> usize {
+            self.scheduler
+                .schedule(container, 0, 0)
+                .unwrap()
+                .num_scheduled
+        }
+
+        fn receive_completed(
+            &mut self,
+            container: &mut TransactionStateContainer<Tx>,
+            decision: &BufferedPacketsDecision,
+        ) {
+            self.scheduler
+                .receive_completed(container, decision)
+                .unwrap();
+        }
+    }
+
+    fn insert_admission_batch(
+        container: &mut TransactionStateContainer<Tx>,
+        transactions: impl IntoIterator<Item = Tx>,
+        seq_id: u32,
+    ) {
+        let transactions: SmallVec<_> = transactions
+            .into_iter()
+            .map(|tx| (tx, MaxAge::MAX))
+            .collect();
+        let revert_on_error = transactions.len() > 1;
+        container
+            .insert_new_batch(
+                transactions,
+                u64::MAX - u64::from(seq_id),
+                revert_on_error,
+                u64::MAX,
+                seq_id,
+            )
+            .unwrap();
+    }
+
     fn set_block_cost_limit(bank: &Bank, block_cost: u64) {
         bank.write_cost_tracker()
             .unwrap()
@@ -1724,9 +1801,7 @@ mod tests {
                 extra_info: Some(FinishedConsumeWorkExtraInfo { processed_results }),
             })
             .unwrap();
-        test.scheduler
-            .receive_completed(container, decision)
-            .unwrap();
+        test.receive_completed(container, decision);
     }
 
     fn next_result(
@@ -1754,8 +1829,6 @@ mod tests {
         (test, bank)
     }
 
-    // ---- scheduler-side cost admission (JSA-72) ----
-
     /// Two independent batches plus a bank the scheduler can admit on, with `slot` set.
     fn setup_two_batches(
         second_batch_size: usize,
@@ -1768,40 +1841,25 @@ mod tests {
         let (mut test, bank) = admission_scheduler();
         let mut container = TransactionStateContainer::with_capacity(8);
         for (seq_id, size) in [1, second_batch_size].into_iter().enumerate() {
-            container.insert_new_batch(
-                (0..size)
-                    .map(|_| {
-                        (
-                            prioritized_tranfers(&Keypair::new(), [Pubkey::new_unique()], 1000, 0),
-                            MaxAge::MAX,
-                        )
-                    })
-                    .collect(),
-                u64::MAX - seq_id as u64,
-                size > 1,
-                u64::MAX,
+            insert_admission_batch(
+                &mut container,
+                (0..size).map(|_| {
+                    prioritized_tranfers(&Keypair::new(), [Pubkey::new_unique()], 1000, 0)
+                }),
                 seq_id as u32,
             );
         }
         let decision = BufferedPacketsDecision::Consume(bank.clone());
-        test.scheduler
-            .receive_completed(&mut container, &decision)
-            .unwrap();
+        test.receive_completed(&mut container, &decision);
         (test, container, bank, decision)
     }
 
-    /// Deterministic scheduler-level version of the JSA-72 live PoC.
-    ///
-    /// The PoC pauses the earlier, high-CU transaction after dequeue so a later cheap transfer
-    /// can reserve the Bank budget first. Scheduler-side admission makes that worker timing
-    /// irrelevant: only the high-priority work can be dispatched until its estimate settles.
+    /// JSA-72: later cheap work must wait for the earlier high-CU reservation to settle.
     #[test]
     fn test_jsa72_poc_priority_survives_inverted_worker_timing() {
         let (mut test, bank) = admission_scheduler();
 
-        // Match the live PoC shapes: the earlier transaction requests 200k CUs, while the later
-        // transaction is a plain transfer. Distinct payers and recipients keep the batches
-        // independent in the priority graph.
+        // Match the reported transaction shapes with independent payers and recipients.
         let poc_transfer = |compute_unit_limit: Option<u32>| {
             let from = Keypair::new();
             let mut instructions = compute_unit_limit
@@ -1827,9 +1885,7 @@ mod tests {
         let high_estimate = high_cost.sum();
         let low_estimate = low_cost.sum();
 
-        // As in the PoC, the block limit is exactly the high transaction's reservation. If the
-        // low transaction reserved first, the high transaction would be rejected even though
-        // both fit after the high estimate settles to actual execution cost.
+        // The lower-priority reservation would reject the earlier work at this limit.
         set_block_cost_limit(&bank, high_estimate);
         {
             let mut tracker = bank.write_cost_tracker().unwrap();
@@ -1845,43 +1901,27 @@ mod tests {
         drop(transaction_costs);
 
         let mut container = TransactionStateContainer::with_capacity(8);
-        for (transaction, priority, seq_id) in [(high_transaction, 2, 0), (low_transaction, 1, 1)] {
-            assert!(
-                container
-                    .insert_new_batch(
-                        std::iter::once((transaction, MaxAge::MAX)).collect(),
-                        priority,
-                        false,
-                        u64::MAX,
-                        seq_id,
-                    )
-                    .is_some()
-            );
+        for (seq_id, transaction) in [high_transaction, low_transaction].into_iter().enumerate() {
+            insert_admission_batch(&mut container, [transaction], seq_id as u32);
         }
         let decision = BufferedPacketsDecision::Consume(bank.clone());
-        test.scheduler
-            .receive_completed(&mut container, &decision)
-            .unwrap();
+        test.receive_completed(&mut container, &decision);
 
-        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        test.schedule(&mut container);
         let mut high_work = test.consume_work_receivers[0].try_recv().unwrap();
         let high_info = &test.scheduler.inflight_batch_info[&high_work.batch_id];
         assert_eq!(high_info.batch_priority_ids[0].1, 0);
-        assert!(test.scheduler.pending_admission.is_some());
+        assert!(!test.scheduler.pending_admission.is_empty());
         assert!(test.scheduler.prio_graph.is_empty());
         assert_eq!(block_cost_and_in_flight(&bank), (high_estimate, 1));
         assert!(test.consume_work_receivers[0].try_recv().is_err());
         assert_eq!(
-            test.scheduler
-                .schedule(&mut container, 0, 0)
-                .unwrap()
-                .num_scheduled,
+            test.schedule(&mut container),
             0,
             "a pending batch must not spin or retry before a completion"
         );
 
-        // Complete the high transaction below its estimate. This is the event the live PoC
-        // delayed; here it is explicit, so the test has no sleeps or scheduling races.
+        // Settle explicitly below the estimate, without sleeps or worker timing dependencies.
         settle_committed(&bank, &mut high_work, 150);
         let settled_high_cost = bank.read_cost_tracker().unwrap().block_cost();
         assert!(settled_high_cost + low_estimate <= high_estimate);
@@ -1891,7 +1931,7 @@ mod tests {
         assert!(matches!(result, Committed(_)));
 
         // Only after the earlier reservation settles can the lower-priority work be dispatched.
-        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        test.schedule(&mut container);
         let mut low_work = test.consume_work_receivers[0].try_recv().unwrap();
         let low_info = &test.scheduler.inflight_batch_info[&low_work.batch_id];
         assert_eq!(low_info.batch_priority_ids[0].1, 1);
@@ -1918,9 +1958,9 @@ mod tests {
         let estimate = estimated_cost(&bank);
         set_block_cost_limit(&bank, estimate * second_batch_size as u64 + estimate / 2);
 
-        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        test.schedule(&mut container);
         let mut work_a = test.consume_work_receivers[0].try_recv().unwrap();
-        assert!(test.scheduler.pending_admission.is_some());
+        assert!(!test.scheduler.pending_admission.is_empty());
         // B must roll back any earlier admissions in its batch without touching A's reservation.
         assert_eq!(block_cost_and_in_flight(&bank), (estimate, 1));
         assert!(test.consume_work_receivers[0].try_recv().is_err());
@@ -1940,8 +1980,8 @@ mod tests {
 
         // Nothing inflight can cover the shortfall any more, so B is dispatched with the final
         // per-transaction error, exactly as the worker would have produced it.
-        test.scheduler.schedule(&mut container, 0, 0).unwrap();
-        assert!(test.scheduler.pending_admission.is_none());
+        test.schedule(&mut container);
+        assert!(test.scheduler.pending_admission.is_empty());
         let work_b = test.consume_work_receivers[0].try_recv().unwrap();
         assert_eq!(
             work_b.admission.as_ref().unwrap().1,
@@ -1977,19 +2017,15 @@ mod tests {
             (&keypair_b, vec![Pubkey::new_unique()], 1000, 2, u64::MAX),
         ]);
         let decision = BufferedPacketsDecision::Consume(bank.clone());
-        test.scheduler
-            .receive_completed(&mut container, &decision)
-            .unwrap();
+        test.receive_completed(&mut container, &decision);
 
-        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        test.schedule(&mut container);
         test.consume_work_receivers[0].try_recv().unwrap();
-        assert!(test.scheduler.pending_admission.is_some());
+        assert!(!test.scheduler.pending_admission.is_empty());
 
         // Slot ends: the deferred batch and the batch it was blocking both go back to BAM.
-        test.scheduler
-            .receive_completed(&mut container, &BufferedPacketsDecision::Forward)
-            .unwrap();
-        assert!(test.scheduler.pending_admission.is_none());
+        test.receive_completed(&mut container, &BufferedPacketsDecision::Forward);
+        assert!(test.scheduler.pending_admission.is_empty());
         assert!(test.scheduler.prio_graph.is_empty());
         assert!(container.pop().is_none());
 
@@ -2012,6 +2048,127 @@ mod tests {
         assert_eq!(test.scheduler.inflight_batch_info.len(), 1);
     }
 
+    #[test_case::test_case(false; "repeated_replacement")]
+    #[test_case::test_case(true; "slot_boundary")]
+    fn test_returned_admissions_preserve_order_and_deferred_head(end_slot: bool) {
+        let (mut test, mut container, bank_a, _) = setup_two_batches(1);
+        let estimate = estimated_cost(&bank_a);
+        set_block_cost_limit(&bank_a, estimate * 2);
+        insert_admission_batch(
+            &mut container,
+            [prioritized_tranfers(
+                &Keypair::new(),
+                [Pubkey::new_unique()],
+                1000,
+                0,
+            )],
+            2,
+        );
+        assert_eq!(test.schedule(&mut container), 2);
+        let work_a = test.consume_work_receivers[0].try_recv().unwrap();
+        let work_b = test.consume_work_receivers[0].try_recv().unwrap();
+        let (&deferred_id, _) = test.scheduler.pending_admission.first_key_value().unwrap();
+        let batch_ids = [work_a.batch_id.0, work_b.batch_id.0, deferred_id];
+        assert!(test.consume_work_receivers[0].try_recv().is_err());
+
+        let return_work = |test: &mut TestScheduler, work: ConsumeWork<Tx>| {
+            let retryable_indexes = (0..work.transactions.len())
+                .map(|index| RetryableIndex::new(index, true))
+                .collect();
+            test.finished_consume_work_sender
+                .send(FinishedConsumeWork {
+                    work,
+                    retryable_indexes,
+                    extra_info: None,
+                })
+                .unwrap();
+        };
+        // The later worker returns in the replacement gap; A still holds its old admission.
+        test.scheduler.shared_leader_state.set_bank_replacement();
+        return_work(&mut test, work_b);
+        test.receive_completed(&mut container, &BufferedPacketsDecision::Hold);
+        assert_eq!(block_cost_and_in_flight(&bank_a), (estimate, 1));
+        assert_eq!(test.schedule(&mut container), 0);
+
+        let bank_b = Arc::new(Bank::new_from_parent(
+            bank_a.parent().unwrap(),
+            SlotLeader::new_unique(),
+            bank_a.slot(),
+        ));
+        set_block_cost_limit(&bank_b, estimate);
+        set_leader_bank(
+            &mut test.scheduler.shared_leader_state,
+            Some(bank_b.clone()),
+        );
+        assert_eq!(test.schedule(&mut container), 0);
+        return_work(&mut test, work_a);
+        let decision = BufferedPacketsDecision::Consume(bank_b.clone());
+        test.receive_completed(&mut container, &decision);
+        assert_eq!(block_cost_and_in_flight(&bank_a), (0, 0));
+        assert_eq!(test.scheduler.pending_admission.len(), 3);
+        assert!(test.response_receiver.try_recv().is_err());
+
+        if end_slot {
+            test.receive_completed(&mut container, &BufferedPacketsDecision::Forward);
+            assert!(test.scheduler.pending_admission.is_empty());
+            assert!(test.scheduler.prio_graph.is_empty());
+            assert_eq!(container.buffer_size(), 0);
+            for expected_seq_id in 0..3 {
+                let (seq_id, result) = next_result(&mut test.response_receiver);
+                assert_eq!(seq_id, expected_seq_id);
+                assert!(matches!(
+                    result,
+                    NotCommitted(not_committed) if not_committed.reason == Some(
+                        Reason::SchedulingError(SchedulingError::OutsideLeaderSlot as i32)
+                    )
+                ));
+            }
+            assert!(test.response_receiver.try_recv().is_err());
+            return;
+        }
+
+        assert_eq!(test.schedule(&mut container), 1);
+        let work_a = test.consume_work_receivers[0].try_recv().unwrap();
+        assert_eq!(work_a.batch_id.0, batch_ids[0]);
+        assert!(test.consume_work_receivers[0].try_recv().is_err());
+        assert_eq!(test.scheduler.pending_admission.len(), 2);
+
+        // Replace again while A is dispatched, B is deferred, and C retains its original key.
+        let bank_c = Arc::new(Bank::new_from_parent(
+            bank_a.parent().unwrap(),
+            SlotLeader::new_unique(),
+            bank_a.slot(),
+        ));
+        set_block_cost_limit(&bank_c, estimate * 3);
+        set_leader_bank(
+            &mut test.scheduler.shared_leader_state,
+            Some(bank_c.clone()),
+        );
+        return_work(&mut test, work_a);
+        let decision = BufferedPacketsDecision::Consume(bank_c.clone());
+        test.receive_completed(&mut container, &decision);
+        assert_eq!(block_cost_and_in_flight(&bank_b), (0, 0));
+        assert_eq!(test.schedule(&mut container), 3);
+        for (expected_seq_id, batch_id) in batch_ids.into_iter().enumerate() {
+            let mut work = test.consume_work_receivers[0].try_recv().unwrap();
+            assert_eq!(work.batch_id.0, batch_id);
+            let (owner, results) = work.admission.as_ref().unwrap();
+            assert_eq!(owner.bank_id(), bank_c.bank_id());
+            assert_eq!(results, &vec![Ok(())]);
+            settle_committed(&bank_c, &mut work, 150);
+            finish_committed(&mut test, &mut container, &decision, work, 150);
+            let (seq_id, result) = next_result(&mut test.response_receiver);
+            assert_eq!(seq_id as usize, expected_seq_id);
+            assert!(matches!(result, Committed(_)));
+        }
+        assert!(test.scheduler.pending_admission.is_empty());
+        assert!(!test.scheduler.has_in_flight_transactions());
+        assert_eq!(test.scheduler.inflight_reserved_cost, 0);
+        assert_eq!(block_cost_and_in_flight(&bank_c).1, 0);
+        assert_eq!(container.buffer_size(), 0);
+        assert!(test.response_receiver.try_recv().is_err());
+    }
+
     #[test]
     fn test_bank_replacement_within_slot_restarts_admission_on_new_bank() {
         let (mut test, mut container, bank_1, _) = setup_two_batches(1);
@@ -2019,39 +2176,21 @@ mod tests {
         // A failed preparation's deadline holds work without popping or reserving it.
         test.scheduler.tip_retry_at =
             Some((bank_1.bank_id(), Instant::now() + Duration::from_secs(60)));
-        assert_eq!(
-            test.scheduler
-                .schedule(&mut container, 0, 0)
-                .unwrap()
-                .num_scheduled,
-            0
-        );
+        assert_eq!(test.schedule(&mut container), 0);
         assert_eq!(block_cost_and_in_flight(&bank_1), (0, 0));
         assert!(test.consume_work_receivers[0].try_recv().is_err());
         test.scheduler.tip_retry_at = Some((bank_1.bank_id(), Instant::now()));
-        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        test.schedule(&mut container);
         assert!(test.scheduler.tip_retry_at.is_none());
         let work_a = test.consume_work_receivers[0].try_recv().unwrap();
         let work_b = test.consume_work_receivers[0].try_recv().unwrap();
         assert_eq!(block_cost_and_in_flight(&bank_1), (estimate * 2, 2));
 
         // The bankless handover clears the graph. Work arriving in the gap must remain queued.
-        test.scheduler
-            .receive_completed(&mut container, &BufferedPacketsDecision::Forward)
-            .unwrap();
+        test.receive_completed(&mut container, &BufferedPacketsDecision::Forward);
         assert_eq!(test.scheduler.slot, None);
         let transaction = prioritized_tranfers(&Keypair::new(), [Pubkey::new_unique()], 1000, 0);
-        assert!(
-            container
-                .insert_new_batch(
-                    std::iter::once((transaction, MaxAge::MAX)).collect(),
-                    u64::MAX,
-                    false,
-                    u64::MAX,
-                    2,
-                )
-                .is_some()
-        );
+        insert_admission_batch(&mut container, [transaction], 2);
 
         // ParentReady installs a replacement for the same slot. Do not adopt it or dispatch C
         // until both old-bank batches have returned.
@@ -2068,10 +2207,8 @@ mod tests {
         let decision = BufferedPacketsDecision::Consume(bank_1b.clone());
         // Old work returned with its admission attached must drain before C can dispatch.
         for (work, remaining) in [(work_a, 1), (work_b, 0)] {
-            test.scheduler
-                .receive_completed(&mut container, &decision)
-                .unwrap();
-            test.scheduler.schedule(&mut container, 0, 0).unwrap();
+            test.receive_completed(&mut container, &decision);
+            test.schedule(&mut container);
             assert!(test.consume_work_receivers[0].try_recv().is_err());
             assert_eq!(test.scheduler.slot, None);
             finish_committed(&mut test, &mut container, &decision, work, 150);
@@ -2085,10 +2222,8 @@ mod tests {
         // The previous BankId's retry deadline must not delay replacement preparation.
         test.scheduler.tip_retry_at =
             Some((bank_1.bank_id(), Instant::now() + Duration::from_secs(60)));
-        test.scheduler
-            .receive_completed(&mut container, &decision)
-            .unwrap();
-        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        test.receive_completed(&mut container, &decision);
+        test.schedule(&mut container);
         let work_c = test.consume_work_receivers[0].try_recv().unwrap();
         let admission = work_c.admission.as_ref().unwrap();
         assert_eq!(admission.0.bank_id(), bank_1b.bank_id());
@@ -2116,7 +2251,7 @@ mod tests {
             return;
         }
 
-        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        test.schedule(&mut container);
         let work_a = test.consume_work_receivers[0].try_recv().unwrap();
         assert_eq!(block_cost_and_in_flight(&bank), (estimate, 1));
 
@@ -2132,9 +2267,7 @@ mod tests {
                 }),
             })
             .unwrap();
-        test.scheduler
-            .receive_completed(&mut container, &decision)
-            .unwrap();
+        test.receive_completed(&mut container, &decision);
         assert_eq!(block_cost_and_in_flight(&bank), (0, 0));
         assert_eq!(test.scheduler.inflight_reserved_cost, 0);
         // The released admission must not keep the bank alive from the reuse pool.

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -13,6 +13,7 @@ use {
         bam_dependencies::BamOutboundMessage,
         banking_stage::{
             decision_maker::BufferedPacketsDecision,
+            qos_service::QosService,
             scheduler_messages::{
                 ConsumeWork, FinishedConsumeWork, NotCommittedReason, TransactionBatchId,
                 TransactionResult,
@@ -29,7 +30,8 @@ use {
     },
     prio_graph::{AccessKind, GraphNode, PrioGraph},
     smallvec::SmallVec,
-    solana_clock::{MAX_PROCESSING_AGE, Slot},
+    solana_clock::{BankId, MAX_PROCESSING_AGE, Slot},
+    solana_measure::measure_us,
     solana_nohash_hasher::IntMap,
     solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::Pubkey,
@@ -38,7 +40,7 @@ use {
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction_error::TransactionError,
-    std::{borrow::Borrow, time::Instant},
+    std::{borrow::Borrow, sync::Arc, time::Instant},
     tokio::sync::mpsc::Sender as TokioSender,
 };
 
@@ -80,6 +82,14 @@ pub struct BamScheduler<Tx: TransactionWithMeta> {
 
     extra_checks_enabled: bool,
     shared_leader_state: SharedLeaderState,
+
+    /// Bank whose cost tracker holds the current reservations.
+    admission_bank: Option<(BankId, Slot)>,
+    /// Estimated cost reserved on `admission_bank` by dispatched work that has not settled.
+    inflight_reserved_cost: u64,
+    /// Deferred head-of-line batch and the inflight estimate at its last attempt.
+    pending_admission: Option<(TransactionPriorityId, u64)>,
+    admission_us: Histogram,
 }
 
 // A structure to hold information about inflight batches.
@@ -90,6 +100,8 @@ struct InflightBatchInfo {
     // SmallVec 1: each scheduled work item typically corresponds to one batch id.
     pub batch_priority_ids: SmallVec<[(TransactionPriorityId, u32 /* seq_id */); 1]>,
     pub slot: Slot,
+    /// Estimate the scheduler reserved for this work, held until completion.
+    pub reserved_cost: u64,
 }
 
 impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
@@ -115,6 +127,10 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             reusable_consume_work: Vec::new(),
             extra_checks_enabled: true,
             shared_leader_state,
+            admission_bank: None,
+            inflight_reserved_cost: 0,
+            pending_admission: None,
+            admission_us: Histogram::new(),
         }
     }
 
@@ -205,13 +221,40 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
     fn send_to_workers(
         &mut self,
         container: &mut impl StateContainer<Tx>,
-        num_scheduled: &mut usize,
-        working_bank: &Bank,
-    ) {
-        let slot = working_bank.slot();
+        admission_bank: &Arc<Bank>,
+    ) -> Result<usize, SchedulerError> {
+        if self.prio_graph.is_empty() && self.pending_admission.is_none() {
+            return Ok(0);
+        }
+        let slot = admission_bank.slot();
+
+        if self.admission_bank != Some((admission_bank.bank_id(), slot)) {
+            // Work admitted before a replacement may admit locally there in worker order.
+            // Keep later work behind it.
+            if !self.inflight_batch_info.is_empty() {
+                return Ok(0);
+            }
+            self.admission_bank = Some((admission_bank.bank_id(), slot));
+        }
 
         let now = Instant::now();
-        while let Some(id) = self.prio_graph.pop() {
+        let mut num_scheduled = 0;
+        loop {
+            // A deferred batch holds the head of the line until work on its bank settles or the
+            // bank itself changes; either way it gets the next attempt before anything else.
+            let id = if let Some((id, attempted_inflight_cost)) = self.pending_admission {
+                if attempted_inflight_cost == self.inflight_reserved_cost {
+                    return Ok(num_scheduled);
+                }
+                self.pending_admission = None;
+                id
+            } else {
+                let Some(id) = self.prio_graph.pop() else {
+                    return Ok(num_scheduled);
+                };
+                id
+            };
+
             let (batch_ids, revert_on_error, max_schedule_slot, seq_id) =
                 container.get_batch(id.id).unwrap();
 
@@ -242,7 +285,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                         lock_results.push(Ok(()));
                     }
                 }
-                let check_result = working_bank.check_transactions::<Tx>(
+                let check_result = admission_bank.check_transactions::<Tx>(
                     &sanitized_txs,
                     &lock_results,
                     MAX_PROCESSING_AGE,
@@ -271,19 +314,54 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                 };
             }
 
-            // Schedule it
             let mut work = self.get_or_create_work_object();
-            let batch_id = self.get_next_schedule_id();
-            *num_scheduled += batch_ids.len();
             Self::populate_consume_work(
                 &mut work,
-                batch_id,
+                TransactionBatchId::new(self.next_batch_id),
                 &[id],
                 revert_on_error,
                 container,
                 slot,
             );
-            self.send_to_worker(SmallVec::from([(id, seq_id)]), work, slot);
+
+            // Admit cost here, in pop order, so eight workers racing for the cost tracker cannot
+            // reorder it.
+            let (attempt, admission_us) = measure_us!(QosService::try_admit_transactions(
+                admission_bank,
+                &work.transactions,
+                work.transactions
+                    .iter()
+                    .zip(&work.max_ages)
+                    .map(|(tx, max_age)| {
+                        admission_bank.resanitize_transaction_minimally(
+                            tx,
+                            max_age.sanitized_epoch,
+                            max_age.alt_invalidation_slot,
+                        )
+                    }),
+                self.inflight_reserved_cost,
+            ));
+            let _ = self.admission_us.increment(admission_us);
+            let Some((results, reserved_cost)) = attempt else {
+                debug!(
+                    "deferring batch {seq_id}: {} in flight",
+                    self.inflight_reserved_cost
+                );
+                // The retry takes the transactions out again; hand them back until then.
+                for (txn_id, transaction) in work.ids.iter().zip(work.transactions.drain(..)) {
+                    container
+                        .get_mut_transaction_state(*txn_id)
+                        .unwrap()
+                        .retry_transaction(transaction);
+                }
+                self.recycle_work_object(work);
+                self.pending_admission = Some((id, self.inflight_reserved_cost));
+                return Ok(num_scheduled);
+            };
+            work.batch_id = self.get_next_schedule_id();
+            work.admission = Some((Arc::clone(admission_bank), results));
+            num_scheduled += work.ids.len();
+            self.send_to_worker(SmallVec::from([(id, seq_id)]), work, slot, reserved_cost)?;
         }
     }
 
@@ -293,17 +371,26 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         priority_ids: SmallVec<[(TransactionPriorityId, u32); 1]>,
         work: ConsumeWork<Tx>,
         slot: Slot,
-    ) {
+        reserved_cost: u64,
+    ) -> Result<(), SchedulerError> {
         let batch_id = work.batch_id;
-        let _ = self.consume_work_sender.send(work);
+        if let Err(err) = self.consume_work_sender.send(work) {
+            self.recycle_work_object(err.0);
+            return Err(SchedulerError::DisconnectedSendChannel(
+                "BAM worker disconnected",
+            ));
+        }
+        self.inflight_reserved_cost += reserved_cost;
         self.inflight_batch_info.insert(
             batch_id,
             InflightBatchInfo {
                 schedule_time: Instant::now(),
                 batch_priority_ids: priority_ids,
                 slot,
+                reserved_cost,
             },
         );
+        Ok(())
     }
 
     fn get_next_schedule_id(&mut self) -> TransactionBatchId {
@@ -324,12 +411,20 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                 respond_with_extra_info: false,
                 target_slot: 0,
                 max_schedule_slot: None,
+                admission: None,
             }
         })
     }
 
     fn recycle_work_object(&mut self, mut work: ConsumeWork<Tx>) {
-        // Just in case, clear the work object
+        if let Some((bank, results)) = work.admission.take() {
+            let costs = QosService::compute_transaction_costs(
+                &bank.feature_set,
+                work.transactions.iter(),
+                results.into_iter(),
+            );
+            QosService::remove_or_update_costs(costs.iter(), None, &bank);
+        }
         work.ids.clear();
         work.transactions.clear();
         work.max_ages.clear();
@@ -509,6 +604,11 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         if bank_slot == self.slot {
             return;
         }
+        // A bankless boundary already unblocked and cleared the old graph. Keep its slot
+        // inactive until old completions drain so a same-slot replacement cannot unblock twice.
+        if self.slot.is_none() && !self.inflight_batch_info.is_empty() {
+            return;
+        }
         let prev_slot = self.slot;
         match bank_slot {
             Some(bank_slot) => {
@@ -528,6 +628,16 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             }
         }
 
+        // A batch deferred on cost admission was popped from the prio-graph but never
+        // dispatched. It gets the same result as everything still queued, and it must be
+        // unblocked so the drain below reaches its dependents.
+        if let Some((pending_id, _)) = self.pending_admission.take() {
+            self.prio_graph.unblock(&pending_id);
+            if let Some((_, _, _, seq_id)) = container.get_batch(pending_id.id) {
+                self.send_no_leader_slot_bundle_result(seq_id);
+            }
+            container.remove_by_id(pending_id.id);
+        }
         // Unblock all transactions blocked by inflight batches
         // and then drain the prio-graph
         for inflight_info in self.inflight_batch_info.values() {
@@ -668,8 +778,19 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                 self.time_between_schedule_us.maximum().unwrap_or_default(),
                 i64
             ),
+            (
+                "admission_us_p99",
+                self.admission_us.percentile(99.0).unwrap_or_default(),
+                i64
+            ),
+            (
+                "admission_us_max",
+                self.admission_us.maximum().unwrap_or_default(),
+                i64
+            ),
         );
         self.time_between_schedule_us.clear();
+        self.admission_us.clear();
     }
 }
 
@@ -704,7 +825,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for BamScheduler<Tx> {
             && Some(bank.slot()) == self.slot
         {
             self.pull_into_prio_graph(container, bank);
-            self.send_to_workers(container, &mut num_scheduled, bank);
+            num_scheduled = self.send_to_workers(container, bank)?;
         }
 
         // TODO(seg): Double check the zeros here
@@ -744,6 +865,13 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for BamScheduler<Tx> {
             let Some(inflight_batch_info) = self.inflight_batch_info.remove(&batch_id) else {
                 continue;
             };
+
+            // Settled work may have freed budget for a batch deferred on this bank's block limit.
+            // Dispatch is held across a bank change until the old work drains, so everything in
+            // flight was admitted on `admission_bank`.
+            self.inflight_reserved_cost = self
+                .inflight_reserved_cost
+                .saturating_sub(inflight_batch_info.reserved_cost);
 
             let _ = self.time_in_worker_us.increment(
                 now.duration_since(inflight_batch_info.schedule_time)
@@ -807,9 +935,12 @@ mod tests {
         crate::{
             bam_dependencies::BamOutboundMessage,
             banking_stage::{
+                consumer::RetryableIndex,
                 decision_maker::BufferedPacketsDecision,
+                qos_service::QosService,
                 scheduler_messages::{
-                    ConsumeWork, FinishedConsumeWork, MaxAge, NotCommittedReason, TransactionResult,
+                    ConsumeWork, FinishedConsumeWork, FinishedConsumeWorkExtraInfo, MaxAge,
+                    NotCommittedReason, TransactionResult,
                 },
                 tests::create_slow_genesis_config,
                 transaction_scheduler::{
@@ -823,13 +954,19 @@ mod tests {
         crossbeam_channel::unbounded,
         itertools::Itertools,
         jito_protos::proto::bam_types::{
-            TransactionCommittedResult,
-            atomic_txn_batch_result::Result::{Committed, NotCommitted},
+            SchedulingError, TransactionCommittedResult,
+            atomic_txn_batch_result::{
+                self,
+                Result::{Committed, NotCommitted},
+            },
+            not_committed::Reason,
         },
         smallvec::SmallVec,
         solana_compute_budget_interface::ComputeBudgetInstruction,
+        solana_cost_model::cost_tracker::{CostTrackerError, CostTrackerLimits},
         solana_hash::Hash,
         solana_keypair::Keypair,
+        solana_leader_schedule::SlotLeader,
         solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_message::Message,
         solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
@@ -837,13 +974,16 @@ mod tests {
         solana_runtime::{bank::Bank, bank_forks::BankForks},
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_signer::Signer,
-        solana_system_interface::instruction::transfer_many,
+        solana_system_interface::instruction::{transfer, transfer_many},
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
+        solana_transaction_error::TransactionError,
         std::{
             borrow::Borrow,
             sync::{Arc, RwLock},
         },
     };
+
+    type Tx = RuntimeTransaction<SanitizedTransaction>;
 
     struct TestScheduler {
         scheduler: BamScheduler<RuntimeTransaction<SanitizedTransaction>>,
@@ -1143,6 +1283,17 @@ mod tests {
             "Scheduler slot should be set after receiving bank start"
         );
 
+        // A stale Consume decision must not dispatch without an active leader Bank.
+        assert_eq!(
+            scheduler
+                .schedule(&mut container, 0, 0)
+                .unwrap()
+                .num_scheduled,
+            0
+        );
+        assert!(consume_work_receivers[0].try_recv().is_err());
+        set_leader_bank(&mut scheduler.shared_leader_state, Some(decision.bank().unwrap().clone()));
+
         // Schedule the transactions
         let result = scheduler.schedule(&mut container, 0, 0).unwrap();
 
@@ -1152,8 +1303,10 @@ mod tests {
         // Receive the scheduled work
         let work_1 = consume_work_receivers[0].try_recv().unwrap();
         assert_eq!(work_1.ids.len(), 1);
+        assert!(work_1.admission.is_some());
         let work_2 = consume_work_receivers[0].try_recv().unwrap();
         assert_eq!(work_2.ids.len(), 1);
+        assert!(work_2.admission.is_some());
 
         // Check that the first transaction is from keypair_a and first recipient is the first recipient
         assert_eq!(
@@ -1488,5 +1641,480 @@ mod tests {
             !scheduler.prio_graph.is_empty(),
             "bundle sharing a writable account should be inserted and schedulable"
         );
+
+        // A dispatch-time recheck rejects the default blockhash without reserving any cost.
+        set_leader_bank(&mut scheduler.shared_leader_state, Some(bank.clone()));
+        scheduler.extra_checks_enabled = true;
+        assert_eq!(scheduler.send_to_workers(&mut container).unwrap(), 0);
+        assert!(scheduler.prio_graph.is_empty());
+        assert_eq!(container.buffer_size(), 0);
+        assert_eq!(block_cost_and_in_flight(&bank), (0, 0));
+    }
+
+    fn set_block_cost_limit(bank: &Bank, block_cost: u64) {
+        bank.write_cost_tracker()
+            .unwrap()
+            .set_limits(CostTrackerLimits::new(u64::MAX, block_cost, u64::MAX));
+    }
+
+    fn estimated_cost(bank: &Bank) -> u64 {
+        let tx = prioritized_tranfers(&Keypair::new(), vec![Pubkey::new_unique()], 1000, 0);
+        QosService::compute_transaction_costs(
+            &bank.feature_set,
+            std::iter::once(&tx),
+            std::iter::once(Ok(())),
+        )[0]
+        .as_ref()
+        .unwrap()
+        .sum()
+    }
+
+    fn block_cost_and_in_flight(bank: &Bank) -> (u64, usize) {
+        let tracker = bank.read_cost_tracker().unwrap();
+        (tracker.block_cost(), tracker.in_flight_transaction_count())
+    }
+
+    fn settle_committed(bank: &Bank, work: &mut ConsumeWork<Tx>, actual_units: u64) {
+        let costs = QosService::compute_transaction_costs(
+            &bank.feature_set,
+            work.transactions.iter(),
+            std::iter::repeat(Ok(())),
+        );
+        let mut tracker = bank.write_cost_tracker().unwrap();
+        for cost in costs.iter().flatten() {
+            tracker.update_execution_cost(cost, actual_units, 0);
+        }
+        tracker.sub_transactions_in_flight(costs.len());
+        drop(tracker);
+        work.admission = None;
+    }
+
+    fn finish_committed(
+        test: &mut TestScheduler,
+        container: &mut TransactionStateContainer<Tx>,
+        decision: &BufferedPacketsDecision,
+        work: ConsumeWork<Tx>,
+        cus_consumed: u32,
+    ) {
+        let processed_results = vec![
+            TransactionResult::Committed(TransactionCommittedResult {
+                cus_consumed,
+                feepayer_balance_lamports: 0,
+                loaded_accounts_data_size: 0,
+                execution_success: true,
+            });
+            work.transactions.len()
+        ];
+        test.finished_consume_work_sender
+            .send(FinishedConsumeWork {
+                work,
+                retryable_indexes: vec![],
+                extra_info: Some(FinishedConsumeWorkExtraInfo { processed_results }),
+            })
+            .unwrap();
+        test.scheduler
+            .receive_completed(container, decision)
+            .unwrap();
+    }
+
+    fn next_result(
+        response_receiver: &mut tokio::sync::mpsc::Receiver<BamOutboundMessage>,
+    ) -> (u32, atomic_txn_batch_result::Result) {
+        let BamOutboundMessage::AtomicTxnBatchResult(result) = response_receiver
+            .try_recv()
+            .expect("a result should be queued")
+        else {
+            panic!("expected AtomicTxnBatchResult message");
+        };
+        (result.seq_id, result.result.expect("result should be set"))
+    }
+
+    fn admission_scheduler() -> (TestScheduler, Arc<Bank>) {
+        let (bank_forks, _) = test_bank_forks();
+        let mut test = create_test_scheduler(1, &bank_forks);
+        test.scheduler.extra_checks_enabled = false;
+        let bank = Arc::new(Bank::new_from_parent(
+            bank_forks.read().unwrap().working_bank(),
+            SlotLeader::new_unique(),
+            1,
+        ));
+        set_leader_bank(&mut test.scheduler.shared_leader_state, Some(bank.clone()));
+        (test, bank)
+    }
+
+    // ---- scheduler-side cost admission (JSA-72) ----
+
+    /// Two independent batches plus a bank the scheduler can admit on, with `slot` set.
+    fn setup_two_batches(
+        second_batch_size: usize,
+    ) -> (
+        TestScheduler,
+        TransactionStateContainer<Tx>,
+        Arc<Bank>,
+        BufferedPacketsDecision,
+    ) {
+        let (mut test, bank) = admission_scheduler();
+        let mut container = TransactionStateContainer::with_capacity(8);
+        for (seq_id, size) in [1, second_batch_size].into_iter().enumerate() {
+            container.insert_new_batch(
+                (0..size)
+                    .map(|_| {
+                        (
+                            prioritized_tranfers(&Keypair::new(), [Pubkey::new_unique()], 1000, 0),
+                            MaxAge::MAX,
+                        )
+                    })
+                    .collect(),
+                u64::MAX - seq_id as u64,
+                size > 1,
+                u64::MAX,
+                seq_id as u32,
+            );
+        }
+        let decision = BufferedPacketsDecision::Consume(bank.clone());
+        test.scheduler
+            .receive_completed(&mut container, &decision)
+            .unwrap();
+        (test, container, bank, decision)
+    }
+
+    /// Deterministic scheduler-level version of the JSA-72 live PoC.
+    ///
+    /// The PoC pauses the earlier, high-CU transaction after dequeue so a later cheap transfer
+    /// can reserve the Bank budget first. Scheduler-side admission makes that worker timing
+    /// irrelevant: only the high-priority work can be dispatched until its estimate settles.
+    #[test]
+    fn test_jsa72_poc_priority_survives_inverted_worker_timing() {
+        let (mut test, bank) = admission_scheduler();
+
+        // Match the live PoC shapes: the earlier transaction requests 200k CUs, while the later
+        // transaction is a plain transfer. Distinct payers and recipients keep the batches
+        // independent in the priority graph.
+        let poc_transfer = |compute_unit_limit: Option<u32>| {
+            let from = Keypair::new();
+            let mut instructions = compute_unit_limit
+                .map(ComputeBudgetInstruction::set_compute_unit_limit)
+                .into_iter()
+                .collect_vec();
+            instructions.push(transfer(&from.pubkey(), &Pubkey::new_unique(), 1));
+            RuntimeTransaction::from_transaction_for_tests(Transaction::new(
+                &[&from],
+                Message::new(&instructions, Some(&from.pubkey())),
+                Hash::default(),
+            ))
+        };
+        let high_transaction = poc_transfer(Some(200_000));
+        let low_transaction = poc_transfer(None);
+        let transaction_costs = QosService::compute_transaction_costs(
+            &bank.feature_set,
+            [&high_transaction, &low_transaction].into_iter(),
+            std::iter::repeat(Ok(())),
+        );
+        let high_cost = transaction_costs[0].as_ref().unwrap();
+        let low_cost = transaction_costs[1].as_ref().unwrap();
+        let high_estimate = high_cost.sum();
+        let low_estimate = low_cost.sum();
+
+        // As in the PoC, the block limit is exactly the high transaction's reservation. If the
+        // low transaction reserved first, the high transaction would be rejected even though
+        // both fit after the high estimate settles to actual execution cost.
+        set_block_cost_limit(&bank, high_estimate);
+        {
+            let mut tracker = bank.write_cost_tracker().unwrap();
+            tracker.try_add(low_cost).unwrap();
+            assert!(matches!(
+                tracker.try_add(high_cost),
+                Err(CostTrackerError::WouldExceedBlockMaxLimit)
+            ));
+            assert_eq!(tracker.block_cost(), low_estimate);
+            assert!(tracker.block_cost() < tracker.block_cost_limit());
+            tracker.remove(low_cost);
+        }
+        drop(transaction_costs);
+
+        let mut container = TransactionStateContainer::with_capacity(8);
+        for (transaction, priority, seq_id) in [(high_transaction, 2, 0), (low_transaction, 1, 1)] {
+            assert!(
+                container
+                    .insert_new_batch(
+                        std::iter::once((transaction, MaxAge::MAX)).collect(),
+                        priority,
+                        false,
+                        u64::MAX,
+                        seq_id,
+                    )
+                    .is_some()
+            );
+        }
+        let decision = BufferedPacketsDecision::Consume(bank.clone());
+        test.scheduler
+            .receive_completed(&mut container, &decision)
+            .unwrap();
+
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        let mut high_work = test.consume_work_receivers[0].try_recv().unwrap();
+        let high_info = &test.scheduler.inflight_batch_info[&high_work.batch_id];
+        assert_eq!(high_info.batch_priority_ids[0].1, 0);
+        assert!(test.scheduler.pending_admission.is_some());
+        assert_eq!(block_cost_and_in_flight(&bank), (high_estimate, 1));
+        assert!(test.consume_work_receivers[0].try_recv().is_err());
+        assert_eq!(
+            test.scheduler
+                .schedule(&mut container, 0, 0)
+                .unwrap()
+                .num_scheduled,
+            0,
+            "a pending batch must not spin or retry before a completion"
+        );
+
+        // Complete the high transaction below its estimate. This is the event the live PoC
+        // delayed; here it is explicit, so the test has no sleeps or scheduling races.
+        settle_committed(&bank, &mut high_work, 150);
+        let settled_high_cost = bank.read_cost_tracker().unwrap().block_cost();
+        assert!(settled_high_cost + low_estimate <= high_estimate);
+        finish_committed(&mut test, &mut container, &decision, high_work, 150);
+        let (seq_id, result) = next_result(&mut test.response_receiver);
+        assert_eq!(seq_id, 0);
+        assert!(matches!(result, Committed(_)));
+
+        // Only after the earlier reservation settles can the lower-priority work be dispatched.
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        let mut low_work = test.consume_work_receivers[0].try_recv().unwrap();
+        let low_info = &test.scheduler.inflight_batch_info[&low_work.batch_id];
+        assert_eq!(low_info.batch_priority_ids[0].1, 1);
+        assert_eq!(
+            block_cost_and_in_flight(&bank),
+            (settled_high_cost + low_estimate, 1)
+        );
+
+        settle_committed(&bank, &mut low_work, 150);
+        finish_committed(&mut test, &mut container, &decision, low_work, 150);
+        let (seq_id, result) = next_result(&mut test.response_receiver);
+        assert_eq!(seq_id, 1);
+        assert!(matches!(result, Committed(_)));
+        assert_eq!(block_cost_and_in_flight(&bank).1, 0);
+        assert!(test.scheduler.inflight_batch_info.is_empty());
+    }
+
+    #[test_case::test_case(1; "single_transaction")]
+    #[test_case::test_case(2; "partial_batch_rollback")]
+    fn test_deferred_batch_is_final_once_inflight_settles_without_freeing_budget(
+        second_batch_size: usize,
+    ) {
+        let (mut test, mut container, bank, decision) = setup_two_batches(second_batch_size);
+        let estimate = estimated_cost(&bank);
+        set_block_cost_limit(&bank, estimate * second_batch_size as u64 + estimate / 2);
+
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        let mut work_a = test.consume_work_receivers[0].try_recv().unwrap();
+        assert!(test.scheduler.pending_admission.is_some());
+        // B must roll back any earlier admissions in its batch without touching A's reservation.
+        assert_eq!(block_cost_and_in_flight(&bank), (estimate, 1));
+        assert!(test.consume_work_receivers[0].try_recv().is_err());
+
+        // A commits at exactly its estimate: nothing is freed. The worker settled it.
+        bank.write_cost_tracker()
+            .unwrap()
+            .sub_transactions_in_flight(1);
+        work_a.admission = None;
+        finish_committed(
+            &mut test,
+            &mut container,
+            &decision,
+            work_a,
+            estimate as u32,
+        );
+
+        // Nothing inflight can cover the shortfall any more, so B is dispatched with the final
+        // per-transaction error, exactly as the worker would have produced it.
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        assert!(test.scheduler.pending_admission.is_none());
+        let work_b = test.consume_work_receivers[0].try_recv().unwrap();
+        assert_eq!(
+            work_b.admission.as_ref().unwrap().1,
+            std::iter::repeat_n(Ok(()), second_batch_size - 1)
+                .chain([Err(TransactionError::WouldExceedMaxBlockCostLimit)])
+                .collect_vec()
+        );
+        assert_eq!(
+            block_cost_and_in_flight(&bank),
+            (estimate * second_batch_size as u64, second_batch_size - 1)
+        );
+        test.scheduler.recycle_work_object(work_b);
+        assert_eq!(block_cost_and_in_flight(&bank), (estimate, 0));
+    }
+
+    #[test]
+    fn test_deferred_batch_and_its_dependents_are_drained_at_slot_boundary() {
+        let (mut test, bank) = admission_scheduler();
+        let estimate = estimated_cost(&bank);
+        set_block_cost_limit(&bank, estimate + estimate / 2);
+
+        // A and B are independent; C shares B's fee payer and is blocked behind it.
+        let keypair_b = Keypair::new();
+        let mut container = create_container(vec![
+            (
+                &Keypair::new(),
+                vec![Pubkey::new_unique()],
+                1000,
+                0,
+                u64::MAX,
+            ),
+            (&keypair_b, vec![Pubkey::new_unique()], 1000, 1, u64::MAX),
+            (&keypair_b, vec![Pubkey::new_unique()], 1000, 2, u64::MAX),
+        ]);
+        let decision = BufferedPacketsDecision::Consume(bank.clone());
+        test.scheduler
+            .receive_completed(&mut container, &decision)
+            .unwrap();
+
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        test.consume_work_receivers[0].try_recv().unwrap();
+        assert!(test.scheduler.pending_admission.is_some());
+
+        // Slot ends: the deferred batch and the batch it was blocking both go back to BAM.
+        test.scheduler
+            .receive_completed(&mut container, &BufferedPacketsDecision::Forward)
+            .unwrap();
+        assert!(test.scheduler.pending_admission.is_none());
+        assert!(test.scheduler.prio_graph.is_empty());
+        assert!(container.pop().is_none());
+
+        let mut seq_ids = vec![];
+        for _ in 0..2 {
+            let (seq_id, result) = next_result(&mut test.response_receiver);
+            assert!(matches!(
+                result,
+                NotCommitted(not_committed)
+                    if not_committed.reason == Some(Reason::SchedulingError(
+                        SchedulingError::OutsideLeaderSlot as i32
+                    ))
+            ));
+            seq_ids.push(seq_id);
+        }
+        seq_ids.sort_unstable();
+        assert_eq!(seq_ids, vec![1, 2]);
+        assert!(test.response_receiver.try_recv().is_err());
+        // A is still inflight; its result arrives with the worker's response as before.
+        assert_eq!(test.scheduler.inflight_batch_info.len(), 1);
+    }
+
+    #[test]
+    fn test_bank_replacement_within_slot_restarts_admission_on_new_bank() {
+        let (mut test, mut container, bank_1, _) = setup_two_batches(1);
+        let estimate = estimated_cost(&bank_1);
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        let work_a = test.consume_work_receivers[0].try_recv().unwrap();
+        let work_b = test.consume_work_receivers[0].try_recv().unwrap();
+        assert_eq!(block_cost_and_in_flight(&bank_1), (estimate * 2, 2));
+
+        // The bankless handover clears the graph. Work arriving in the gap must remain queued.
+        test.scheduler
+            .receive_completed(&mut container, &BufferedPacketsDecision::Forward)
+            .unwrap();
+        assert_eq!(test.scheduler.slot, None);
+        let transaction = prioritized_tranfers(&Keypair::new(), [Pubkey::new_unique()], 1000, 0);
+        assert!(
+            container
+                .insert_new_batch(
+                    std::iter::once((transaction, MaxAge::MAX)).collect(),
+                    u64::MAX,
+                    false,
+                    u64::MAX,
+                    2,
+                )
+                .is_some()
+        );
+
+        // ParentReady installs a replacement for the same slot. Do not adopt it or dispatch C
+        // until both old-bank batches have returned.
+        let bank_1b = Arc::new(Bank::new_from_parent(
+            bank_1.parent().unwrap(),
+            SlotLeader::new_unique(),
+            bank_1.slot(),
+        ));
+        assert_ne!(bank_1b.bank_id(), bank_1.bank_id());
+        set_leader_bank(&mut test.scheduler.shared_leader_state, Some(bank_1b.clone()));
+        let decision = BufferedPacketsDecision::Consume(bank_1b.clone());
+        // Old work returned with its admission attached must drain before C can dispatch.
+        for (work, remaining) in [(work_a, 1), (work_b, 0)] {
+            test.scheduler
+                .receive_completed(&mut container, &decision)
+                .unwrap();
+            test.scheduler.schedule(&mut container, 0, 0).unwrap();
+            assert!(test.consume_work_receivers[0].try_recv().is_err());
+            assert_eq!(test.scheduler.slot, None);
+            finish_committed(&mut test, &mut container, &decision, work, 150);
+            assert_eq!(
+                block_cost_and_in_flight(&bank_1),
+                (estimate * remaining as u64, remaining)
+            );
+        }
+
+        // With both old-bank batches drained, adopt the new bank and admit C.
+        test.scheduler
+            .receive_completed(&mut container, &decision)
+            .unwrap();
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        let work_c = test.consume_work_receivers[0].try_recv().unwrap();
+        let admission = work_c.admission.as_ref().unwrap();
+        assert_eq!(admission.0.bank_id(), bank_1b.bank_id());
+        assert_eq!(test.scheduler.inflight_reserved_cost, estimate);
+        assert_eq!(block_cost_and_in_flight(&bank_1b), (estimate, 1));
+    }
+
+    #[test_case::test_case(false; "returned_work")]
+    #[test_case::test_case(true; "disconnected_worker")]
+    fn test_unprocessed_work_releases_reservation_on_its_bank(disconnected: bool) {
+        let (mut test, mut container, bank, decision) = setup_two_batches(1);
+        let estimate = estimated_cost(&bank);
+        set_block_cost_limit(&bank, estimate);
+
+        if disconnected {
+            drop(test.consume_work_receivers);
+            assert!(matches!(
+                test.scheduler.schedule(&mut container, 0, 0),
+                Err(super::SchedulerError::DisconnectedSendChannel(_))
+            ));
+            assert_eq!(block_cost_and_in_flight(&bank), (0, 0));
+            assert_eq!(test.scheduler.inflight_reserved_cost, 0);
+            assert!(!test.scheduler.has_in_flight_transactions());
+            return;
+        }
+
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        let work_a = test.consume_work_receivers[0].try_recv().unwrap();
+        assert_eq!(block_cost_and_in_flight(&bank), (estimate, 1));
+
+        // The worker found the bank complete and returned A untouched, admission attached.
+        test.finished_consume_work_sender
+            .send(FinishedConsumeWork {
+                work: work_a,
+                retryable_indexes: vec![RetryableIndex::new(0, true)],
+                extra_info: Some(FinishedConsumeWorkExtraInfo {
+                    processed_results: vec![TransactionResult::NotCommitted(
+                        NotCommittedReason::PohTimeout,
+                    )],
+                }),
+            })
+            .unwrap();
+        test.scheduler
+            .receive_completed(&mut container, &decision)
+            .unwrap();
+        assert_eq!(block_cost_and_in_flight(&bank), (0, 0));
+        assert_eq!(test.scheduler.inflight_reserved_cost, 0);
+        // The released admission must not keep the bank alive from the reuse pool.
+        assert!(
+            test.scheduler
+                .reusable_consume_work
+                .iter()
+                .all(|work| work.admission.is_none())
+        );
+        assert!(matches!(
+            next_result(&mut test.response_receiver),
+            (0, NotCommitted(not_committed))
+                if not_committed.reason
+                    == Some(Reason::SchedulingError(SchedulingError::PohTimeout as i32))
+        ));
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/bam_scheduler.rs
@@ -33,16 +33,12 @@ use {
     solana_nohash_hasher::IntMap,
     solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::Pubkey,
-    solana_runtime::bank_forks::BankForks,
+    solana_runtime::bank::Bank,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction_error::TransactionError,
-    std::{
-        borrow::Borrow,
-        sync::{Arc, RwLock},
-        time::Instant,
-    },
+    std::{borrow::Borrow, time::Instant},
     tokio::sync::mpsc::Sender as TokioSender,
 };
 
@@ -63,14 +59,6 @@ fn passthrough_priority(
 
 pub const MAX_PACKETS_PER_BUNDLE: usize = 5; // copied from BundleStorage::MAX_PACKETS_PER_BUNDLE
 
-// Sized from 30 days of mainnet data ending 2026-08-18. Atomic-only ClickHouse counts of distinct
-// `(source, seq_id)` batches per validator-slot had p99=149, p99.9=236, 99.94% <=256, and max=540.
-// The full-slot count conservatively upper-bounds the pre-ParentReady subset stored here.
-// Mainnet-validator Influx `bam_connection-metrics.bundle_received` active 25 ms samples, which
-// also include non-atomic batches, had p99=183, p99.9=272, 99.86% <=256, and max=881. Thus 256
-// keeps the atomic p99.9 inline in 4 KiB while rarer bursts spill safely.
-const DEFERRED_ATOMIC_BATCHES_INLINE_CAPACITY: usize = 256;
-
 pub struct BamScheduler<Tx: TransactionWithMeta> {
     consume_work_sender: Sender<ConsumeWork<Tx>>,
     finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
@@ -89,11 +77,8 @@ pub struct BamScheduler<Tx: TransactionWithMeta> {
 
     // Reusable objects to avoid allocations
     reusable_consume_work: Vec<ConsumeWork<Tx>>,
-    deferred_atomic_batches:
-        SmallVec<[TransactionPriorityId; DEFERRED_ATOMIC_BATCHES_INLINE_CAPACITY]>,
 
     extra_checks_enabled: bool,
-    bank_forks: Arc<RwLock<BankForks>>,
     shared_leader_state: SharedLeaderState,
 }
 
@@ -112,7 +97,6 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
         consume_work_sender: Sender<ConsumeWork<Tx>>,
         finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
         response_sender: TokioSender<BamOutboundMessage>,
-        bank_forks: Arc<RwLock<BankForks>>,
         shared_leader_state: SharedLeaderState,
     ) -> Self {
         Self {
@@ -129,9 +113,7 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
             last_schedule_time: Instant::now(),
             slot: None,
             reusable_consume_work: Vec::new(),
-            deferred_atomic_batches: SmallVec::new(),
             extra_checks_enabled: true,
-            bank_forks,
             shared_leader_state,
         }
     }
@@ -151,29 +133,21 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
     }
 
     /// Insert all incoming transactions into the `PrioGraph`.
-    fn pull_into_prio_graph<S: StateContainer<Tx>>(&mut self, container: &mut S) {
-        let Some(slot) = self.slot else {
-            warn!("Slot is not set, cannot pull transactions into prio-graph");
-            return;
-        };
-
-        let working_bank = self.bank_forks.read().unwrap().working_bank();
-        let atomic_batches_enabled = self.shared_leader_state.load().atomic_batches_enabled();
-        self.deferred_atomic_batches.clear();
+    fn pull_into_prio_graph<S: StateContainer<Tx>>(
+        &mut self,
+        container: &mut S,
+        working_bank: &Bank,
+    ) {
+        let slot = working_bank.slot();
 
         while let Some(next_batch_id) = container.pop() {
-            let Some((batch_ids, revert_on_error, max_schedule_slot, seq_id)) =
+            let Some((batch_ids, _, max_schedule_slot, seq_id)) =
                 container.get_batch(next_batch_id.id)
             else {
                 error!("Batch {} not found in container", next_batch_id.id);
                 container.remove_by_id(next_batch_id.id);
                 continue;
             };
-
-            if revert_on_error && !atomic_batches_enabled {
-                self.deferred_atomic_batches.push(next_batch_id);
-                continue;
-            }
 
             if max_schedule_slot < slot {
                 // If the slot has changed, we cannot schedule this batch
@@ -226,24 +200,17 @@ impl<Tx: TransactionWithMeta> BamScheduler<Tx> {
                 Self::get_transactions_account_access(txns.into_iter()),
             );
         }
-
-        // Atomic batches must wait until ParentReady confirms or replaces the provisional bank.
-        // Non-atomic batches can still be rescheduled after sad handover.
-        container.push_ids_into_queue(self.deferred_atomic_batches.drain(..));
     }
 
     fn send_to_workers(
         &mut self,
         container: &mut impl StateContainer<Tx>,
         num_scheduled: &mut usize,
+        working_bank: &Bank,
     ) {
-        let Some(slot) = self.slot else {
-            warn!("Slot is not set, cannot schedule transactions");
-            return;
-        };
+        let slot = working_bank.slot();
 
         let now = Instant::now();
-        let working_bank = self.bank_forks.read().unwrap().working_bank();
         while let Some(id) = self.prio_graph.pop() {
             let (batch_ids, revert_on_error, max_schedule_slot, seq_id) =
                 container.get_batch(id.id).unwrap();
@@ -729,8 +696,16 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for BamScheduler<Tx> {
 
         let mut num_scheduled = 0;
 
-        self.pull_into_prio_graph(container);
-        self.send_to_workers(container, &mut num_scheduled);
+        // Pin both validation passes to the same resolved bank, even if BankForks advances.
+        let leader_state = self.shared_leader_state.load();
+        if leader_state.atomic_batches_enabled()
+            && let Some(bank) = leader_state.working_bank()
+            && !bank.is_complete()
+            && Some(bank.slot()) == self.slot
+        {
+            self.pull_into_prio_graph(container, bank);
+            self.send_to_workers(container, &mut num_scheduled, bank);
+        }
 
         // TODO(seg): Double check the zeros here
         Ok(SchedulingSummary {
@@ -838,6 +813,7 @@ mod tests {
                 },
                 tests::create_slow_genesis_config,
                 transaction_scheduler::{
+                    bam_receive_and_buffer::tests::set_leader_bank,
                     bam_scheduler::{BamScheduler, MAX_PACKETS_PER_BUNDLE},
                     scheduler::Scheduler,
                     transaction_state_container::{StateContainer, TransactionStateContainer},
@@ -886,12 +862,16 @@ mod tests {
         let (consume_work_sender, consume_work_receiver) = unbounded();
         let (finished_consume_work_sender, finished_consume_work_receiver) = unbounded();
         let (response_sender, response_receiver) = tokio::sync::mpsc::channel(100);
+        let mut shared_leader_state = SharedLeaderState::new(0, None, None);
+        set_leader_bank(
+            &mut shared_leader_state,
+            Some(bank_forks.read().unwrap().working_bank()),
+        );
         let scheduler = BamScheduler::new(
             consume_work_sender,
             finished_consume_work_receiver,
             response_sender,
-            bank_forks.clone(),
-            SharedLeaderState::new(0, None, None),
+            shared_leader_state,
         );
         TestScheduler {
             scheduler,
@@ -978,6 +958,140 @@ mod tests {
         let mut container = TransactionStateContainer::with_capacity(100);
         let result = scheduler.schedule(&mut container, 0, 0).unwrap();
         assert_eq!(result.num_scheduled, 0);
+    }
+
+    #[test]
+    fn test_unresolved_bank_behavior() {
+        let (bank_forks, _) = test_bank_forks();
+        let bank = bank_forks.read().unwrap().working_bank();
+        let mut shared_leader_state = SharedLeaderState::new(0, None, None);
+        shared_leader_state.store(Arc::new(LeaderState::new_with_atomic_batches_enabled(
+            Some(bank.clone()),
+            0,
+            None,
+            None,
+            false,
+        )));
+        let mut test = create_test_scheduler(1, &bank_forks);
+        test.scheduler.shared_leader_state = shared_leader_state.clone();
+        test.scheduler.extra_checks_enabled = false;
+        let mut container = TransactionStateContainer::with_capacity(10 * 1024);
+        for (fifo_index, (revert_on_error, seq_id)) in
+            [(true, 71), (false, 72)].into_iter().enumerate()
+        {
+            let transaction = prioritized_tranfers(
+                &Keypair::new(),
+                [Pubkey::new_unique()],
+                1_000,
+                u64::from(seq_id),
+            );
+            container
+                .insert_new_batch(
+                    smallvec::smallvec![(transaction, MaxAge::MAX)],
+                    u64::MAX - fifo_index as u64,
+                    revert_on_error,
+                    bank.slot(),
+                    seq_id,
+                )
+                .unwrap();
+        }
+        test.scheduler
+            .receive_completed(
+                &mut container,
+                &BufferedPacketsDecision::Consume(bank.clone()),
+            )
+            .unwrap();
+
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        assert_eq!(container.queue_size(), 2);
+        assert!(test.consume_work_receivers[0].try_recv().is_err());
+        assert!(test.response_receiver.try_recv().is_err());
+
+        // A stale Consume decision must not dispatch through the no-bank replacement gap.
+        shared_leader_state.set_bank_replacement();
+        assert_eq!(
+            test.scheduler
+                .schedule(&mut container, 0, 0)
+                .unwrap()
+                .num_scheduled,
+            0
+        );
+        assert_eq!(container.queue_size(), 2);
+
+        // A held controller iteration preserves work through resolution.
+        set_leader_bank(&mut shared_leader_state, Some(bank.clone()));
+        test.scheduler
+            .receive_completed(&mut container, &BufferedPacketsDecision::Hold)
+            .unwrap();
+        assert_eq!(test.scheduler.slot, Some(bank.slot()));
+        assert_eq!(container.queue_size(), 2);
+
+        test.scheduler.schedule(&mut container, 0, 0).unwrap();
+        assert_eq!(container.queue_size(), 0);
+        let atomic_work = test.consume_work_receivers[0].try_recv().unwrap();
+        let non_atomic_work = test.consume_work_receivers[0].try_recv().unwrap();
+        assert!(atomic_work.revert_on_error);
+        assert!(!non_atomic_work.revert_on_error);
+        assert!(test.consume_work_receivers[0].try_recv().is_err());
+        assert!(test.response_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_scheduler_validates_selected_leader_bank() {
+        let (bank_forks, mint) = test_bank_forks();
+        let bank = Arc::new(Bank::new_from_parent(
+            bank_forks.read().unwrap().working_bank(),
+            solana_leader_schedule::SlotLeader::new_unique(),
+            1,
+        ));
+        bank.register_unique_recent_blockhash_for_test();
+        let mut test = create_test_scheduler(1, &bank_forks);
+        set_leader_bank(&mut test.scheduler.shared_leader_state, Some(bank.clone()));
+        let transaction = solana_system_transaction::transfer(
+            &mint,
+            &Pubkey::new_unique(),
+            1,
+            bank.last_blockhash(),
+        );
+        let mut container = TransactionStateContainer::with_capacity(10);
+        container
+            .insert_new_batch(
+                smallvec::smallvec![(
+                    RuntimeTransaction::from_transaction_for_tests(transaction),
+                    MaxAge::MAX
+                )],
+                u64::MAX,
+                false,
+                bank.slot(),
+                1,
+            )
+            .unwrap();
+        test.scheduler
+            .receive_completed(
+                &mut container,
+                &BufferedPacketsDecision::Consume(bank.clone()),
+            )
+            .unwrap();
+        // BankForks still exposes a different bank which cannot validate this blockhash.
+        assert_ne!(
+            bank.bank_id(),
+            bank_forks.read().unwrap().working_bank().bank_id()
+        );
+        assert_eq!(
+            test.scheduler
+                .schedule(&mut container, 0, 0)
+                .unwrap()
+                .num_scheduled,
+            1
+        );
+        assert_eq!(
+            test.consume_work_receivers[0]
+                .try_recv()
+                .unwrap()
+                .target_slot,
+            bank.slot()
+        );
+        assert!(test.response_receiver.try_recv().is_err());
     }
 
     #[test]
@@ -1292,14 +1406,13 @@ mod tests {
             (&keypair_a, vec![Pubkey::new_unique()], 1000, 0, u64::MAX),
             (&keypair_b, vec![Pubkey::new_unique()], 2000, 1, u64::MAX),
         ]);
-        scheduler.pull_into_prio_graph(&mut container);
+        scheduler.pull_into_prio_graph(&mut container, &bank);
         assert!(
             !scheduler.prio_graph.is_empty(),
             "Prio graph should have transactions"
         );
 
-        let leader_state = LeaderState::new(Some(bank), 0, None, None);
-        scheduler.shared_leader_state.store(Arc::new(leader_state));
+        set_leader_bank(&mut scheduler.shared_leader_state, Some(bank));
         scheduler.shared_leader_state.set_bank_replacement();
         scheduler
             .receive_completed(&mut container, &BufferedPacketsDecision::Hold)
@@ -1369,7 +1482,7 @@ mod tests {
         container.insert_new_batch(txns_max_age, priority, false, u64::MAX, 0);
 
         // Must not panic; the bundle becomes a single schedulable node.
-        scheduler.pull_into_prio_graph(&mut container);
+        scheduler.pull_into_prio_graph(&mut container, &bank);
 
         assert!(
             !scheduler.prio_graph.is_empty(),

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -218,6 +218,7 @@ impl<Tx> SchedulingCommon<Tx> {
             revert_on_error: false,
             respond_with_extra_info: false,
             max_schedule_slot: None,
+            admission: None,
         };
         self.consume_work_senders[thread_index]
             .send(work)
@@ -254,6 +255,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                         revert_on_error: _,
                         respond_with_extra_info: _,
                         max_schedule_slot: _,
+                        admission: _,
                     },
                 retryable_indexes,
                 extra_info: _,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -1506,6 +1506,7 @@ mod tests {
             finished_work_receiver,
             response_sender,
             shared_leader_state.clone(),
+            None,
         );
 
         let mut controller = SchedulerController::new(

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -1504,7 +1504,6 @@ mod tests {
             consume_work_sender,
             finished_work_receiver,
             response_sender,
-            bank_forks.clone(),
             shared_leader_state.clone(),
         );
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -1109,6 +1109,7 @@ mod tests {
                     revert_on_error: false,
                     respond_with_extra_info: false,
                     max_schedule_slot: None,
+                    admission: None,
                 },
                 retryable_indexes: vec![],
                 extra_info: None,

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -2054,6 +2054,7 @@ mod tests {
             finished_work_receiver,
             response_sender,
             shared_leader_state.clone(),
+            None,
         );
         let optimistic_decision = BufferedPacketsDecision::Consume(optimistic_bank);
         bam_scheduler

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -2004,7 +2004,7 @@ mod tests {
         );
         let optimistic_leader_state = shared_leader_state.load();
 
-        // Both atomic transactions are valid on the optimistic fork: they reference its
+        // Both batch types are valid on the optimistic fork: they reference its
         // unique recent blockhash, which the replacement fork does not know. (Account state
         // cannot distinguish the forks in the same-parent-slot variant because same-slot
         // banks share accounts-db storage.) The scheduler must hold them until ParentReady
@@ -2034,7 +2034,7 @@ mod tests {
         container
             .insert_new_batch(
                 [(
-                    runtime_transfer(&ordinary_payer, Pubkey::new_unique(), recent_blockhash),
+                    runtime_transfer(&ordinary_payer, Pubkey::new_unique(), optimistic_blockhash),
                     MaxAge::MAX,
                 )]
                 .into_iter()
@@ -2048,12 +2048,11 @@ mod tests {
 
         let (consume_work_sender, consume_work_receiver) = unbounded();
         let (finished_work_sender, finished_work_receiver) = unbounded();
-        let (response_sender, mut response_receiver) = tokio::sync::mpsc::channel(1);
+        let (response_sender, mut response_receiver) = tokio::sync::mpsc::channel(2);
         let mut bam_scheduler = BamScheduler::new(
             consume_work_sender,
             finished_work_receiver,
             response_sender,
-            ctx.bank_forks.clone(),
             shared_leader_state.clone(),
         );
         let optimistic_decision = BufferedPacketsDecision::Consume(optimistic_bank);
@@ -2061,8 +2060,8 @@ mod tests {
             .receive_completed(&mut container, &optimistic_decision)
             .unwrap();
         bam_scheduler.schedule(&mut container, 0, u64::MAX).unwrap();
-        assert_eq!(container.queue_size(), 1);
-        assert!(!consume_work_receiver.try_recv().unwrap().revert_on_error);
+        assert_eq!(container.queue_size(), 2);
+        assert!(consume_work_receiver.try_recv().is_err());
         assert!(response_receiver.try_recv().is_err());
 
         let accumulated_tx = versioned_transfer(1);
@@ -2144,7 +2143,7 @@ mod tests {
                 .atomic_batches_enabled()
         );
 
-        // Reject the provisional batch on the replacement fork, then verify a valid control
+        // Reject both provisional batches on the replacement fork, then verify a valid control
         // transaction commits through the real consume worker.
         let (replay_vote_sender, _replay_vote_receiver) = bounded(1);
         let worker_exit = Arc::new(AtomicBool::default());
@@ -2170,7 +2169,7 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        for (seq_id, batch) in [(71, None), (73, Some(control))] {
+        for (seq_id, batch) in [(71, None), (72, None), (73, Some(control))] {
             if let Some(batch) = batch {
                 container
                     .insert_new_batch(batch, u64::MAX, true, leader_slot, seq_id)
@@ -2208,7 +2207,7 @@ mod tests {
                 panic!("expected atomic transaction batch result");
             };
             assert_eq!(result.seq_id, seq_id);
-            if seq_id == 71 {
+            if seq_id != 73 {
                 assert!(matches!(result.result, Some(NotCommitted(_))));
                 assert_eq!(
                     new_bank.entry_bytes_budget().consumed(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -79,7 +79,7 @@ use {
         num::NonZeroUsize,
         path::PathBuf,
         sync::{
-            Arc, Mutex, RwLock,
+            Arc, RwLock,
             atomic::{AtomicBool, AtomicU8},
         },
         thread::{self, JoinHandle},
@@ -454,7 +454,6 @@ impl Tpu {
             bundle_account_locker.clone(),
             Some(TipProcessingDependencies {
                 tip_manager: tip_manager.clone(),
-                tip_programs_lock: Arc::new(Mutex::new(())),
                 block_builder_fee_info: block_builder_fee_info.clone(),
                 cluster_info: cluster_info.clone(),
                 bundle_account_locker: bundle_account_locker.clone(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -454,9 +454,8 @@ impl Tpu {
             bundle_account_locker.clone(),
             Some(TipProcessingDependencies {
                 tip_manager: tip_manager.clone(),
-                last_tip_updated_bank: Arc::new(Mutex::new(None)),
+                tip_programs_lock: Arc::new(Mutex::new(())),
                 block_builder_fee_info: block_builder_fee_info.clone(),
-                bam_enabled: bam_enabled.clone(),
                 cluster_info: cluster_info.clone(),
                 bundle_account_locker: bundle_account_locker.clone(),
             }),


### PR DESCRIPTION
MEV-12649 / JSA-72: independent BAM batches share eight workers, so a later batch could reserve the remaining block budget before an earlier batch. Near the block limit, this rejected earlier work even when both batches would fit after cost settlement.

Reserve costs on the selected resolved Bank in BAM priority-pop order. Defer a block-limit failure when earlier unsettled estimates could cover the shortfall, then retry the deferred head before later work. Workers consume admission on its exact Bank; returned or unsent work releases its reservation exactly once. Allocate admission results before locking the cost tracker.

On same-slot Bank replacement, workers return stale reservations to the scheduler. The scheduler releases them on the owning Bank, drains outstanding work, and retries returned batches in original dispatch order using stable batch IDs.

Prepare required tip programs before the first BAM cost admission on each concrete Bank, retaining queued work on preparation failure. Reconcile replacement Banks before the idle shortcut; deferred admissions remain eligible for retry even when the priority graph is empty. Preparation is cached per Bank; refreshing builder metadata after preparation on the same Bank remains outside this change.

Tip maintenance runs only on the scheduler. Remove the unused worker fallback, its alternate constructor and dependency plumbing, and the tip-only mutex. Tip tests own their preparation dependencies directly; account locking and reservation handling are preserved.

Includes the bank-resolution work merged in #1617, including deferred fork checks when a provisional Bank has not yet been published in shared leader state.

Validation after worker tip cleanup: 263 banking-stage and block-creation-loop tests passed, including unpublished/resolved-Bank validation, JSA-72 priority inversion, deferred-head retries, reservation refunds, tip preparation/recovery, and repeated bank replacement. Pinned-nightly Clippy (`--lib --tests -- -D warnings`) and workspace formatting passed. The quiet-host performance comparison remains open.