### PR TITLE
build: drop dev-bins packages from DCOU_TAINTED_PACKAGES

### DIFF
--- a/scripts/agave-build-lists.sh
+++ b/scripts/agave-build-lists.sh
@@ -40,14 +40,12 @@ AGAVE_BINS_DEPRECATED=(
   agave-install-init
 )
 
+# Root-workspace packages that pull in dev-context-only-utils. Packages that
+# live in the dev-bins/ workspace (ledger-tool, store-tool, conformance, ...)
+# are built separately and must not be listed here: cargo warns about
+# --exclude names that are not workspace members.
 DCOU_TAINTED_PACKAGES=(
-  agave-conformance
-  agave-ledger-tool
-  bam-local-cluster
   agave-store-histogram
-  agave-store-tool
   solana-accounts-cluster-bench
-  solana-banking-bench
   solana-local-cluster
-  solana-svm-conformance
 )


### PR DESCRIPTION
cargo-install-all.sh passes every entry as `--exclude` to
`cargo build --workspace`. ledger-tool, store-tool, bam-local-cluster,
svm-conformance and conformance now live in the dev-bins/ workspace and
solana-banking-bench no longer exists, so cargo warned on every build:

    warning: excluded package(s) agave-ledger-tool, agave-store-tool,
    bam-local-cluster, solana-banking-bench, solana-svm-conformance not
    found in workspace


