### PR TITLE
ci: Attach duplicate-shreds CPU clamp via scripts

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -85,7 +85,9 @@ slow-timeout = { period = "60s", terminate-after = 3 }
 filter = 'package(solana-local-cluster) & test(/^test_duplicate_shreds_broadcast_leader$/)'
 slow-timeout = { period = "60s", terminate-after = 10 }
 
-[[profile.ci.overrides]]
+# Wrapper scripts attach via `[[profile.<name>.scripts]]`, not `overrides`
+# (nextest ignores `overrides.*.run-wrapper` with a warning).
+[[profile.ci.scripts]]
 filter = 'package(solana-local-cluster) & test(/^test_duplicate_shreds_broadcast_leader$/)'
 platform = 'cfg(target_os = "linux")'
 run-wrapper = "clamp-cpus"


### PR DESCRIPTION
nextest ignores `run-wrapper` under `[[profile.ci.overrides]]`
("ignoring unknown configuration key"), so the `taskset -c 0-15`
clamp from #1611 never ran and `test_duplicate_shreds_broadcast_leader`
kept failing local-cluster-2 on 128-thread agents (every master build
since #1611).

- Move the clamp to `[[profile.ci.scripts]]`, where wrapper scripts
  are attached