### PR TITLE
build(workspace): Isolate bam-local-cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,43 +1279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bam-local-cluster"
-version = "4.4.0-alpha.2"
-dependencies = [
- "agave-feature-set",
- "agave-logger",
- "anyhow",
- "clap 2.33.3",
- "log",
- "serde",
- "serde_json",
- "solana-account 4.6.0",
- "solana-cluster-type",
- "solana-commitment-config",
- "solana-faucet",
- "solana-feature-gate-interface",
- "solana-fee-calculator",
- "solana-genesis-config",
- "solana-genesis-utils",
- "solana-keypair",
- "solana-ledger",
- "solana-local-cluster",
- "solana-native-token",
- "solana-program-binaries",
- "solana-pubkey 4.3.0",
- "solana-rent",
- "solana-rpc",
- "solana-rpc-client",
- "solana-runtime",
- "solana-shred-version",
- "solana-signer",
- "solana-system-interface 3.3.0",
- "solana-vote-program",
- "tokio",
- "toml 0.9.12+spec-1.1.0",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5598,7 +5561,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml 0.5.8",
+ "toml",
 ]
 
 [[package]]
@@ -6753,15 +6716,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -12880,34 +12834,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "toml_edit"
@@ -12916,24 +12846,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 0.6.5",
- "winnow 0.5.16",
+ "toml_datetime",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.3+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
-dependencies = [
- "winnow 1.0.4",
-]
-
-[[package]]
-name = "toml_writer"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -13879,18 +13794,6 @@ checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
     "accounts-db",
     "accounts-db/store-histogram",
     "bam-banking-bench",
-    "bam-local-cluster",
     "banking-stage-ingress-types",
     "banks-client",
     "banks-interface",

--- a/bam-local-cluster/Cargo.toml
+++ b/bam-local-cluster/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+workspace = "../dev-bins"
 
 [features]
 agave-unstable-api = []

--- a/bam-local-cluster/README.md
+++ b/bam-local-cluster/README.md
@@ -18,20 +18,28 @@ The tool automatically handles:
 
 ## Quick Start
 
+The cluster tool belongs to the `dev-bins` workspace so its development
+features do not propagate into production validator builds. Run these
+commands from the repository root.
+
 1. **Build the binaries**:
+
    ```bash
    # Build agave-validator
-   cargo build --release --bin agave-validator
-   
-   # Build bam-local-cluster
-   cargo build --release --bin bam-local-cluster
+   cargo build --release -p agave-validator
+
+   # Build the development tools separately
+   cargo build --release --manifest-path dev-bins/Cargo.toml \
+     --bin bam-local-cluster --bin agave-ledger-tool
    ```
 
 2. **Create a configuration file** (see `examples/example_config.toml`)
 
 3. **Run the cluster**:
+
    ```bash
-   RUST_LOG=info ./target/release/bam-local-cluster --config bam-local-cluster/examples/example_config.toml
+   RUST_LOG=info ./dev-bins/target/release/bam-local-cluster \
+     --config bam-local-cluster/examples/example_config.toml
    ```
 
 ## Configuration
@@ -48,7 +56,8 @@ Key configuration options:
 - `enable_tx_v1`: Optional transaction v1 genesis feature activation for BAM conformance tests
 - `ledger_base_directory`: Base directory for validator ledgers
 - `validator_build_path`: Build output directory (e.g., "target/debug" or "target/release") - required
-- `ledger_tool_build_path`: Builder output for ledger tool (e.g., "target/debug" or "target/release") - required
+- `ledger_tool_build_path`: Ledger tool output directory, such as
+  "dev-bins/target/debug" or "dev-bins/target/release" - required
 - `bind_address`: Optional validator listen address override passed through as `--bind-address`
 - `gossip_host`: Optional validator gossip advertisement override passed through as `--gossip-host`
 - `validators`: Array of validator configurations (first is bootstrap node)
