### PR TITLE
build: apply DCOU exclusions to production binaries

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -187,6 +187,8 @@ dcouExcludeArgs=()
 for pkg in "${DCOU_TAINTED_PACKAGES[@]}"; do
   dcouExcludeArgs+=(--exclude "${pkg}")
 done
+# Keep the checked and compiled production feature graphs identical.
+productionBuildArgs=("${binArgs[@]}" --workspace "${dcouExcludeArgs[@]}")
 
 cargo_build() {
   # shellcheck disable=SC2086 # Don't want to double quote $maybeRustVersion
@@ -215,7 +217,7 @@ check_dcou() {
   # output after turning rustc into the nightly mode with RUSTC_BOOTSTRAP=1.
   # In this way, additional requirement of nightly rustc toolchian is avoided.
   # Note that `cargo tree` can't be used, because it doesn't support `--bin`.
-  if check_dcou "${binArgs[@]}" --workspace "${dcouExcludeArgs[@]}"; then
+  if check_dcou "${productionBuildArgs[@]}"; then
      echo 'dcou feature activation is incorrectly activated!'
      exit 1
   fi
@@ -237,7 +239,7 @@ check_dcou() {
 
   # Build our production binaries without dcou.
   if [[ ${#binArgs[@]} -gt 0 ]]; then
-    cargo_build "${binArgs[@]}" --workspace
+    cargo_build "${productionBuildArgs[@]}"
   fi
 
   # Finally, build the remaining dev tools with dcou.


### PR DESCRIPTION
#### Problem
`dcouExcludeArgs` is not passed to `cargo_build`, this results in the validator binary accidentally being tainted with the DCOU feature.

We observed this as jito adds `bam-local-cluster` which enables DCOU and then got propagated to `agave-votor-messages`

#### Summary of Changes
Apply `dcouExcludeArgs` to cargo build as well 
