### PR TITLE
ci: publish release artifacts for -jito.N hotfix tags

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - "v*-jito"
+      - "v*-jito.[0-9]*"  # hotfix re-cuts, e.g. v4.2.2-jito.1
   # Self-test: PR runs build but never touch a release.
   pull_request:
     paths:


### PR DESCRIPTION
problem:

The release-artifacts workflow triggers on the tag glob `v*-jito`, which does not match `-jito.1` , which we want to cut during patch releases.

fix: match `*jito.[0-9]*`