@@ -93,7 +102,8 @@ still fall back to advertising `127.0.0.1`, which is not reachable by remote pee
 Common issues:
 
 - **Port conflicts**: Bootstrap node uses gossip port 8001 and RPC port 8899
-- **Binary not found**: Ensure `agave-validator` and `agave-ledger-tool` are built in your target directory
+- **Binary not found**: Check `validator_build_path` and
+  `ledger_tool_build_path` against the separate build output directories
 - **Permission errors**: Make sure the ledger base directory is writable
 
 Validator output is streamed to the console for debugging.
@@ -108,4 +118,4 @@ To modify the cluster behavior:
 
 ## License
 
-This project is part of the Jito Solana JDS repository and follows the same license terms. 
+This project is part of the Jito Solana JDS repository and follows the same license terms.

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -1011,6 +1011,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "bam-local-cluster"
+version = "4.4.0-alpha.2"
+dependencies = [
+ "agave-feature-set",
+ "agave-logger",
+ "anyhow",
+ "clap 2.34.0",
+ "log",
+ "serde",
+ "serde_json",
+ "solana-account 4.6.0",
+ "solana-cluster-type",
+ "solana-commitment-config",
+ "solana-faucet",
+ "solana-feature-gate-interface",
+ "solana-fee-calculator",
+ "solana-genesis-config",
+ "solana-genesis-utils",
+ "solana-keypair",
+ "solana-ledger",
+ "solana-local-cluster",
+ "solana-native-token",
+ "solana-program-binaries",
+ "solana-pubkey 4.3.0",
+ "solana-rent",
+ "solana-rpc",
+ "solana-rpc-client",
+ "solana-runtime",
+ "solana-shred-version",
+ "solana-signer",
+ "solana-system-interface 3.3.0",
+ "solana-vote-program",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4429,7 +4466,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -5369,6 +5406,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -7203,6 +7249,80 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
  "solana-system-interface 2.0.0",
+]
+
+[[package]]
+name = "solana-local-cluster"
+version = "4.4.0-alpha.2"
+dependencies = [
+ "agave-feature-set",
+ "agave-logger",
+ "agave-snapshots",
+ "agave-votor",
+ "agave-votor-messages",
+ "agave-votor-transport",
+ "arc-swap",
+ "crossbeam-channel",
+ "itertools 0.15.0",
+ "log",
+ "rand 0.9.4",
+ "rayon",
+ "solana-account 4.6.0",
+ "solana-accounts-db",
+ "solana-bls-signatures",
+ "solana-client-traits",
+ "solana-clock",
+ "solana-cluster-type",
+ "solana-commitment-config",
+ "solana-core",
+ "solana-entry",
+ "solana-epoch-schedule",
+ "solana-feature-gate-interface",
+ "solana-fee-structure",
+ "solana-genesis-config",
+ "solana-gossip",
+ "solana-hard-forks",
+ "solana-hash 4.6.0",
+ "solana-keypair",
+ "solana-leader-schedule",
+ "solana-ledger",
+ "solana-message",
+ "solana-native-token",
+ "solana-net-utils",
+ "solana-packet 4.3.0",
+ "solana-perf",
+ "solana-poh-config",
+ "solana-program-binaries",
+ "solana-pubkey 4.3.0",
+ "solana-pubsub-client",
+ "solana-rent",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-runtime",
+ "solana-sdk-ids",
+ "solana-shred-version",
+ "solana-signer",
+ "solana-slot-hashes",
+ "solana-stake-interface",
+ "solana-streamer",
+ "solana-system-interface 3.3.0",
+ "solana-system-transaction",
+ "solana-time-utils",
+ "solana-tpu-client",
+ "solana-tpu-client-next",
+ "solana-transaction",
+ "solana-transaction-error",
+ "solana-turbine",
+ "solana-validator-exit",
+ "solana-vote",
+ "solana-vote-interface",
+ "solana-vote-program",
+ "static_assertions",
+ "strum",
+ "tempfile",
+ "tokio",
+ "tokio-util 0.7.19",
+ "wincode",
 ]
 
 [[package]]
