### PR TITLE
fix(rpc): reject simulated bundles that load vote accounts

### DIFF
--- a/rpc-client-api/src/bundles.rs
+++ b/rpc-client-api/src/bundles.rs
@@ -43,6 +43,9 @@ pub enum RpcBundleExecutionError {
     #[error("Invalid pre or post accounts")]
     InvalidPreOrPostAccounts,
 
+    #[error("A transaction in the bundle loads a blacklisted account")]
+    BundleLoadedBlacklistedAccount,
+
     #[error("PoH record error: {0}")]
     PohRecordError(String),
 

--- a/rpc/src/rpc/bundles.rs
+++ b/rpc/src/rpc/bundles.rs
@@ -148,6 +148,15 @@ pub(super) fn simulate_bundle(
         }
     }
 
+    // A bundle that loads a vote account will be filtered by the validator's bundle path and
+    // cannot land. Mirror that behavior here instead of reporting a successful simulation.
+    let vote_accounts = bank.vote_accounts();
+    let blacklisted_tx = transactions.iter().find(|tx| {
+        tx.account_keys()
+            .iter()
+            .any(|key| vote_accounts.contains_key(key))
+    });
+
     let pre_execution_accounts = account_configs_to_accounts(&pre_execution_accounts_configs)?;
     let post_execution_accounts = account_configs_to_accounts(&post_execution_accounts_configs)?;
 
@@ -158,8 +167,13 @@ pub(super) fn simulate_bundle(
         Some(1_000),
     );
     let result = RpcSimulateBundleResult {
+        summary: if let Some(tx) = blacklisted_tx {
+            RpcBundleSimulationSummary::Failed {
+                error: RpcBundleExecutionError::BundleLoadedBlacklistedAccount,
+                tx_signature: Some(tx.signature().to_string()),
+            }
         // if any of them errored out, return the first one that did
-        summary: if let Some((tx, (_pre_accounts, result, _post_accounts))) = transactions
+        } else if let Some((tx, (_pre_accounts, result, _post_accounts))) = transactions
             .iter()
             .zip(results.iter())
             .find(|(_tx, (_pre_accounts, result, _post_accounts))| result.result.is_err())


### PR DESCRIPTION
## Summary

Make `simulateBundle` report `BundleLoadedBlacklistedAccount` when a transaction in the bundle loads a vote account, instead of returning a successful simulation for a bundle that the validator bundle path will reject.

Changes:
- add `BundleLoadedBlacklistedAccount` to the RPC bundle execution error surface;
- detect vote accounts after transaction sanitization against the selected simulation bank;
- return a failed bundle simulation summary with the offending transaction signature before considering execution errors.

This keeps RPC simulation behavior aligned with the validator-side bundle filtering described in #1476.

## Testing

I could not run the Rust test suite in this environment because outbound GitHub access is unavailable from the local runner. CI should be treated as authoritative.

Fixes #1476