@@ -9880,6 +10000,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9895,7 +10039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -9908,6 +10052,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["../accounts-db/store-tool", "../ledger-tool", "../svm-conformance"]
+members = [
+    "../accounts-db/store-tool",
+    "../bam-local-cluster",
+    "../ledger-tool",
+    "../svm-conformance",
+]
 
 resolver = "2"
 
@@ -40,6 +45,7 @@ agave-snapshots = { path = "../snapshots", version = "=4.4.0-alpha.2", features 
 agave-transaction-view = "6.1.0"
 agave-votor = { path = "../votor", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 ahash = "0.8.11"
+anyhow = "1.0.104"
 assert_cmd = "2.2.2"
 bincode = "1.3.3"
 bytes = "1.12.1"
@@ -114,6 +120,7 @@ solana-native-token = "3.0.0"
 solana-net-utils = { path = "../net-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-nonce = "3.2.1"
 solana-precompile-error = "3.0.0"
+solana-program-binaries = { path = "../program-binaries", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-program-runtime = { path = "../program-runtime", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-pubkey = { version = "4.2.0", default-features = false }
 solana-quic-client = { path = "../quic-client", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
@@ -156,6 +163,7 @@ solana-vote-program = { path = "../programs/vote", version = "=4.4.0-alpha.2", d
 tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = "1.48.0"
+toml = "0.9.11"
 wincode = { version = "0.6.1", features = ["derive"] }
 
 [profile.dev]

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -556,25 +556,14 @@ mod tests {
     fn test_verify_many_ports_reachable() {
         agave_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let config = SocketConfiguration::default();
         let mut tcp_listeners = vec![];
         let mut udp_sockets = vec![];
 
-        let port_range = unique_port_range_for_tests(1);
-        let (_server_port, (_, server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (port_range.start, port_range.end), config)
-                .unwrap();
+        // TCP and UDP reachability are checked separately, so let the OS choose free ports.
+        let server_tcp_listener = TcpListener::bind((ip_addr, 0)).unwrap();
         for _ in 0..MAX_PORT_VERIFY_THREADS * 2 {
-            let port_range = unique_port_range_for_tests(1);
-            let (_client_port, (client_udp_socket, client_tcp_listener)) =
-                bind_common_in_range_with_config(
-                    ip_addr,
-                    (port_range.start, port_range.end),
-                    config,
-                )
-                .unwrap();
-            tcp_listeners.push(client_tcp_listener);
-            udp_sockets.push(client_udp_socket);
+            tcp_listeners.push(TcpListener::bind((ip_addr, 0)).unwrap());
+            udp_sockets.push(UdpSocket::bind((ip_addr, 0)).unwrap());
         }
 
         let ip_echo_server_addr = server_tcp_listener.local_addr().unwrap();

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -563,7 +563,7 @@ mod tests {
         let server_tcp_listener = TcpListener::bind((ip_addr, 0)).unwrap();
         for _ in 0..MAX_PORT_VERIFY_THREADS * 2 {
             tcp_listeners.push(TcpListener::bind((ip_addr, 0)).unwrap());
-            udp_sockets.push(UdpSocket::bind((ip_addr, 0)).unwrap());
+            udp_sockets.push(bind_to(ip_addr, 0).unwrap());
         }
 
         let ip_echo_server_addr = server_tcp_listener.local_addr().unwrap();


### PR DESCRIPTION
Root Cargo builds can enable DCOU through `bam-local-cluster`.
Move it into `dev-bins` so production builds keep DCOU disabled.

Validated macOS/Linux release graphs for bare, binary, package, and
workspace builds, plus the installer DCOU check and
`cargo check --all-targets` for `bam-local-cluster`.

Companion BAM build updates: https://github.com/jito-labs/bam/pull/2083.
